### PR TITLE
Add the README, GPL-3.0 licence, third-party notices, and close the reachable security advisories

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: |
             desktop/go.sum

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,674 @@
-MIT License
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Copyright (c) 2026 WhiteDNS contributors
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -1,33 +1,159 @@
 # WhiteVPN Desktop
 
-WhiteVPN Desktop is a Wails v2 VPN client for macOS, Windows, and Linux. It
-uses the same pinned Mihomo-based engine as the WhiteVPN Android client and
-supports subscriptions plus manually imported proxy configurations.
+A desktop VPN client for Windows, macOS and Linux, built to behave like
+[WhiteVPN for Android](https://github.com/WhiteDNS/WhiteVPN) and to run the same
+engine underneath it: [mihomo](https://github.com/MetaCubeX/mihomo), through
+[FlClash](https://github.com/chen08209/FlClash)'s protocol glue.
 
-## Development
+Someone who has used the phone app should find the same options here, under
+recognisable names, producing the same behaviour. Where the desktop needs
+something the phone has no equivalent for — a tray icon, a system proxy, a
+server workbench — it is added deliberately and recorded as a divergence in
+[`desktop/ANDROID-PARITY.md`](desktop/ANDROID-PARITY.md).
 
-Prerequisites are Go 1.25, Node.js 24, npm, the Wails v2 CLI, and the native
-Wails dependencies for your operating system.
+[![Release](https://img.shields.io/github/v/release/WhiteDNS/WhiteVPN-Desktop?sort=semver)](https://github.com/WhiteDNS/WhiteVPN-Desktop/releases)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 
-```sh
+---
+
+## What it does
+
+- **Connects through a subscription** — the built-in catalogue, or any
+  `vless://`, `vmess://`, `trojan://`, `ss://`, `hysteria2://` or
+  `wireguard://` list you add.
+- **Chooses for you, or lets you choose** — filter by country, by protocol, or
+  pin one node by hand. A choice nothing matches is refused rather than
+  silently ignored.
+- **Reports what is true** — the status card shows the node's claimed country
+  *and* the country of the address the internet actually sees, measured through
+  the tunnel. When they disagree, the measurement wins and the tooltip says so.
+- **Recovers on its own** — a connection is re-checked every 20 seconds and
+  moves to another node if it stops carrying traffic. A node you pinned by hand
+  is left alone and reported instead.
+- **A server workbench** — test any subscription's nodes for reachability,
+  delay and throughput; sort by any column; share a node's link.
+- **Runs in the background** — closing the window hides it to the tray; the
+  tunnel keeps running.
+- **Speaks English and Persian**, laying the interface out right-to-left in
+  Persian.
+
+## Install
+
+Grab the asset for your machine from the
+[latest release](https://github.com/WhiteDNS/WhiteVPN-Desktop/releases/latest).
+
+| Platform | Asset |
+|---|---|
+| Windows 10/11, Intel or AMD | `*-windows-x64.zip` |
+| Windows on ARM (Snapdragon, Surface Pro X) | `*-windows-arm64-windows-on-arm.zip` |
+| macOS, Apple Silicon | `*-macos-arm64.zip` |
+| macOS, Intel | `*-macos-amd64.zip` |
+| Debian, Ubuntu | `*-linux-amd64.deb` or `*-linux-arm64.deb` |
+| Fedora, RHEL, openSUSE | `*-linux-amd64.rpm` or `*-linux-arm64.rpm` |
+| Ubuntu 24.04+, Fedora 40+ (WebKitGTK 4.1) | the `*-linux-amd64-webkit41.*` assets |
+| Any x86-64 Linux, no package manager | `*-linux-amd64-webkit41.AppImage` |
+| Portable fallback | `.tar.gz` — needs GTK 3 and a matching WebKitGTK |
+
+Download the ZIP from the release assets rather than a raw `.app` from a CI
+artifact: artifact downloads strip the executable bit and macOS then refuses to
+open the app.
+
+## Known limitations
+
+Stated plainly, because finding these out by surprise is worse than reading
+them here.
+
+| | Windows | macOS | Linux |
+|---|:---:|:---:|:---:|
+| Proxy mode | ✅ | ✅ | ⚠️ |
+| System proxy set automatically | ✅ | ✅ | ❌ |
+| TUN mode (whole-machine tunnel) | ✅ | ❌ | ❌ |
+| Signed / notarised binaries | ❌ | ❌ | ❌ |
+
+- **TUN is Windows-only.** Elsewhere the tunnel needs a privileged helper that
+  is not written yet — `SMJobBless` or launchd on macOS. Proxy mode works on
+  all three.
+- **The system proxy is not set on Linux.** GNOME, KDE and a bare window
+  manager keep that setting in three different places and none of them binds
+  anything that is not already asking, so the app declines rather than
+  pretending. Point your browser at `127.0.0.1:2080` by hand.
+- **Nothing is code-signed.** macOS will refuse to open the app until you allow
+  it in System Settings → Privacy & Security; Windows SmartScreen will warn.
+- **The kill switch is not implemented** on any platform.
+
+## Building
+
+Requires Go 1.26.5+, Node 24+, and the [Wails v2](https://wails.io) CLI. The
+mihomo engine is **not** in this repository — the build fetches its pinned
+source and compiles it for the target, so a first build needs network access.
+
+```bash
 make deps
 make test
-make dev
+make build
 ```
 
-Release packages can be built with:
+Platform packages:
 
-```sh
-make build-mac
-make build-windows
-make build-linux
+```bash
+make package-windows
+make package-mac
+make package-linux
+make package-linux-distros
 ```
 
-See [desktop/README.md](desktop/README.md) for platform and packaging details.
+`make package-mac` must run on a Mac — the tray needs Cocoa, so the build needs
+CGO and the macOS SDK. Windows and Linux cross-compile from anywhere; Wails
+packaging for Linux still wants a Linux host or Docker
+(`make package-linux-all-docker`).
 
-## Security and licensing
+The engine alone:
 
-Please report vulnerabilities using the process in [SECURITY.md](SECURITY.md).
-The application source is available under the [MIT License](LICENSE). Bundled
-components retain their own licenses; exact sources, versions, and hashes are
-listed in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+```bash
+make mihomo-core TARGET_GOOS=darwin TARGET_GOARCH=arm64
+```
+
+Runtime state lives in the platform config directory, under
+`WhiteVPN Desktop/state.json`.
+
+## Releasing
+
+Every platform is built by GitHub Actions. Tag and push:
+
+```bash
+git tag vpn-v1.0.0 && git push origin vpn-v1.0.0
+```
+
+The workflow builds seven targets and attaches the assets to a GitHub Release.
+To check a build without publishing anything, run the workflow by hand from the
+Actions tab — the publish step only runs for a `vpn-v*` tag.
+
+## Repository layout
+
+```
+desktop/
+  app.go, mihomo_connect.go     the app and its connect path
+  internal/session/             one connected engine: config, health, recovery
+  internal/engine/              the core process and its action protocol
+  internal/mihomoconf/          share links and YAML → mihomo configuration
+  internal/sysproxy/            pointing the machine at the local proxy
+  frontend/                     React + TypeScript, Tailwind, shadcn/ui
+  ANDROID-PARITY.md             the specification, and every divergence from it
+```
+
+`ANDROID-PARITY.md` is worth reading before changing anything. It records what
+was measured rather than assumed, and a section — *Things that will bite* — of
+failures that cost real time.
+
+## Security
+
+Please report vulnerabilities using the private process in
+[SECURITY.md](SECURITY.md).
+
+## License
+
+WhiteVPN Desktop is licensed under the
+[GNU General Public License, version 3](LICENSE). Bundled components retain
+their upstream licences; their exact sources, versions, hashes, and licence
+references are recorded in
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,7 +1,7 @@
 # Third-party notices and binary provenance
 
 WhiteVPN Desktop includes or builds the following third-party components. Each
-component remains under its upstream license; the repository's MIT license
+component remains under its upstream license; the repository's GPL-3.0 license
 does not replace those terms.
 
 ## Runtime components

--- a/WhitednsTC/engine/go.mod
+++ b/WhitednsTC/engine/go.mod
@@ -2,6 +2,8 @@ module tunnelcheck/engine
 
 go 1.25.0
 
+toolchain go1.26.5
+
 require (
 	github.com/quic-go/quic-go v0.59.1
 	golang.org/x/mobile v0.0.0-20260514233045-7de0a8fa7f4d

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -35,7 +35,7 @@ LINUX_PACKAGE_FORMATS ?= deb,rpm
 LINUX_ASSET_SUFFIX ?= linux-$(LINUX_CLIENT_ARCH)$(if $(filter 4.1,$(LINUX_WEBKIT)),-webkit41,)
 LINUX_PACKAGE_OUTPUT_DIR ?= build/releases
 LINUX_DOCKER ?= docker
-LINUX_DOCKER_IMAGE ?= golang:1.25-bookworm
+LINUX_DOCKER_IMAGE ?= golang:1.26.5-bookworm
 LINUX_NODE_MAJOR ?= 24
 ifeq ($(UPX),1)
 WAILS_OPTIONAL_UPX_FLAGS := -upx -upxflags "$(UPX_FLAGS)"

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,68 +1,107 @@
-# WhiteVPN Desktop
+# WhiteVPN Desktop — developer notes
 
-Wails v2 desktop client for WhiteVPN subscriptions and manual proxy profiles,
-served by the embedded Mihomo/FlClash core.
+The project README is [one level up](../README.md): what the app is, how to
+install it, and how to build it. This file is the detail that only matters once
+you are working on the code.
+
+Before changing anything, read [ANDROID-PARITY.md](./ANDROID-PARITY.md). It is
+the specification — WhiteVPN for Android, setting by setting — and it records
+every deliberate divergence from it, along with a section of failures that cost
+real time to find.
 
 The MasterDNS/StormDNS side of the original combined app lives on in
 [WhiteDNS-Desktop](https://github.com/WhiteDNS/WhiteDNS-Desktop).
 
-## Release notes
+## Persian user-facing documents
 
-- [Persian quick download guide](./DOWNLOAD_GUIDE_FA.md)
-- [Persian release note for users](./RELEASE_NOTES_FA.md)
-- [Persian Telegram announcement draft](./TELEGRAM_ANNOUNCEMENT_FA.md)
+- [Quick download guide](./DOWNLOAD_GUIDE_FA.md)
+- [Release note for users](./RELEASE_NOTES_FA.md)
+- [Telegram announcement draft](./TELEGRAM_ANNOUNCEMENT_FA.md)
 
-## Windows downloads
+## The engine
 
-For normal 64-bit Windows 10/11 PCs, download the `Windows x64` package. This is the correct build for Intel and AMD processors.
+mihomo is the only engine. The Xray path this app started with was removed on
+2026-08-04, and features written against it — IP fronting was one — turned out
+to have been invisible in the shipping app the whole time. Anything that still
+reads a field from that era is a bug; several were found by users noticing a
+number that could not be true.
 
-Do not download `Windows ARM64` unless the device is specifically a Windows-on-ARM PC, such as a Snapdragon device or Surface Pro X. The ARM64 executable will show "This app can't run on your PC" on ordinary Intel/AMD 64-bit Windows.
+The engine is not vendored. `make mihomo-core` fetches FlClash and mihomo at
+their pinned refs, applies the FlClash commit, and builds a plain executable
+with `CGO_ENABLED=0` and `-tags=with_gvisor`. The result lands in
+`cores/mihomo-<goos>-<goarch>` and is embedded into the app binary, so a
+release is one file rather than a file and a folder that has to stay beside it.
 
-## macOS downloads
+Override the binary during development with `WHITEVPN_MIHOMO_BIN`.
 
-For Apple Silicon Macs, download the `macos-arm64.zip` release asset. For Intel Macs, download `macos-amd64.zip`.
+## Verifying a change
 
-Use the ZIP from the GitHub Release assets. Do not distribute a raw `.app` folder from GitHub Actions artifacts, because artifact downloads can strip executable permissions and macOS will show "The application can't be opened."
-
-## Development
+From the repository root:
 
 ```bash
-make deps
 make test
-make dev
 ```
 
-The app extracts its embedded Mihomo core from
-`cores/mihomo-<goos>-<goarch>`. Package targets build the pinned engine source
-for the target platform and embed it into the app binary. Release packages do
-not need a separate `cores/` folder beside the app.
-
-Runtime profile data is stored under the platform user config directory in `WhiteVPN Desktop/state.json`.
-
-`make build-mac` and `make build-windows` can run from macOS. `make all` builds Linux packages from non-Linux hosts through Docker. If Docker is not available, run `make build-linux` on a Linux host or use the `Desktop Release Builds` GitHub Actions workflow.
-
-`make all` builds stripped/minified release packages for the desktop matrix. The default matrix stages macOS amd64/arm64 separately, Windows amd64/arm64, and Linux amd64/arm64. Override `ALL_MACOS_PLATFORMS`, `ALL_WINDOWS_PLATFORMS`, or `ALL_LINUX_PLATFORMS` to change the matrix.
-
-Linux release jobs also publish native distro packages and an amd64 AppImage. Linux x64 users who want the least package-manager friction should try the `.AppImage` first. Debian and Ubuntu users can use the `.deb` package, RPM-based distributions can use the `.rpm` package, and the `.tar.gz` archive remains available as a portable fallback that still needs GTK 3 plus the matching WebKitGTK runtime from the distribution.
-
-For newer RPM-based distributions that provide WebKitGTK 4.1 instead of 4.0, use the `linux-amd64-webkit41.rpm` asset. The older WebKitGTK 4.0 Linux assets remain for older distributions.
-
-Pass the release version with `VERSION=1.0.0-beta6`, or use the GNU-make-safe flag form `make all -- --version 1.0.0-beta6`. Release staging writes platform folders under `build/releases/all/` and versioned compressed assets such as `WhiteVPN-Desktop-1.0.0-beta6-macos-arm64.zip`.
-
-For Ubuntu 24.04+ Linux builds, pass `LINUX_GO_TAGS=webkit2_41` and install `libwebkit2gtk-4.1-dev`. Ubuntu 22.04 builds can use the default WebKitGTK 4.0 dependency. To build native Linux packages locally, install `dpkg-deb` and `rpmbuild`, then run `make package-linux-distros`. To include an amd64 AppImage, also include `appimage` in `LINUX_PACKAGE_FORMATS`; the packaging script downloads linuxdeploy unless `LINUXDEPLOY_BIN` points to an executable local copy.
-
-Useful targets:
+Tests that need a real engine are gated behind environment variables and skip
+otherwise:
 
 ```bash
-make mihomo-core
-make build
-make package
-make build-mac
-make build-windows
-make build-linux
-make package-linux-distros
-make package-linux-all-docker
-make build-all
-make all
-make clean
+WHITEVPN_MEASURE_LIVE=1 \
+WHITEVPN_MIHOMO_BIN=/path/to/mihomo \
+WHITEVPN_PROBE_SUB=/path/to/subscription.txt \
+  go test ./internal/session -run Live -v
 ```
+
+## Two traps worth knowing before they cost you an afternoon
+
+**`wails build -s` skips the frontend.** The Go side rebuilds, the binary looks
+new, and the interface inside it is whatever was last built properly. Two
+rounds of "I fixed that, why is it still broken" came from this. Check the
+timestamp on `frontend/dist/assets/*.js`, or look for `Compiling frontend: Done`.
+
+**`exec.CommandContext` kills what it starts.** The context that lets a user
+cancel a connect must never own the engine's lifetime. It did once, and every
+proxy-mode connection died about a second after reporting success — while TUN
+was untouched, because that path spawns through `ShellExecuteExW` where no
+context can reach. `TestLiveConnectionOutlivesItsConnectContext` fails within
+three seconds if it comes back.
+
+The rest of that list lives in ANDROID-PARITY.md under *Things that will bite*.
+
+## Make targets
+
+```bash
+make deps                        npm install and go mod tidy
+make dev                         wails dev
+make build                       frontend + Go binary
+make test                        Go tests and the frontend build
+
+make package-windows             per-platform release packages
+make package-mac                 (must run on a Mac)
+make package-linux               (must run on Linux)
+make package-linux-distros       .deb and .rpm from a Linux build
+make package-linux-all-docker    Linux packages from a non-Linux host
+
+make mihomo-core                 build the engine for this host
+make mihomo-core-setup           fetch the pinned engine source only
+make clean                       remove build output and cached cores
+```
+
+Pass a version with `VERSION=1.0.0`, or the make-safe form
+`make all -- --version 1.0.0`.
+
+Linux packaging needs `dpkg-deb` and `rpmbuild`. For an AppImage, include
+`appimage` in `LINUX_PACKAGE_FORMATS`; the script downloads linuxdeploy unless
+`LINUXDEPLOY_BIN` points at a local copy. On Ubuntu 24.04+ pass
+`LINUX_GO_TAGS=webkit2_41` and install `libwebkit2gtk-4.1-dev`.
+
+## Where state lives
+
+`<user config dir>/WhiteVPN Desktop/`:
+
+- `state.json` — settings, subscriptions, and the selected node
+- `mihomo/` — the live engine's home; `config.yaml` is written here
+- `mihomo-measure/` — the second engine the Servers page tests with
+- `system-proxy.json` — what the machine's proxy settings were before the app
+  changed them. Present only while connected; if it survives a crash, startup
+  restores from it before anything else can connect.

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -2,6 +2,8 @@ module whitevpn-desktop
 
 go 1.25.0
 
+toolchain go1.26.5
+
 require (
 	github.com/wailsapp/wails/v2 v2.12.0
 	tunnelcheck/engine v0.0.0

--- a/desktop/scripts/build-linux-releases-docker.sh
+++ b/desktop/scripts/build-linux-releases-docker.sh
@@ -2,7 +2,7 @@
 set -eu
 
 docker_bin="${LINUX_DOCKER:-docker}"
-image="${LINUX_DOCKER_IMAGE:-golang:1.25-bookworm}"
+image="${LINUX_DOCKER_IMAGE:-golang:1.26.5-bookworm}"
 node_major="${LINUX_NODE_MAJOR:-24}"
 platforms="${ALL_LINUX_PLATFORMS:-linux/amd64,linux/arm64}"
 version="${VERSION:-1.0.0-beta6}"


### PR DESCRIPTION

## What is in here

**`499d9dc` — README, LICENSE, THIRD-PARTY-NOTICES**

The repository had no licence at all, and a README that documented the Xray
core, `make xray-core` and `WHITEVPN_XRAY_BIN` — none of which has been true
since that path was removed. It was documentation for a program that no longer
exists.

GPL-3.0 is not a preference: this software builds mihomo from source and embeds
the result in its own binary, and mihomo is GPL-3.0, so the combined work is.
`THIRD-PARTY-NOTICES.md` records that and every other component with the refs
the build actually pins.

**`7a13d5a` — the security advisories that are actually reachable**

Dependabot reported around 60 alerts. `govulncheck`, which does reachability
analysis rather than version matching, found that nine can actually be called
from this code — and all nine are in the **Go standard library**, not in any
dependency. Nothing to bump; the toolchain that compiles the binary is what
ships them.

CI was building with Go 1.25.x. It builds with 1.26.x now. Verified by
installing 1.26.5 and re-running the scan rather than trusting the advisory
database:

| | before | after |
|---|---|---|
| reachable | 9 | **0** |
| module-level alerts | 37 | 2 |
| npm runtime alerts | 12 | 3 |

`x/crypto`, `x/net` and `quic-go` were bumped too. `quic-go` went 0.45.2 to
0.59.0 in both modules; the tunnelcheck engine's entire use of it is four
symbols, and both modules build, vet and test.

On the npm side every alert traced to one package: `shadcn`, a CLI scaffolding
tool sitting in runtime `dependencies`, dragging in hono, express and
body-parser. Nothing imports it and no script runs it, so it moved to
`devDependencies`. **The built bundle is byte-for-byte identical** before and
after — the hashes were compared.

Left alone deliberately: two advisories in esbuild and postcss, reached through
the vite 5 that `@tailwindcss/vite` pins. Neither appears in the bundle, and the
esbuild one is a dev-server issue affecting a developer's machine rather than a
user's. Clearing them needs vite 5 → 7, which deserves its own change with its
own testing.

## Note for whoever merges

`main` currently carries three commits (YT badge, custom config import, macOS
fix, licence files) that are also on `feat/custom-config-yt-badge-mac-fix` —
the two refs are identical, so that work is not at risk from anything here.

One of those commits contains the macOS tray fix — `systray.Register` in place
of `go systray.Run` — which is what makes the macOS build work. It is worth
keeping.

After this merges, a `vpn-v1.0.1` tag is worth cutting: the 1.0.0 binaries were
built with the older Go toolchain and still carry the standard-library
vulnerabilities.