### PR TITLE
Read every subscription shape a panel serves, not just share links

### DIFF
--- a/desktop/ANDROID-PARITY.md
+++ b/desktop/ANDROID-PARITY.md
@@ -176,7 +176,7 @@ keys here, not copied literals.
 | Selected subscription | `white_dns_user_subscriptions` / `selected_subscription`, default the built-in one | `[x]` |
 | Built-in WhiteDNS catalogue | Encrypted, refreshed every 3 h | `[~]` fetch, decrypt and on-demand refresh exist; its address is never stored or shown |
 | User subscriptions | Add, Edit, Test, Refresh, Delete per card | `[ ]` |
-| Import formats | HTTPS URL (HTTP rejected), Clash/Xray JSON, mihomo YAML, or share links; 2 MB cap | `[~]` HTTPS enforced and the 2 MB cap was already there; share links, base64 of them and mihomo YAML all connect. Clash/Xray **JSON** does not — nothing converts it yet |
+| Import formats | HTTPS URL (HTTP rejected), Clash/Xray JSON, mihomo YAML, or share links; 2 MB cap | `[x]` share links, mihomo YAML **and** JSON, sing-box JSON, Xray JSON or a list of Xray configs, and base64 around any of them. One entry point — `mihomoconf.ParseSubscription` — so everything downstream sees the same `[]Proxy` |
 
 > The live catalogue is **base64-encoded share links**, not mihomo YAML — 864
 > nodes as of 2026-08-04. A link→mihomo converter is required, ported from
@@ -408,11 +408,37 @@ but only the navigation, the connect button and those dialogs are keyed so far.
    parameters, because a sentence with a number in it does not put that number
    in the same place in both languages.
 
-4. **Clash and Xray JSON subscriptions.** Share links, base64 of them and mihomo
-   YAML all connect; JSON does not, because nothing converts it. §4 says so.
-
-5. **Per-card subscription Test.** The phone offers it; refresh is there, test
+4. **Per-card subscription Test.** The phone offers it; refresh is there, test
    is not.
+
+### Subscription formats, and why they are all one shape
+
+`mihomoconf.ParseSubscription` reads share links, mihomo YAML or JSON, sing-box
+JSON, Xray JSON or a list of Xray configs, and base64 around any of them. All of
+them come out as `[]Proxy`, so the Servers page, the delay and speed tests, node
+selection and IP fronting cannot tell them apart. One model, not two.
+
+Measured 2026-08-06 against a BPB panel, which serves nine combinations of
+`sub/{normal,fragment,raw}` and `?app={clash,sing-box,xray}`: all nine are read,
+and three of the four that used to be refused were connected through and passed
+real traffic. A 3x-ui/Sanaei subscription is the regression case for share
+links.
+
+Two things to know before changing it:
+
+- **A document's nodes are extracted; its groups and rules are not run.** A user
+  who picks a node expects that node, not whatever the provider's url-test
+  group decides, and the Servers page needs something to list. The one
+  exception is `proxy-providers`, where the nodes are fetched by the engine and
+  there is nothing to extract — that still passes through, and both paths have
+  a test.
+- **The TLS name lives under `sni` for trojan and `servername` for everything
+  else**, in both the sing-box and Xray converters. Getting it wrong is a
+  handshake that fails with nothing to explain it.
+
+Nodes read out of a document have no share link, because the document carried
+settings rather than a URL. The Servers page disables Share for them and says
+why.
 
 ### Building for the other platforms
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2933,11 +2933,20 @@ function NodesPage({
                         </Tooltip>
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <Button variant="ghost" size="icon-sm" onClick={() => setShareNode(node)} aria-label={t("servers.share")}>
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={() => setShareNode(node)}
+                              // A node read out of a provider's own
+                              // configuration has no share link to give: the
+                              // document carried settings, not a URL.
+                              disabled={!node.link}
+                              aria-label={t("servers.share")}
+                            >
                               <Share2 />
                             </Button>
                           </TooltipTrigger>
-                          <TooltipContent>{t("servers.share")}</TooltipContent>
+                          <TooltipContent>{node.link ? t("servers.share") : t("servers.share.none")}</TooltipContent>
                         </Tooltip>
                       </div>
                     </td>

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -424,6 +424,10 @@ const strings = {
   },
   "servers.use": { en: "Connect through this node", fa: "اتصال از این سرور" },
   "servers.share": { en: "Share", fa: "اشتراک‌گذاری" },
+  "servers.share.none": {
+    en: "This node came from a configuration file, so it has no link to share.",
+    fa: "این سرور از یک فایل کانفیگ آمده، پس لینکی برای اشتراک‌گذاری ندارد.",
+  },
   "servers.copy": { en: "Copy link", fa: "کپی لینک" },
   "servers.copied": { en: "Link copied.", fa: "لینک کپی شد." },
   "servers.option.reachTimeout": { en: "Reachable timeout (ms)", fa: "مهلت در دسترس بودن (ms)" },

--- a/desktop/internal/mihomoconf/describe_test.go
+++ b/desktop/internal/mihomoconf/describe_test.go
@@ -1,0 +1,41 @@
+package mihomoconf
+
+import (
+	"strings"
+	"testing"
+)
+
+// The commonest reasons a subscription will not load are not "it has no V2Ray
+// links": they are a login page, an error page and an empty response. Each has
+// to be recognisable from the message alone, because that message is all a user
+// can send back.
+func TestFailureSaysWhatArrived(t *testing.T) {
+	for _, testCase := range []struct{ body, want string }{
+		{"", "returned nothing"},
+		{"   \n ", "returned nothing"},
+		{"<!DOCTYPE html><html><body>Sign in</body></html>", "web page"},
+		{`{"hello": "world"}`, "JSON"},
+		{"ftp://example.com/file", "links"},
+		{"just some words", "neither share links"},
+	} {
+		_, _, err := ParseSubscription(testCase.body)
+		if err == nil {
+			t.Fatalf("%q should have been refused", testCase.body)
+		}
+		if !strings.Contains(err.Error(), testCase.want) {
+			t.Fatalf("%q: expected the message to mention %q, got %v", testCase.body, testCase.want, err)
+		}
+	}
+}
+
+// The body carries credentials and the message ends up in screenshots.
+func TestFailureNeverRepeatsTheBody(t *testing.T) {
+	secret := "vmess://c3VwZXItc2VjcmV0LWNyZWRlbnRpYWw"
+	_, _, err := ParseSubscription("<html>" + secret + "</html>")
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("the message repeated the body: %v", err)
+	}
+}

--- a/desktop/internal/mihomoconf/document.go
+++ b/desktop/internal/mihomoconf/document.go
@@ -1,0 +1,140 @@
+package mihomoconf
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Subscriptions come in two shapes and this package now reads both.
+//
+// The first is a list of share links — `vless://…` and friends — which is what
+// the built-in catalogue ships and what every parser here was written for. The
+// second is a whole mihomo configuration: `proxies:` with the engine's own
+// schema, plus the provider's groups and rules. Panels that target Clash serve
+// it, usually behind `?app=clash`.
+//
+// The second shape is, if anything, the easier one: it is already the language
+// the engine speaks, so the proxies need no conversion at all. What it needed
+// was for something to look inside it, which nothing did — a subscription in
+// that shape was refused with "must contain V2Ray links or base64 encoded V2Ray
+// links", which is true and useless.
+//
+// Both shapes end as []Proxy so that everything downstream — the node list, the
+// Servers page, delay and speed tests, IP fronting, node selection — works the
+// same way for both. One model, not two.
+
+// ParseSubscription reads either shape and returns the proxies it holds,
+// alongside the share link each came from where there was one.
+//
+// Share links are tried first because they are cheap to recognise and are what
+// most subscriptions are. A document has no share links to report, so the
+// sources come back empty for it rather than invented.
+func ParseSubscription(body string) ([]Proxy, []string, error) {
+	proxies, sources, linkErr := ConvertLinksWithSources(body)
+	if linkErr == nil {
+		return proxies, sources, nil
+	}
+
+	proxies, docErr := ParseDocument(body)
+	if docErr == nil {
+		return proxies, make([]string, len(proxies)), nil
+	}
+
+	if proxies, err := ParseSingBox(body); err == nil {
+		return proxies, make([]string, len(proxies)), nil
+	}
+	if proxies, err := ParseXrayJSON(body); err == nil {
+		return proxies, make([]string, len(proxies)), nil
+	}
+
+	// Base64 is a wrapper, not a format. ConvertLinks already unwraps it to look
+	// for links; a document served the same way deserves the same treatment,
+	// and providers do serve them that way.
+	if decoded, ok := decodeBase64Text(strings.TrimSpace(body)); ok {
+		if proxies, _, err := ParseSubscription(decoded); err == nil {
+			return proxies, make([]string, len(proxies)), nil
+		}
+	}
+
+	// Nothing read it. The link error leads because a subscription that is none
+	// of these is far more often a broken link list than a broken document.
+	return nil, nil, fmt.Errorf("%w (and it is not a mihomo, sing-box or Xray configuration either: %v)", linkErr, docErr)
+}
+
+// ParseDocument reads the `proxies` of a mihomo configuration.
+//
+// JSON is accepted as well as YAML because YAML is a superset of it and some
+// panels serve JSON — the document that prompted this was `{"mixed-port": 7890,
+// … "proxies": [...]}`. A detector that matched on a line beginning `proxies:`
+// would have missed it, which is exactly what the previous one did.
+func ParseDocument(body string) ([]Proxy, error) {
+	if strings.TrimSpace(body) == "" {
+		return nil, fmt.Errorf("mihomoconf: the document is empty")
+	}
+
+	var document struct {
+		Proxies []map[string]any `yaml:"proxies"`
+	}
+	if err := yaml.Unmarshal([]byte(body), &document); err != nil {
+		return nil, fmt.Errorf("mihomoconf: not a readable configuration: %w", err)
+	}
+	if len(document.Proxies) == 0 {
+		return nil, fmt.Errorf("mihomoconf: the configuration has no proxies")
+	}
+
+	names := newNameRegistry()
+	proxies := make([]Proxy, 0, len(document.Proxies))
+	for _, entry := range document.Proxies {
+		proxy := Proxy(entry)
+		// A proxy the engine cannot dial is worse than one that is absent: it
+		// takes a row on the Servers page and fails every test run against it.
+		if !usableProxy(proxy) {
+			continue
+		}
+		// Names have to be unique — they are how a node is chosen, measured and
+		// stored — and a document is not obliged to make them so.
+		proxy["name"] = names.register(proxy.Name())
+		proxies = append(proxies, proxy)
+	}
+	if len(proxies) == 0 {
+		return nil, fmt.Errorf("mihomoconf: the configuration has no usable proxies")
+	}
+	return proxies, nil
+}
+
+// usableProxy reports whether an entry has the parts the engine needs to dial
+// it. The type is checked against nothing: mihomo supports more outbound types
+// than this app converts links for, and a document naming one of them is a
+// document that knows better than we do.
+func usableProxy(proxy Proxy) bool {
+	if strings.TrimSpace(proxy.Name()) == "" {
+		return false
+	}
+	if kind, _ := proxy["type"].(string); strings.TrimSpace(kind) == "" {
+		return false
+	}
+	if server, _ := proxy["server"].(string); strings.TrimSpace(server) == "" {
+		return false
+	}
+	return proxyPortOf(proxy) > 0
+}
+
+// proxyPortOf reads a port that YAML may have decoded as any numeric kind.
+func proxyPortOf(proxy Proxy) int {
+	switch value := proxy["port"].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case string:
+		var port int
+		if _, err := fmt.Sscanf(value, "%d", &port); err == nil {
+			return port
+		}
+	}
+	return 0
+}

--- a/desktop/internal/mihomoconf/document.go
+++ b/desktop/internal/mihomoconf/document.go
@@ -58,9 +58,12 @@ func ParseSubscription(body string) ([]Proxy, []string, error) {
 		}
 	}
 
-	// Nothing read it. The link error leads because a subscription that is none
-	// of these is far more often a broken link list than a broken document.
-	return nil, nil, fmt.Errorf("%w (and it is not a mihomo, sing-box or Xray configuration either: %v)", linkErr, docErr)
+	// Nothing read it. Say what arrived rather than what was hoped for: the
+	// commonest causes are a login page, an error page and an empty response,
+	// and "must contain V2Ray links" describes none of them. What it *is* is
+	// reported, never what it says — a subscription body carries credentials
+	// and this message ends up in screenshots.
+	return nil, nil, fmt.Errorf("this does not look like a subscription: %s", describeBody(body))
 }
 
 // ParseDocument reads the `proxies` of a mihomo configuration.
@@ -137,4 +140,25 @@ func proxyPortOf(proxy Proxy) int {
 		}
 	}
 	return 0
+}
+
+// describeBody says what a subscription body is without repeating what it
+// says. The content is a credential; its shape is a diagnosis.
+func describeBody(body string) string {
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" {
+		return "the server returned nothing"
+	}
+	lower := strings.ToLower(trimmed)
+	switch {
+	case strings.HasPrefix(lower, "<!doctype html"), strings.HasPrefix(lower, "<html"):
+		// Nearly always a login page or an error page behind the address.
+		return fmt.Sprintf("the server returned a web page (%d bytes), not a subscription — check the address, and whether it needs to be signed in to", len(trimmed))
+	case strings.HasPrefix(trimmed, "{"), strings.HasPrefix(trimmed, "["):
+		return fmt.Sprintf("the server returned %d bytes of JSON with no proxies, outbounds or servers in it", len(trimmed))
+	case strings.Contains(trimmed, "://"):
+		return fmt.Sprintf("the server returned %d bytes containing links, but none of a kind this app can use", len(trimmed))
+	default:
+		return fmt.Sprintf("the server returned %d bytes that are neither share links nor a mihomo, sing-box or Xray configuration", len(trimmed))
+	}
 }

--- a/desktop/internal/mihomoconf/singbox.go
+++ b/desktop/internal/mihomoconf/singbox.go
@@ -1,0 +1,198 @@
+package mihomoconf
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// sing-box configurations, which several panels serve alongside the Clash one.
+//
+// The schema is a sibling of mihomo's rather than a stranger to it — the same
+// protocols under different spellings. `server_port` for `port`, `tag` for
+// `name`, a nested `tls` object instead of flat keys, `transport` instead of
+// `network` plus `*-opts`. Translating it is mechanical, and worth doing
+// because a user who picks "sing-box" in their panel should not have to know
+// that this app would rather have had the Clash one.
+//
+// Outbounds that are not servers — `selector`, `urltest`, `direct`, `block`,
+// `dns` — are the provider's routing, not nodes, and are skipped.
+
+// ParseSingBox reads the outbounds of a sing-box configuration.
+func ParseSingBox(body string) ([]Proxy, error) {
+	var document struct {
+		Outbounds []map[string]any `json:"outbounds"`
+	}
+	if err := json.Unmarshal([]byte(body), &document); err != nil {
+		return nil, fmt.Errorf("mihomoconf: not a sing-box configuration: %w", err)
+	}
+	if len(document.Outbounds) == 0 {
+		return nil, fmt.Errorf("mihomoconf: the sing-box configuration has no outbounds")
+	}
+
+	names := newNameRegistry()
+	proxies := make([]Proxy, 0, len(document.Outbounds))
+	for _, outbound := range document.Outbounds {
+		proxy, ok := singBoxProxy(outbound)
+		if !ok {
+			continue
+		}
+		proxy["name"] = names.register(proxy.Name())
+		proxies = append(proxies, proxy)
+	}
+	if len(proxies) == 0 {
+		return nil, fmt.Errorf("mihomoconf: the sing-box configuration has no usable outbounds")
+	}
+	return proxies, nil
+}
+
+func singBoxProxy(outbound map[string]any) (Proxy, bool) {
+	kind := strings.ToLower(jsonString(outbound, "type"))
+	server := jsonString(outbound, "server")
+	port := jsonInt(outbound, "server_port", 0)
+	name := jsonString(outbound, "tag")
+	if server == "" || port < 1 || port > 65535 || strings.TrimSpace(name) == "" {
+		return nil, false
+	}
+
+	proxy := Proxy{"name": name, "server": server, "port": port, "udp": true}
+	switch kind {
+	case "vless":
+		proxy["type"] = "vless"
+		proxy["uuid"] = jsonString(outbound, "uuid")
+		if flow := jsonString(outbound, "flow"); flow != "" {
+			proxy["flow"] = flow
+		}
+	case "vmess":
+		proxy["type"] = "vmess"
+		proxy["uuid"] = jsonString(outbound, "uuid")
+		proxy["alterId"] = jsonInt(outbound, "alter_id", 0)
+		proxy["cipher"] = orDefault(jsonString(outbound, "security"), "auto")
+	case "trojan":
+		proxy["type"] = "trojan"
+		proxy["password"] = jsonString(outbound, "password")
+	case "shadowsocks":
+		proxy["type"] = "ss"
+		proxy["cipher"] = jsonString(outbound, "method")
+		proxy["password"] = jsonString(outbound, "password")
+	case "hysteria2":
+		proxy["type"] = "hysteria2"
+		proxy["password"] = jsonString(outbound, "password")
+	default:
+		// selector, urltest, direct, block, dns — routing, not a server.
+		return nil, false
+	}
+
+	applySingBoxTLS(proxy, outbound)
+	applySingBoxTransport(proxy, outbound)
+	return proxy, true
+}
+
+func applySingBoxTLS(proxy Proxy, outbound map[string]any) {
+	tls, ok := outbound["tls"].(map[string]any)
+	if !ok || !boolValue(tls["enabled"]) {
+		return
+	}
+	proxy["tls"] = true
+	if name := jsonString(tls, "server_name"); name != "" {
+		// trojan reads it as sni, everything else as servername. Writing the
+		// wrong one is a handshake that fails for no visible reason.
+		if proxy["type"] == "trojan" || proxy["type"] == "hysteria2" {
+			proxy["sni"] = name
+		} else {
+			proxy["servername"] = name
+		}
+	}
+	if boolValue(tls["insecure"]) {
+		proxy["skip-cert-verify"] = true
+	}
+	if alpn := jsonStrings(tls, "alpn"); len(alpn) > 0 {
+		proxy["alpn"] = alpn
+	}
+	if utls, ok := tls["utls"].(map[string]any); ok && boolValue(utls["enabled"]) {
+		proxy["client-fingerprint"] = orDefault(jsonString(utls, "fingerprint"), "chrome")
+	}
+	if reality, ok := tls["reality"].(map[string]any); ok && boolValue(reality["enabled"]) {
+		options := map[string]any{"public-key": jsonString(reality, "public_key")}
+		if shortID := jsonString(reality, "short_id"); shortID != "" {
+			options["short-id"] = shortID
+		}
+		proxy["reality-opts"] = options
+	}
+}
+
+func applySingBoxTransport(proxy Proxy, outbound map[string]any) {
+	transport, ok := outbound["transport"].(map[string]any)
+	if !ok {
+		proxy["network"] = "tcp"
+		return
+	}
+	switch strings.ToLower(jsonString(transport, "type")) {
+	case "ws":
+		proxy["network"] = "ws"
+		options := map[string]any{"path": jsonString(transport, "path")}
+		headers := map[string]any{}
+		if host := jsonString(transport, "host"); host != "" {
+			headers["Host"] = host
+		}
+		if raw, ok := transport["headers"].(map[string]any); ok {
+			for key, value := range raw {
+				headers[key] = value
+			}
+		}
+		if len(headers) > 0 {
+			options["headers"] = headers
+		}
+		// sing-box carries early data as its own fields; mihomo expects the
+		// length and the header name under ws-opts.
+		if early := jsonInt(transport, "max_early_data", 0); early > 0 {
+			options["max-early-data"] = early
+		}
+		if header := jsonString(transport, "early_data_header_name"); header != "" {
+			options["early-data-header-name"] = header
+		}
+		proxy["ws-opts"] = options
+	case "grpc":
+		proxy["network"] = "grpc"
+		proxy["grpc-opts"] = map[string]any{"grpc-service-name": jsonString(transport, "service_name")}
+	case "http":
+		proxy["network"] = "http"
+		options := map[string]any{}
+		if path := jsonString(transport, "path"); path != "" {
+			options["path"] = []string{path}
+		}
+		if host := jsonStrings(transport, "host"); len(host) > 0 {
+			options["headers"] = map[string]any{"Host": host}
+		}
+		proxy["http-opts"] = options
+	case "httpupgrade":
+		proxy["network"] = "httpupgrade"
+		proxy["ws-opts"] = map[string]any{
+			"path":    jsonString(transport, "path"),
+			"headers": map[string]any{"Host": jsonString(transport, "host")},
+		}
+	default:
+		proxy["network"] = "tcp"
+	}
+}
+
+// jsonStrings reads a field that may be one string or a list of them, which is
+// how sing-box writes alpn and http hosts.
+func jsonStrings(values map[string]any, key string) []string {
+	switch value := values[key].(type) {
+	case string:
+		if strings.TrimSpace(value) == "" {
+			return nil
+		}
+		return []string{value}
+	case []any:
+		out := make([]string, 0, len(value))
+		for _, entry := range value {
+			if text, ok := entry.(string); ok && strings.TrimSpace(text) != "" {
+				out = append(out, text)
+			}
+		}
+		return out
+	}
+	return nil
+}

--- a/desktop/internal/mihomoconf/subscription_test.go
+++ b/desktop/internal/mihomoconf/subscription_test.go
@@ -1,0 +1,182 @@
+package mihomoconf
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func base64Of(body string) string { return base64.StdEncoding.EncodeToString([]byte(body)) }
+
+// The fixtures are real subscriptions from a BPB panel with every credential
+// and hostname replaced. Their shape is the point: each of these was refused
+// with "subscription must contain V2Ray links or base64 encoded V2Ray links",
+// which was true and useless, and each is now read.
+func fixture(t *testing.T, name string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}
+
+// One entry point, whatever the provider decided to serve. Everything after it
+// — the Servers page, delay and speed tests, node selection, IP fronting —
+// sees the same []Proxy and cannot tell the shapes apart.
+func TestParseSubscriptionReadsEveryShape(t *testing.T) {
+	links := "vless://11111111-2222-3333-4444-555555555555@a.example.com:443?type=ws&security=tls#Alpha\n" +
+		"trojan://pw@b.example.com:443?sni=b.example.com#Beta"
+
+	for _, testCase := range []struct {
+		name string
+		body string
+		want int
+	}{
+		{"share links", links, 2},
+		{"mihomo document", fixture(t, "clash-normal.json"), 3},
+		{"sing-box document", fixture(t, "singbox-normal.json"), 3},
+		{"xray document list", fixture(t, "xray-normal.json"), 3},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			proxies, sources, err := ParseSubscription(testCase.body)
+			if err != nil {
+				t.Fatalf("ParseSubscription: %v", err)
+			}
+			if len(proxies) != testCase.want {
+				t.Fatalf("got %d proxies, want %d", len(proxies), testCase.want)
+			}
+			// One source slot per proxy, always, so callers can index either
+			// list without checking which shape it came from.
+			if len(sources) != len(proxies) {
+				t.Fatalf("got %d source slots for %d proxies", len(sources), len(proxies))
+			}
+			for i, proxy := range proxies {
+				if proxy.Name() == "" {
+					t.Fatalf("proxy %d has no name", i)
+				}
+				if server, _ := proxy["server"].(string); server == "" {
+					t.Fatalf("proxy %q has no server", proxy.Name())
+				}
+				if proxyPortOf(proxy) <= 0 {
+					t.Fatalf("proxy %q has no port", proxy.Name())
+				}
+				if kind, _ := proxy["type"].(string); kind == "" {
+					t.Fatalf("proxy %q has no type", proxy.Name())
+				}
+			}
+		})
+	}
+}
+
+// Base64 is a wrapper, not a format, and providers wrap all of these in it.
+func TestParseSubscriptionUnwrapsBase64(t *testing.T) {
+	for _, name := range []string{"clash-normal.json", "singbox-normal.json", "xray-normal.json"} {
+		plain, _, err := ParseSubscription(fixture(t, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		wrapped, _, err := ParseSubscription(base64Of(fixture(t, name)))
+		if err != nil {
+			t.Fatalf("%s wrapped in base64: %v", name, err)
+		}
+		if len(wrapped) != len(plain) {
+			t.Fatalf("%s: %d proxies wrapped, %d plain", name, len(wrapped), len(plain))
+		}
+	}
+}
+
+// sing-box and Xray both put the TLS name in one place for trojan and another
+// for everything else. Writing the wrong one is a handshake that fails with
+// nothing to explain it.
+func TestDocumentsPutTheTLSNameWhereTheProtocolExpectsIt(t *testing.T) {
+	for _, name := range []string{"singbox-normal.json", "xray-normal.json"} {
+		proxies, _, err := ParseSubscription(fixture(t, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, proxy := range proxies {
+			kind, _ := proxy["type"].(string)
+			if enabled, _ := proxy["tls"].(bool); !enabled {
+				continue
+			}
+			_, hasSNI := proxy["sni"]
+			_, hasServerName := proxy["servername"]
+			if kind == "trojan" && !hasSNI {
+				t.Fatalf("%s: trojan %q needs sni, got %#v", name, proxy.Name(), proxy)
+			}
+			if kind == "vless" && !hasServerName {
+				t.Fatalf("%s: vless %q needs servername, got %#v", name, proxy.Name(), proxy)
+			}
+		}
+	}
+}
+
+// Routing entries are not servers. A selector or a urltest taking a row on the
+// Servers page would be a node that every test run fails against.
+func TestSingBoxSkipsRoutingOutbounds(t *testing.T) {
+	proxies, err := ParseSingBox(fixture(t, "singbox-normal.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, proxy := range proxies {
+		switch proxy["type"] {
+		case "selector", "urltest", "direct", "block", "dns":
+			t.Fatalf("%q is routing, not a server", proxy.Name())
+		}
+	}
+}
+
+// Names are how a node is chosen, measured and remembered. A document is under
+// no obligation to make them unique; this package is.
+func TestDocumentNamesAreMadeUnique(t *testing.T) {
+	document := `
+proxies:
+  - {name: Same, type: trojan, server: a.example.com, port: 443, password: pw}
+  - {name: Same, type: trojan, server: b.example.com, port: 443, password: pw}
+  - {name: Same, type: trojan, server: c.example.com, port: 443, password: pw}
+`
+	proxies, err := ParseDocument(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{}
+	for _, proxy := range proxies {
+		if seen[proxy.Name()] {
+			t.Fatalf("duplicate name %q", proxy.Name())
+		}
+		seen[proxy.Name()] = true
+	}
+	if len(seen) != 3 {
+		t.Fatalf("expected 3 distinct names, got %d", len(seen))
+	}
+}
+
+// A proxy the engine cannot dial is worse than one that is absent: it takes a
+// row, fails every test, and looks like the app is broken.
+func TestDocumentDropsUndialableProxies(t *testing.T) {
+	document := `
+proxies:
+  - {name: Good, type: trojan, server: a.example.com, port: 443, password: pw}
+  - {name: NoServer, type: trojan, port: 443}
+  - {name: NoPort, type: trojan, server: b.example.com}
+  - {name: NoType, server: c.example.com, port: 443}
+  - {type: trojan, server: d.example.com, port: 443}
+`
+	proxies, err := ParseDocument(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(proxies) != 1 || proxies[0].Name() != "Good" {
+		t.Fatalf("expected only the dialable one, got %#v", proxies)
+	}
+}
+
+func TestParseSubscriptionRefusesWhatIsNeitherShape(t *testing.T) {
+	for _, body := range []string{"", "   ", "this is not a subscription", "{}", "[]"} {
+		if _, _, err := ParseSubscription(body); err == nil {
+			t.Fatalf("expected %q to be refused", body)
+		}
+	}
+}

--- a/desktop/internal/mihomoconf/testdata/clash-normal.json
+++ b/desktop/internal/mihomoconf/testdata/clash-normal.json
@@ -1,0 +1,215 @@
+{
+ "mixed-port": 7890,
+ "ipv6": true,
+ "allow-lan": false,
+ "unified-delay": false,
+ "log-level": "warning",
+ "mode": "rule",
+ "disable-keep-alive": false,
+ "keep-alive-idle": 10,
+ "keep-alive-interval": 15,
+ "tcp-concurrent": true,
+ "geo-auto-update": true,
+ "geo-update-interval": 168,
+ "external-controller": "127.0.0.1:9090",
+ "external-controller-cors": {
+  "allow-origins": [
+   "*"
+  ],
+  "allow-private-network": true
+ },
+ "external-ui": "ui",
+ "external-ui-url": "https://github.com/MetaCubeX/metacubexd/archive/refs/heads/gh-pages.zip",
+ "profile": {
+  "store-selected": true,
+  "store-fake-ip": true
+ },
+ "dns": {
+  "enable": true,
+  "respect-rules": true,
+  "use-system-hosts": false,
+  "listen": "127.0.0.1:1053",
+  "ipv6": false,
+  "nameserver": [
+   "https://8.8.8.8/dns-query#✅ Selector"
+  ],
+  "proxy-server-nameserver": [
+   "8.8.8.8#DIRECT"
+  ],
+  "direct-nameserver": [
+   "8.8.8.8#DIRECT"
+  ],
+  "direct-nameserver-follow-policy": true,
+  "enhanced-mode": "redir-host"
+ },
+ "tun": {
+  "enable": true,
+  "stack": "mixed",
+  "auto-route": true,
+  "strict-route": true,
+  "auto-detect-interface": true,
+  "dns-hijack": [
+   "any:53",
+   "tcp://any:53"
+  ],
+  "mtu": 9000
+ },
+ "sniffer": {
+  "enable": true,
+  "force-dns-mapping": true,
+  "parse-pure-ip": true,
+  "override-destination": true,
+  "sniff": {
+   "HTTP": {
+    "ports": [
+     80,
+     8080,
+     8880,
+     2052,
+     2082,
+     2086,
+     2095
+    ]
+   },
+   "TLS": {
+    "ports": [
+     443,
+     8443,
+     2053,
+     2083,
+     2087,
+     2096
+    ]
+   }
+  }
+ },
+ "proxies": [
+  {
+   "name": "💦 1. VLESS - Domain : 443",
+   "type": "vless",
+   "server": "example.workers.dev",
+   "port": 443,
+   "ip-version": "ipv4",
+   "tfo": false,
+   "udp": false,
+   "uuid": "11111111-2222-3333-4444-555555555555",
+   "packet-encoding": "",
+   "encryption": "",
+   "tls": true,
+   "servername": "example.workers.dev",
+   "client-fingerprint": "chrome",
+   "skip-cert-verify": false,
+   "alpn": [
+    "http/1.1"
+   ],
+   "network": "ws",
+   "ws-opts": {
+    "path": "/vl/PLACEHOLDER",
+    "max-early-data": 2560,
+    "early-data-header-name": "Sec-WebSocket-Protocol",
+    "headers": {
+     "Host": "example.workers.dev"
+    }
+   }
+  },
+  {
+   "name": "💦 2. VLESS - IPv4 : 443",
+   "type": "vless",
+   "server": "203.0.113.11",
+   "port": 443,
+   "ip-version": "ipv4",
+   "tfo": false,
+   "udp": false,
+   "uuid": "11111111-2222-3333-4444-555555555555",
+   "packet-encoding": "",
+   "encryption": "",
+   "tls": true,
+   "servername": "example.workers.dev",
+   "client-fingerprint": "chrome",
+   "skip-cert-verify": false,
+   "alpn": [
+    "http/1.1"
+   ],
+   "network": "ws",
+   "ws-opts": {
+    "path": "/vl/PLACEHOLDER",
+    "max-early-data": 2560,
+    "early-data-header-name": "Sec-WebSocket-Protocol",
+    "headers": {
+     "Host": "example.workers.dev"
+    }
+   }
+  },
+  {
+   "name": "💦 1. Trojan - Domain : 443",
+   "type": "trojan",
+   "server": "example.workers.dev",
+   "port": 443,
+   "ip-version": "ipv4",
+   "tfo": false,
+   "udp": false,
+   "password": "PLACEHOLDER",
+   "tls": true,
+   "sni": "example.workers.dev",
+   "client-fingerprint": "chrome",
+   "skip-cert-verify": false,
+   "alpn": [
+    "http/1.1"
+   ],
+   "network": "ws",
+   "ws-opts": {
+    "path": "/tr/PLACEHOLDER",
+    "max-early-data": 2560,
+    "early-data-header-name": "Sec-WebSocket-Protocol",
+    "headers": {
+     "Host": "example.workers.dev"
+    }
+   }
+  }
+ ],
+ "proxy-groups": [
+  {
+   "name": "✅ Selector",
+   "type": "select",
+   "proxies": [
+    "💦 Best Ping 🚀",
+    "💦 1. VLESS - Domain : 443",
+    "💦 2. VLESS - IPv4 : 443",
+    "💦 3. VLESS - IPv4 : 443",
+    "💦 4. VLESS - Clean IP : 443",
+    "💦 1. Trojan - Domain : 443",
+    "💦 2. Trojan - IPv4 : 443",
+    "💦 3. Trojan - IPv4 : 443",
+    "💦 4. Trojan - Clean IP : 443"
+   ]
+  },
+  {
+   "name": "💦 Best Ping 🚀",
+   "type": "url-test",
+   "proxies": [
+    "💦 1. VLESS - Domain : 443",
+    "💦 2. VLESS - IPv4 : 443",
+    "💦 3. VLESS - IPv4 : 443",
+    "💦 4. VLESS - Clean IP : 443",
+    "💦 1. Trojan - Domain : 443",
+    "💦 2. Trojan - IPv4 : 443",
+    "💦 3. Trojan - IPv4 : 443",
+    "💦 4. Trojan - Clean IP : 443"
+   ],
+   "url": "https://www.gstatic.com/generate_204",
+   "interval": 30,
+   "tolerance": 50
+  }
+ ],
+ "rules": [
+  "GEOIP,lan,DIRECT,no-resolve",
+  "NETWORK,udp,REJECT",
+  "MATCH,✅ Selector"
+ ],
+ "ntp": {
+  "enable": true,
+  "server": "time.cloudflare.com",
+  "port": 123,
+  "interval": 30
+ }
+}

--- a/desktop/internal/mihomoconf/testdata/singbox-normal.json
+++ b/desktop/internal/mihomoconf/testdata/singbox-normal.json
@@ -1,0 +1,206 @@
+{
+ "log": {
+  "disabled": false,
+  "level": "warn",
+  "timestamp": true
+ },
+ "dns": {
+  "servers": [
+   {
+    "type": "https",
+    "server": "8.8.8.8",
+    "detour": "✅ Selector",
+    "tag": "dns-remote"
+   },
+   {
+    "type": "udp",
+    "server": "8.8.8.8",
+    "tag": "dns-direct"
+   }
+  ],
+  "rules": [
+   {
+    "clash_mode": "Direct",
+    "server": "dns-direct"
+   },
+   {
+    "clash_mode": "Global",
+    "server": "dns-remote"
+   }
+  ],
+  "strategy": "ipv4_only",
+  "independent_cache": true
+ },
+ "inbounds": [
+  {
+   "type": "tun",
+   "tag": "tun-in",
+   "address": [
+    "172.19.0.1/28"
+   ],
+   "mtu": 9000,
+   "auto_route": true,
+   "strict_route": true,
+   "stack": "mixed"
+  },
+  {
+   "type": "mixed",
+   "tag": "mixed-in",
+   "listen": "127.0.0.1",
+   "listen_port": 2080
+  }
+ ],
+ "outbounds": [
+  {
+   "tag": "💦 1. VLESS - Domain : 443",
+   "type": "vless",
+   "server": "example.workers.dev",
+   "server_port": 443,
+   "tcp_fast_open": false,
+   "uuid": "11111111-2222-3333-4444-555555555555",
+   "packet_encoding": "",
+   "network": "tcp",
+   "tls": {
+    "enabled": true,
+    "server_name": "example.workers.dev",
+    "record_fragment": false,
+    "insecure": false,
+    "alpn": [
+     "http/1.1"
+    ],
+    "utls": {
+     "enabled": true,
+     "fingerprint": "chrome"
+    }
+   },
+   "transport": {
+    "type": "ws",
+    "path": "/vl/PLACEHOLDER",
+    "max_early_data": 2560,
+    "early_data_header_name": "Sec-WebSocket-Protocol",
+    "headers": {
+     "Host": "example.workers.dev"
+    }
+   },
+   "domain_resolver": "dns-direct"
+  },
+  {
+   "tag": "💦 2. VLESS - IPv4 : 443",
+   "type": "vless",
+   "server": "203.0.113.11",
+   "server_port": 443,
+   "tcp_fast_open": false,
+   "uuid": "11111111-2222-3333-4444-555555555555",
+   "packet_encoding": "",
+   "network": "tcp",
+   "tls": {
+    "enabled": true,
+    "server_name": "example.workers.dev",
+    "record_fragment": false,
+    "insecure": false,
+    "alpn": [
+     "http/1.1"
+    ],
+    "utls": {
+     "enabled": true,
+     "fingerprint": "chrome"
+    }
+   },
+   "transport": {
+    "type": "ws",
+    "path": "/vl/PLACEHOLDER",
+    "max_early_data": 2560,
+    "early_data_header_name": "Sec-WebSocket-Protocol",
+    "headers": {
+     "Host": "example.workers.dev"
+    }
+   }
+  },
+  {
+   "tag": "💦 1. Trojan - Domain : 443",
+   "type": "trojan",
+   "server": "example.workers.dev",
+   "server_port": 443,
+   "tcp_fast_open": false,
+   "password": "PLACEHOLDER",
+   "network": "tcp",
+   "tls": {
+    "enabled": true,
+    "server_name": "example.workers.dev",
+    "record_fragment": false,
+    "insecure": false,
+    "alpn": [
+     "http/1.1"
+    ],
+    "utls": {
+     "enabled": true,
+     "fingerprint": "chrome"
+    }
+   },
+   "transport": {
+    "type": "ws",
+    "path": "/tr/PLACEHOLDER",
+    "max_early_data": 2560,
+    "early_data_header_name": "Sec-WebSocket-Protocol",
+    "headers": {
+     "Host": "example.workers.dev"
+    }
+   },
+   "domain_resolver": "dns-direct"
+  }
+ ],
+ "route": {
+  "rules": [
+   {
+    "ip_cidr": "172.19.0.2",
+    "action": "hijack-dns"
+   },
+   {
+    "clash_mode": "Direct",
+    "outbound": "direct"
+   },
+   {
+    "clash_mode": "Global",
+    "outbound": "✅ Selector"
+   },
+   {
+    "action": "sniff"
+   },
+   {
+    "protocol": "dns",
+    "action": "hijack-dns"
+   },
+   {
+    "ip_is_private": true,
+    "outbound": "direct"
+   },
+   {
+    "network": "udp",
+    "action": "reject"
+   }
+  ],
+  "auto_detect_interface": true,
+  "final": "✅ Selector"
+ },
+ "ntp": {
+  "enabled": true,
+  "server": "time.cloudflare.com",
+  "server_port": 123,
+  "domain_resolver": "dns-direct",
+  "interval": "30m",
+  "write_to_system": false
+ },
+ "experimental": {
+  "cache_file": {
+   "enabled": true,
+   "store_fakeip": true
+  },
+  "clash_api": {
+   "external_controller": "127.0.0.1:9090",
+   "external_ui": "ui",
+   "default_mode": "Rule",
+   "external_ui_download_url": "https://github.com/MetaCubeX/metacubexd/archive/refs/heads/gh-pages.zip",
+   "external_ui_download_detour": "direct"
+  }
+ }
+}

--- a/desktop/internal/mihomoconf/testdata/xray-normal.json
+++ b/desktop/internal/mihomoconf/testdata/xray-normal.json
@@ -1,0 +1,593 @@
+[
+ {
+  "remarks": "💦 1. VLESS - Domain : 443",
+  "version": {
+   "min": "26.2.6"
+  },
+  "log": {
+   "loglevel": "warning"
+  },
+  "dns": {
+   "servers": [
+    {
+     "address": "https://8.8.8.8/dns-query",
+     "tag": "remote-dns"
+    },
+    {
+     "address": "8.8.8.8",
+     "domains": [
+      "full:example.workers.dev"
+     ],
+     "skipFallback": true
+    }
+   ],
+   "queryStrategy": "UseIP",
+   "tag": "dns"
+  },
+  "inbounds": [
+   {
+    "listen": "127.0.0.1",
+    "port": 10808,
+    "protocol": "mixed",
+    "settings": {
+     "auth": "noauth",
+     "udp": true
+    },
+    "sniffing": {
+     "destOverride": [
+      "http",
+      "tls"
+     ],
+     "enabled": true,
+     "routeOnly": true
+    },
+    "tag": "mixed-in"
+   },
+   {
+    "listen": "127.0.0.1",
+    "port": 10853,
+    "protocol": "dokodemo-door",
+    "settings": {
+     "address": "1.1.1.1",
+     "network": "tcp,udp",
+     "port": 53
+    },
+    "tag": "dns-in"
+   }
+  ],
+  "outbounds": [
+   {
+    "protocol": "vless",
+    "settings": {
+     "vnext": [
+      {
+       "address": "example.workers.dev",
+       "port": 443,
+       "users": [
+        {
+         "id": "11111111-2222-3333-4444-555555555555",
+         "encryption": "none"
+        }
+       ]
+      }
+     ]
+    },
+    "streamSettings": {
+     "network": "ws",
+     "wsSettings": {
+      "host": "example.workers.dev",
+      "path": "/vl/PLACEHOLDER?ed=2560"
+     },
+     "security": "tls",
+     "tlsSettings": {
+      "serverName": "example.workers.dev",
+      "fingerprint": "chrome",
+      "alpn": [
+       "http/1.1"
+      ]
+     },
+     "sockopt": {
+      "domainStrategy": "UseIP",
+      "happyEyeballs": {
+       "tryDelayMs": 250,
+       "prioritizeIPv6": false,
+       "interleave": 2,
+       "maxConcurrentTry": 4
+      }
+     }
+    },
+    "tag": "proxy"
+   },
+   {
+    "protocol": "dns",
+    "settings": {
+     "rules": [
+      {
+       "action": "hijack"
+      }
+     ]
+    },
+    "tag": "dns-out"
+   },
+   {
+    "protocol": "freedom",
+    "settings": {
+     "domainStrategy": "UseIP"
+    },
+    "tag": "direct"
+   },
+   {
+    "protocol": "blackhole",
+    "settings": {
+     "response": {
+      "type": "http"
+     }
+    },
+    "tag": "block"
+   }
+  ],
+  "routing": {
+   "domainStrategy": "IPIfNonMatch",
+   "rules": [
+    {
+     "inboundTag": [
+      "mixed-in"
+     ],
+     "port": 53,
+     "outboundTag": "dns-out",
+     "type": "field"
+    },
+    {
+     "inboundTag": [
+      "dns-in"
+     ],
+     "outboundTag": "dns-out",
+     "type": "field"
+    },
+    {
+     "inboundTag": [
+      "remote-dns"
+     ],
+     "outboundTag": "proxy",
+     "type": "field"
+    },
+    {
+     "inboundTag": [
+      "dns"
+     ],
+     "outboundTag": "direct",
+     "type": "field"
+    },
+    {
+     "domain": [
+      "geosite:private"
+     ],
+     "outboundTag": "direct",
+     "type": "field"
+    },
+    {
+     "ip": [
+      "geoip:private"
+     ],
+     "outboundTag": "direct",
+     "type": "field"
+    },
+    {
+     "network": "udp",
+     "outboundTag": "block",
+     "type": "field"
+    },
+    {
+     "network": "tcp",
+     "outboundTag": "proxy",
+     "type": "field"
+    }
+   ]
+  },
+  "policy": {
+   "levels": {
+    "0": {
+     "connIdle": 300,
+     "handshake": 4,
+     "uplinkOnly": 1,
+     "downlinkOnly": 1
+    }
+   },
+   "system": {
+    "statsOutboundUplink": true,
+    "statsOutboundDownlink": true
+   }
+  },
+  "stats": {}
+ },
+ {
+  "remarks": "💦 2. VLESS - IPv4 : 443",
+  "version": {
+   "min": "26.2.6"
+  },
+  "log": {
+   "loglevel": "warning"
+  },
+  "dns": {
+   "servers": [
+    {
+     "address": "https://8.8.8.8/dns-query",
+     "tag": "remote-dns"
+    }
+   ],
+   "queryStrategy": "UseIP",
+   "tag": "dns"
+  },
+  "inbounds": [
+   {
+    "listen": "127.0.0.1",
+    "port": 10808,
+    "protocol": "mixed",
+    "settings": {
+     "auth": "noauth",
+     "udp": true
+    },
+    "sniffing": {
+     "destOverride": [
+      "http",
+      "tls"
+     ],
+     "enabled": true,
+     "routeOnly": true
+    },
+    "tag": "mixed-in"
+   },
+   {
+    "listen": "127.0.0.1",
+    "port": 10853,
+    "protocol": "dokodemo-door",
+    "settings": {
+     "address": "1.1.1.1",
+     "network": "tcp,udp",
+     "port": 53
+    },
+    "tag": "dns-in"
+   }
+  ],
+  "outbounds": [
+   {
+    "protocol": "vless",
+    "settings": {
+     "vnext": [
+      {
+       "address": "203.0.113.10",
+       "port": 443,
+       "users": [
+        {
+         "id": "11111111-2222-3333-4444-555555555555",
+         "encryption": "none"
+        }
+       ]
+      }
+     ]
+    },
+    "streamSettings": {
+     "network": "ws",
+     "wsSettings": {
+      "host": "example.workers.dev",
+      "path": "/vl/PLACEHOLDER?ed=2560"
+     },
+     "security": "tls",
+     "tlsSettings": {
+      "serverName": "example.workers.dev",
+      "fingerprint": "chrome",
+      "alpn": [
+       "http/1.1"
+      ]
+     },
+     "sockopt": {
+      "domainStrategy": "UseIP",
+      "happyEyeballs": {
+       "tryDelayMs": 250,
+       "prioritizeIPv6": false,
+       "interleave": 2,
+       "maxConcurrentTry": 4
+      }
+     }
+    },
+    "tag": "proxy"
+   },
+   {
+    "protocol": "dns",
+    "settings": {
+     "rules": [
+      {
+       "action": "hijack"
+      }
+     ]
+    },
+    "tag": "dns-out"
+   },
+   {
+    "protocol": "freedom",
+    "settings": {
+     "domainStrategy": "UseIP"
+    },
+    "tag": "direct"
+   },
+   {
+    "protocol": "blackhole",
+    "settings": {
+     "response": {
+      "type": "http"
+     }
+    },
+    "tag": "block"
+   }
+  ],
+  "routing": {
+   "domainStrategy": "IPIfNonMatch",
+   "rules": [
+    {
+     "inboundTag": [
+      "mixed-in"
+     ],
+     "port": 53,
+     "outboundTag": "dns-out",
+     "type": "field"
+    },
+    {
+     "inboundTag": [
+      "dns-in"
+     ],
+     "outboundTag": "dns-out",
+     "type": "field"
+    },
+    {
+     "inboundTag": [
+      "remote-dns"
+     ],
+     "outboundTag": "proxy",
+     "type": "field"
+    },
+    {
+     "inboundTag": [
+      "dns"
+     ],
+     "outboundTag": "direct",
+     "type": "field"
+    },
+    {
+     "domain": [
+      "geosite:private"
+     ],
+     "outboundTag": "direct",
+     "type": "field"
+    },
+    {
+     "ip": [
+      "geoip:private"
+     ],
+     "outboundTag": "direct",
+     "type": "field"
+    },
+    {
+     "network": "udp",
+     "outboundTag": "block",
+     "type": "field"
+    },
+    {
+     "network": "tcp",
+     "outboundTag": "proxy",
+     "type": "field"
+    }
+   ]
+  },
+  "policy": {
+   "levels": {
+    "0": {
+     "connIdle": 300,
+     "handshake": 4,
+     "uplinkOnly": 1,
+     "downlinkOnly": 1
+    }
+   },
+   "system": {
+    "statsOutboundUplink": true,
+    "statsOutboundDownlink": true
+   }
+  },
+  "stats": {}
+ },
+ {
+  "remarks": "💦 1. Trojan - Domain : 443",
+  "version": {
+   "min": "26.2.6"
+  },
+  "log": {
+   "loglevel": "warning"
+  },
+  "dns": {
+   "servers": [
+    {
+     "address": "https://8.8.8.8/dns-query",
+     "tag": "remote-dns"
+    },
+    {
+     "address": "8.8.8.8",
+     "domains": [
+      "full:example.workers.dev"
+     ],
+     "skipFallback": true
+    }
+   ],
+   "queryStrategy": "UseIP",
+   "tag": "dns"
+  },
+  "inbounds": [
+   {
+    "listen": "127.0.0.1",
+    "port": 10808,
+    "protocol": "mixed",
+    "settings": {
+     "auth": "noauth",
+     "udp": true
+    },
+    "sniffing": {
+     "destOverride": [
+      "http",
+      "tls"
+     ],
+     "enabled": true,
+     "routeOnly": true
+    },
+    "tag": "mixed-in"
+   },
+   {
+    "listen": "127.0.0.1",
+    "port": 10853,
+    "protocol": "dokodemo-door",
+    "settings": {
+     "address": "1.1.1.1",
+     "network": "tcp,udp",
+     "port": 53
+    },
+    "tag": "dns-in"
+   }
+  ],
+  "outbounds": [
+   {
+    "protocol": "trojan",
+    "settings": {
+     "servers": [
+      {
+       "address": "example.workers.dev",
+       "port": 443,
+       "password": "PLACEHOLDER"
+      }
+     ]
+    },
+    "streamSettings": {
+     "network": "ws",
+     "wsSettings": {
+      "host": "example.workers.dev",
+      "path": "/tr/PLACEHOLDER?ed=2560"
+     },
+     "security": "tls",
+     "tlsSettings": {
+      "serverName": "example.workers.dev",
+      "fingerprint": "chrome",
+      "alpn": [
+       "http/1.1"
+      ]
+     },
+     "sockopt": {
+      "domainStrategy": "UseIP",
+      "happyEyeballs": {
+       "tryDelayMs": 250,
+       "prioritizeIPv6": false,
+       "interleave": 2,
+       "maxConcurrentTry": 4
+      }
+     }
+    },
+    "tag": "proxy"
+   },
+   {
+    "protocol": "dns",
+    "settings": {
+     "rules": [
+      {
+       "action": "hijack"
+      }
+     ]
+    },
+    "tag": "dns-out"
+   },
+   {
+    "protocol": "freedom",
+    "settings": {
+     "domainStrategy": "UseIP"
+    },
+    "tag": "direct"
+   },
+   {
+    "protocol": "blackhole",
+    "settings": {
+     "response": {
+      "type": "http"
+     }
+    },
+    "tag": "block"
+   }
+  ],
+  "routing": {
+   "domainStrategy": "IPIfNonMatch",
+   "rules": [
+    {
+     "inboundTag": [
+      "mixed-in"
+     ],
+     "port": 53,
+     "outboundTag": "dns-out",
+     "type": "field"
+    },
+    {
+     "inboundTag": [
+      "dns-in"
+     ],
+     "outboundTag": "dns-out",
+     "type": "field"
+    },
+    {
+     "inboundTag": [
+      "remote-dns"
+     ],
+     "outboundTag": "proxy",
+     "type": "field"
+    },
+    {
+     "inboundTag": [
+      "dns"
+     ],
+     "outboundTag": "direct",
+     "type": "field"
+    },
+    {
+     "domain": [
+      "geosite:private"
+     ],
+     "outboundTag": "direct",
+     "type": "field"
+    },
+    {
+     "ip": [
+      "geoip:private"
+     ],
+     "outboundTag": "direct",
+     "type": "field"
+    },
+    {
+     "network": "udp",
+     "outboundTag": "block",
+     "type": "field"
+    },
+    {
+     "network": "tcp",
+     "outboundTag": "proxy",
+     "type": "field"
+    }
+   ]
+  },
+  "policy": {
+   "levels": {
+    "0": {
+     "connIdle": 300,
+     "handshake": 4,
+     "uplinkOnly": 1,
+     "downlinkOnly": 1
+    }
+   },
+   "system": {
+    "statsOutboundUplink": true,
+    "statsOutboundDownlink": true
+   }
+  },
+  "stats": {}
+ }
+]

--- a/desktop/internal/mihomoconf/xrayjson.go
+++ b/desktop/internal/mihomoconf/xrayjson.go
@@ -1,0 +1,259 @@
+package mihomoconf
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Xray and V2Ray JSON, which is what a panel serves for v2rayN, MahsaNG and
+// Streisand.
+//
+// Two shapes arrive under this name. A single configuration is an object with
+// `outbounds`; a subscription is an array of whole configurations, each with a
+// `remarks` naming it, because those clients treat one config as one server.
+// Both are read here, and in the array case the remarks becomes the node name —
+// it is the only place the name lives.
+//
+// The proxy itself hides two levels down: `settings.vnext[0]` for vless and
+// vmess, `settings.servers[0]` for trojan and shadowsocks, with the transport
+// and TLS in a `streamSettings` beside it.
+
+// ParseXrayJSON reads an Xray configuration, or a list of them.
+func ParseXrayJSON(body string) ([]Proxy, error) {
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" {
+		return nil, fmt.Errorf("mihomoconf: the configuration is empty")
+	}
+
+	names := newNameRegistry()
+	var proxies []Proxy
+
+	if strings.HasPrefix(trimmed, "[") {
+		var configs []map[string]any
+		if err := json.Unmarshal([]byte(trimmed), &configs); err != nil {
+			return nil, fmt.Errorf("mihomoconf: not an Xray configuration list: %w", err)
+		}
+		for _, config := range configs {
+			proxies = appendXrayOutbounds(proxies, config, jsonString(config, "remarks"), names)
+		}
+	} else {
+		var config map[string]any
+		if err := json.Unmarshal([]byte(trimmed), &config); err != nil {
+			return nil, fmt.Errorf("mihomoconf: not an Xray configuration: %w", err)
+		}
+		proxies = appendXrayOutbounds(proxies, config, "", names)
+	}
+
+	if len(proxies) == 0 {
+		return nil, fmt.Errorf("mihomoconf: the configuration has no usable outbounds")
+	}
+	return proxies, nil
+}
+
+func appendXrayOutbounds(into []Proxy, config map[string]any, remarks string, names *nameRegistry) []Proxy {
+	outbounds, _ := config["outbounds"].([]any)
+	for _, entry := range outbounds {
+		outbound, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		proxy, ok := xrayProxy(outbound)
+		if !ok {
+			continue
+		}
+		// The remarks names the whole configuration, so it belongs to the one
+		// outbound that carries traffic. A tag is the fallback, and the address
+		// after that, because a node with no name cannot be chosen or measured.
+		name := strings.TrimSpace(remarks)
+		if name == "" {
+			name = strings.TrimSpace(jsonString(outbound, "tag"))
+		}
+		if name == "" {
+			name = fmt.Sprintf("%v:%v", proxy["server"], proxy["port"])
+		}
+		proxy["name"] = names.register(name)
+		into = append(into, proxy)
+		// One server per configuration: the rest are freedom, blackhole and dns,
+		// which xrayProxy already refuses, but an array entry that somehow held
+		// two would otherwise take the remarks twice.
+		break
+	}
+	return into
+}
+
+func xrayProxy(outbound map[string]any) (Proxy, bool) {
+	protocol := strings.ToLower(jsonString(outbound, "protocol"))
+	settings, _ := outbound["settings"].(map[string]any)
+	if settings == nil {
+		return nil, false
+	}
+
+	proxy := Proxy{"udp": true}
+	switch protocol {
+	case "vless", "vmess":
+		next := firstMap(settings["vnext"])
+		if next == nil {
+			return nil, false
+		}
+		user := firstMap(next["users"])
+		if user == nil {
+			return nil, false
+		}
+		proxy["type"] = protocol
+		proxy["server"] = jsonString(next, "address")
+		proxy["port"] = jsonInt(next, "port", 0)
+		proxy["uuid"] = jsonString(user, "id")
+		if protocol == "vless" {
+			if flow := jsonString(user, "flow"); flow != "" {
+				proxy["flow"] = flow
+			}
+		} else {
+			proxy["alterId"] = jsonInt(user, "alterId", 0)
+			proxy["cipher"] = orDefault(jsonString(user, "security"), "auto")
+		}
+	case "trojan":
+		server := firstMap(settings["servers"])
+		if server == nil {
+			return nil, false
+		}
+		proxy["type"] = "trojan"
+		proxy["server"] = jsonString(server, "address")
+		proxy["port"] = jsonInt(server, "port", 0)
+		proxy["password"] = jsonString(server, "password")
+	case "shadowsocks":
+		server := firstMap(settings["servers"])
+		if server == nil {
+			return nil, false
+		}
+		proxy["type"] = "ss"
+		proxy["server"] = jsonString(server, "address")
+		proxy["port"] = jsonInt(server, "port", 0)
+		proxy["cipher"] = jsonString(server, "method")
+		proxy["password"] = jsonString(server, "password")
+	default:
+		// freedom, blackhole, dns, socks, http — not servers this app offers.
+		return nil, false
+	}
+
+	server, _ := proxy["server"].(string)
+	port, _ := proxy["port"].(int)
+	if strings.TrimSpace(server) == "" || port < 1 || port > 65535 {
+		return nil, false
+	}
+
+	applyXrayStreamSettings(proxy, outbound)
+	return proxy, true
+}
+
+func applyXrayStreamSettings(proxy Proxy, outbound map[string]any) {
+	stream, _ := outbound["streamSettings"].(map[string]any)
+	if stream == nil {
+		proxy["network"] = "tcp"
+		return
+	}
+
+	switch strings.ToLower(jsonString(stream, "security")) {
+	case "tls":
+		proxy["tls"] = true
+		applyXrayTLS(proxy, stream, "tlsSettings")
+	case "reality":
+		proxy["tls"] = true
+		applyXrayTLS(proxy, stream, "realitySettings")
+		if reality, ok := stream["realitySettings"].(map[string]any); ok {
+			options := map[string]any{"public-key": jsonString(reality, "publicKey")}
+			if shortID := jsonString(reality, "shortId"); shortID != "" {
+				options["short-id"] = shortID
+			}
+			proxy["reality-opts"] = options
+		}
+	}
+
+	network := strings.ToLower(jsonString(stream, "network"))
+	if network == "" {
+		network = "tcp"
+	}
+	switch network {
+	case "ws", "websocket":
+		proxy["network"] = "ws"
+		ws, _ := stream["wsSettings"].(map[string]any)
+		options := map[string]any{"path": jsonString(ws, "path")}
+		if host := jsonString(ws, "host"); host != "" {
+			options["headers"] = map[string]any{"Host": host}
+		}
+		proxy["ws-opts"] = options
+	case "grpc":
+		proxy["network"] = "grpc"
+		grpc, _ := stream["grpcSettings"].(map[string]any)
+		proxy["grpc-opts"] = map[string]any{"grpc-service-name": jsonString(grpc, "serviceName")}
+	case "httpupgrade":
+		proxy["network"] = "httpupgrade"
+		upgrade, _ := stream["httpupgradeSettings"].(map[string]any)
+		proxy["ws-opts"] = map[string]any{
+			"path":    jsonString(upgrade, "path"),
+			"headers": map[string]any{"Host": jsonString(upgrade, "host")},
+		}
+	case "xhttp", "splithttp":
+		proxy["network"] = "xhttp"
+		settings, _ := stream["xhttpSettings"].(map[string]any)
+		if settings == nil {
+			settings, _ = stream["splithttpSettings"].(map[string]any)
+		}
+		options := map[string]any{}
+		for _, key := range []string{"path", "host", "mode"} {
+			if value := jsonString(settings, key); value != "" {
+				options[key] = value
+			}
+		}
+		if extra, ok := settings["extra"].(map[string]any); ok {
+			applyXhttpExtra(options, extra)
+		}
+		proxy["xhttp-opts"] = options
+	case "h2", "http":
+		proxy["network"] = "h2"
+		h2, _ := stream["httpSettings"].(map[string]any)
+		options := map[string]any{}
+		if path := jsonString(h2, "path"); path != "" {
+			options["path"] = path
+		}
+		if hosts := jsonStrings(h2, "host"); len(hosts) > 0 {
+			options["host"] = hosts
+		}
+		proxy["h2-opts"] = options
+	default:
+		proxy["network"] = "tcp"
+	}
+}
+
+func applyXrayTLS(proxy Proxy, stream map[string]any, key string) {
+	settings, _ := stream[key].(map[string]any)
+	if settings == nil {
+		return
+	}
+	name := jsonString(settings, "serverName")
+	if name != "" {
+		if proxy["type"] == "trojan" {
+			proxy["sni"] = name
+		} else {
+			proxy["servername"] = name
+		}
+	}
+	if boolValue(settings["allowInsecure"]) {
+		proxy["skip-cert-verify"] = true
+	}
+	if alpn := jsonStrings(settings, "alpn"); len(alpn) > 0 {
+		proxy["alpn"] = alpn
+	}
+	if fingerprint := jsonString(settings, "fingerprint"); fingerprint != "" {
+		proxy["client-fingerprint"] = fingerprint
+	}
+}
+
+func firstMap(value any) map[string]any {
+	list, ok := value.([]any)
+	if !ok || len(list) == 0 {
+		return nil
+	}
+	first, _ := list[0].(map[string]any)
+	return first
+}

--- a/desktop/internal/session/session.go
+++ b/desktop/internal/session/session.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	yaml "gopkg.in/yaml.v3"
+
 	"whitevpn-desktop/internal/engine"
 	"whitevpn-desktop/internal/mihomoconf"
 )
@@ -371,7 +373,13 @@ func PrepareConfig(opts Options) (string, []string, error) {
 		candidates  []string
 		group       string
 	)
-	if proxies, err := mihomoconf.ConvertLinks(body); err == nil {
+	// One parser for every shape a subscription arrives in, so a mihomo document
+	// yields the same []Proxy as a list of share links and everything after this
+	// point — groups, rules, node selection, fronting — is identical for both.
+	// The document's own groups and rules are deliberately not carried over: a
+	// user picking a node on the Servers page expects that node, not whatever
+	// the provider's url-test group decides.
+	if proxies, _, err := mihomoconf.ParseSubscription(body); err == nil {
 		if opts.FrontingIP != "" {
 			// Nodes fronting cannot be applied to are left reachable at their own
 			// address rather than dropped: a front that covers most of the list is
@@ -397,13 +405,16 @@ func PrepareConfig(opts Options) (string, []string, error) {
 			candidates = preferred
 		}
 		group = mihomoconf.SelectGroup
-	} else if looksLikeMihomoYAML(body) {
-		// Already a mihomo document: pass it through and let its own groups and
-		// rules stand, including whichever node they select.
+	} else if looksLikeMihomoDocument(body) {
+		// A mihomo document whose proxies could not be read as a list — the
+		// usual reason is `proxy-providers`, where the nodes are fetched by the
+		// engine rather than written inline. There is nothing to extract, so it
+		// is passed through and its own groups and rules stand, including
+		// whichever node they select.
 		proxiesYAML = body
 		group = detectProxyGroup(body)
 	} else {
-		return "", nil, fmt.Errorf("session: subscription is neither usable share links nor mihomo YAML: %w", err)
+		return "", nil, fmt.Errorf("session: subscription is neither usable share links nor a mihomo configuration: %w", err)
 	}
 
 	secret, err := randomSecret()
@@ -443,13 +454,23 @@ func intersect(available []string, wanted []string) []string {
 	return kept
 }
 
-func looksLikeMihomoYAML(body string) bool {
-	for _, line := range strings.Split(body, "\n") {
-		if strings.HasPrefix(line, "proxies:") || strings.HasPrefix(line, "proxy-groups:") {
-			return true
-		}
+// looksLikeMihomoDocument decides by parsing rather than by looking at the
+// start of a line.
+//
+// The line-prefix version missed every configuration served as JSON — where the
+// key reads `    "proxies": [` — and JSON is what the panel that prompted this
+// serves. It also missed any YAML that indented its top level or opened with a
+// `---`. Reading the document costs microseconds and cannot be wrong about it.
+func looksLikeMihomoDocument(body string) bool {
+	var document struct {
+		Proxies        []any          `yaml:"proxies"`
+		ProxyGroups    []any          `yaml:"proxy-groups"`
+		ProxyProviders map[string]any `yaml:"proxy-providers"`
 	}
-	return false
+	if err := yaml.Unmarshal([]byte(body), &document); err != nil {
+		return false
+	}
+	return len(document.Proxies) > 0 || len(document.ProxyGroups) > 0 || len(document.ProxyProviders) > 0
 }
 
 // countProxies counts entries under `proxies:` only. Groups use the same

--- a/desktop/internal/session/session_test.go
+++ b/desktop/internal/session/session_test.go
@@ -38,7 +38,15 @@ func TestPrepareConfigFromShareLinks(t *testing.T) {
 
 // A mihomo document already has its own groups and rules, and rewriting them
 // would override choices the provider made deliberately.
-func TestPrepareConfigPassesMihomoYAMLThrough(t *testing.T) {
+// A provider's document is read for its nodes rather than run as-is.
+//
+// It used to be passed through whole, so the provider's groups and rules stood
+// and the app chose nothing. That reads well until you use it: the Servers page
+// had nothing to list, no node could be tested or picked, and a user who chose
+// a country got whatever the provider's own group decided. Extracting the
+// proxies makes a Clash subscription behave exactly like a list of share links,
+// which is the point — one model, not two.
+func TestPrepareConfigReadsTheNodesOutOfAMihomoDocument(t *testing.T) {
 	subscription := strings.Join([]string{
 		"proxies:",
 		"  - name: Node",
@@ -58,12 +66,50 @@ func TestPrepareConfigPassesMihomoYAMLThrough(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// A provider's document selects its own node, so there is nothing for us to
-	// choose between and nothing to override.
-	if len(candidates) != 0 {
-		t.Fatalf("expected no candidates for a provider document, got %v", candidates)
+	if len(candidates) != 1 || candidates[0] != "Node" {
+		t.Fatalf("the document's nodes should be choosable, got %v", candidates)
 	}
 
+	var parsed map[string]any
+	if err := yaml.Unmarshal([]byte(document), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	// Our own groups, so a node picked in the interface is the node used.
+	groups := parsed["proxy-groups"].([]any)
+	if len(groups) == 0 || groups[0].(map[string]any)["name"] != mihomoconf.SelectGroup {
+		t.Fatalf("expected this app's select group, got %#v", groups)
+	}
+	proxies := parsed["proxies"].([]any)
+	if len(proxies) != 1 || proxies[0].(map[string]any)["name"] != "Node" {
+		t.Fatalf("the node should survive into the configuration: %#v", proxies)
+	}
+}
+
+// The exception, and the reason the pass-through still exists: a document whose
+// nodes are fetched by the engine rather than written down. There is nothing to
+// extract, so it is run as the provider wrote it.
+func TestPrepareConfigPassesAProxyProviderDocumentThrough(t *testing.T) {
+	subscription := strings.Join([]string{
+		"proxy-providers:",
+		"  theirs:",
+		"    type: http",
+		"    url: https://example.com/nodes.yaml",
+		"    path: ./theirs.yaml",
+		"proxy-groups:",
+		"  - name: Provider Group",
+		"    type: select",
+		"    use: ['theirs']",
+		"rules:",
+		"  - MATCH,Provider Group",
+	}, "\n")
+
+	document, candidates, err := PrepareConfig(Options{Subscription: subscription})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("nothing is written down to choose between, got %v", candidates)
+	}
 	var parsed map[string]any
 	if err := yaml.Unmarshal([]byte(document), &parsed); err != nil {
 		t.Fatal(err)

--- a/desktop/v2ray.go
+++ b/desktop/v2ray.go
@@ -231,9 +231,22 @@ func (a *App) RefreshV2RaySubscription(id string) (model.V2RaySubscriptionRefres
 
 	rawText, fetchErr := fetchV2RaySubscriptionDocument(context.Background(), subscription.URL)
 	var imported []model.V2RayProfile
+	var importedCount int
 	var parseErr error
 	if fetchErr == nil {
 		imported, parseErr = profiles.ParseV2RaySubscriptionDocument(rawText)
+		importedCount = len(imported)
+		if parseErr != nil {
+			// Not share links. It may still be a whole mihomo configuration —
+			// what a panel serves behind `?app=clash` — which is the engine's
+			// own language and needs no conversion at all. There are no V2Ray
+			// profiles to store for one, and nothing needs them: the node list,
+			// the Servers page and the connect path all read the subscription
+			// body itself.
+			if nodes, err := whiteVPNNodesFromSubscription(rawText); err == nil {
+				imported, parseErr, importedCount = nil, nil, len(nodes)
+			}
+		}
 	}
 
 	a.mu.Lock()
@@ -285,7 +298,7 @@ func (a *App) RefreshV2RaySubscription(id string) (model.V2RaySubscriptionRefres
 
 	// A refresh is a request for the current list, cache included.
 	a.forgetWhiteVPNNodes(id)
-	a.state.V2RaySubscriptions[idx].ImportedCount = len(imported)
+	a.state.V2RaySubscriptions[idx].ImportedCount = importedCount
 	a.state.V2RaySubscriptions[idx].LastUpdatedAt = time.Now().UTC().Format(time.RFC3339)
 	a.state.V2RaySubscriptions[idx].LastError = ""
 	next, err := a.saveLocked()
@@ -294,8 +307,8 @@ func (a *App) RefreshV2RaySubscription(id string) (model.V2RaySubscriptionRefres
 		State:        next,
 		Subscription: subscription,
 		OK:           true,
-		Message:      fmt.Sprintf("Imported %d V2Ray profile%s.", len(imported), pluralSuffix(len(imported))),
-		Imported:     len(imported),
+		Message:      fmt.Sprintf("Imported %d server%s.", importedCount, pluralSuffix(importedCount)),
+		Imported:     importedCount,
 		Removed:      removed,
 	}, err
 }

--- a/desktop/whitevpn_nodes.go
+++ b/desktop/whitevpn_nodes.go
@@ -247,7 +247,10 @@ func measureNodeDelays(ctx context.Context, client *engine.Process, names []stri
 // whiteVPNNodesFromSubscription turns a decrypted catalogue into nodes, in the
 // order the catalogue gave them — which is the order the connect path tries.
 func whiteVPNNodesFromSubscription(subscription string) ([]model.WhiteVPNNode, error) {
-	proxies, sources, err := mihomoconf.ConvertLinksWithSources(subscription)
+	// ParseSubscription rather than ConvertLinksWithSources: a subscription may
+	// be share links or a whole mihomo configuration, and the Servers page, the
+	// tests and the connection dialog have no business knowing which.
+	proxies, sources, err := mihomoconf.ParseSubscription(subscription)
 	if err != nil {
 		return nil, fmt.Errorf("the catalogue held no usable nodes: %w", err)
 	}


### PR DESCRIPTION
Adding a BPB subscription failed with *"subscription must contain V2Ray links or
base64 encoded V2Ray links"*. True, and useless: what it contained was a **mihomo
configuration** — the language this app's own engine speaks.

## What was actually wrong

Support was half-built. `PrepareConfig` already had a pass-through for mihomo
documents; two things kept anything from reaching it:

1. The save gate only understood share links.
2. The detector matched lines beginning `proxies:` — so it missed every
   configuration served as **JSON**, which is what the panel serves.

## Rather than fix that and stop

All nine combinations the panel offers were fetched and tested:

| | clash | sing-box | xray |
|---|---|---|---|
| **normal** | ✅ was fine | ❌ → ✅ 8 | ❌ → ✅ 9 |
| **fragment** | ✅ was fine | ❌ → ✅ 8 | ❌ → ✅ 10 |
| **raw** | ✅ was fine | ✅ was fine | ✅ was fine |

Plus a 3x-ui/Sanaei subscription as a regression check — 5 nodes, share links
intact.

Three of the four that were refused were **connected through and passed real
traffic** to confirm it, not just parsed: exit IPs `89.58.40.177`,
`49.12.237.71`, `89.58.13.3`, all health 200.

## One entry point

`ParseSubscription` reads share links, mihomo YAML/JSON, sing-box JSON, Xray
JSON or a list of Xray configs, and unwraps base64 around any of them.

Everything lands as `[]Proxy`, so the Servers page, delay and speed tests, node
selection and IP fronting cannot tell the shapes apart. That is the point: one
model, not two.

This also covers what **Marzban** and **Hiddify** serve — base64 share links,
Clash YAML, sing-box JSON — though without a sample of either I would not claim
it as tested.

## Two decisions worth naming

**A document's nodes are extracted rather than its groups run as written.** A
user who picks a node expects that node, not whatever the provider's url-test
decides, and the Servers page needs something to list. The exception is
`proxy-providers`, where the nodes are fetched by the engine and there is
nothing to extract; that still passes through. There is a test for each.

**In sing-box and Xray the TLS name goes under `sni` for trojan and
`servername` for everything else.** Getting that wrong is a handshake that fails
with nothing to explain it, so it has its own test.

## Also

The refusal message now names what came back — a web page (a login page behind
the address is the commonest cause), JSON with nothing in it, unusable links, or
nothing at all — with its size but **never its content**, since a subscription
body is a credential and that message is what gets screenshotted.

Share is disabled for nodes read out of a configuration: there is no link to
share, and a button that silently copies nothing is worse than one that says so.

Fixtures are the real subscriptions with every credential, hostname and path
replaced — this repository is public.

## Verification

`go build`, `go vet`, `go test ./...` and `tsc --noEmit --noUnusedLocals` all
clean. The two failures that remain are the pre-existing Windows-only ones on
`main` (`TestFindMihomoCoreExplainsItselfWhenAbsent` and the darwin path test).