### PR TITLE
Read the version from the binary instead of typing it into the sidebar

### DIFF
--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/sh
 
 APP_NAME := WhiteVPN Desktop
-DEFAULT_VERSION := 1.0.0
+DEFAULT_VERSION := 1.0.1
 VERSION_FROM_ARGS := $(shell set -- $(MAKECMDGOALS); while [ "$$1" != "" ]; do if [ "$$1" = "--version" ]; then shift; if [ "$$1" != "" ]; then printf '%s' "$$1"; fi; exit; fi; shift; done)
 VERSION ?= $(if $(VERSION_FROM_ARGS),$(VERSION_FROM_ARGS),$(DEFAULT_VERSION))
 APP_VERSION := $(strip $(VERSION))
@@ -14,13 +14,17 @@ GO_ENV_FILE ?= $(CURDIR)/.cache/go-env
 XRAY_CORE_VERSION ?= v26.3.27
 XRAY_CACHE_DIR ?= $(CURDIR)/.cache/xray
 RELEASE_LDFLAGS ?= -s -w
-WAILS_RELEASE_FLAGS := -trimpath -ldflags "$(RELEASE_LDFLAGS)"
+# -X main.appVersion: the interface reads its version from the binary rather
+# than from a string someone has to remember to edit. Releasing 1.0.1 once
+# shipped an app whose own sidebar said 1.0.0.
+VERSION_LDFLAGS := -X main.appVersion=$(APP_VERSION)
+WAILS_RELEASE_FLAGS := -trimpath -ldflags "$(RELEASE_LDFLAGS) $(VERSION_LDFLAGS)"
 HELPER_GO_LDFLAGS ?= $(RELEASE_LDFLAGS)
 UPX ?= 0
 UPX_FLAGS ?= --best --lzma
 MACOS_CGO_LDFLAGS ?= -framework UniformTypeIdentifiers
 MACOS_GO_TAGS ?= desktop,wv2runtime.download,production
-MACOS_GO_LDFLAGS ?= $(RELEASE_LDFLAGS)
+MACOS_GO_LDFLAGS ?= $(RELEASE_LDFLAGS) $(VERSION_LDFLAGS)
 MACOS_DEPLOYMENT_TARGET_AMD64 ?= 10.13
 MACOS_DEPLOYMENT_TARGET_ARM64 ?= 11.0
 MACOS_BUNDLE_MIN_VERSION ?= $(if $(filter arm64,$(MACOS_CLIENT_ARCH)),$(MACOS_DEPLOYMENT_TARGET_ARM64),$(MACOS_DEPLOYMENT_TARGET_AMD64))

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/sh
 
 APP_NAME := WhiteVPN Desktop
-DEFAULT_VERSION := 1.0.1
+DEFAULT_VERSION := 1.0.2
 VERSION_FROM_ARGS := $(shell set -- $(MAKECMDGOALS); while [ "$$1" != "" ]; do if [ "$$1" = "--version" ]; then shift; if [ "$$1" != "" ]; then printf '%s' "$$1"; fi; exit; fi; shift; done)
 VERSION ?= $(if $(VERSION_FROM_ARGS),$(VERSION_FROM_ARGS),$(DEFAULT_VERSION))
 APP_VERSION := $(strip $(VERSION))

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -674,6 +674,7 @@ function App() {
   // Where the engine's proxy listens, asked once. The page has to be able to
   // name it while disconnected — that is when someone is setting a browser up.
   const [engineProxyEndpoint, setEngineProxyEndpoint] = useState("");
+  const [appVersion, setAppVersion] = useState("");
   const [page, setPage] = useState<Page>("vpn");
   const [errorToast, setErrorToast] = useState<AppErrorToast | null>(null);
   const [successToast, setSuccessToast] = useState<AppErrorToast | null>(null);
@@ -826,6 +827,10 @@ function App() {
       .getAppState()
       .then(applyState)
       .catch((err) => showError(messageFromError(err)));
+    backend
+      .getAppVersion()
+      .then(setAppVersion)
+      .catch(() => setAppVersion(""));
     backend
       .getLocalProxyEndpoint()
       .then(setEngineProxyEndpoint)
@@ -986,7 +991,7 @@ function App() {
   return (
     <TooltipProvider>
       <SidebarProvider defaultOpen>
-        <AppSidebar page={activePage} runtime={state.runtime} onPage={setPage} language={language} t={t} />
+        <AppSidebar page={activePage} runtime={state.runtime} onPage={setPage} language={language} version={appVersion} t={t} />
         <SidebarInset className="min-w-0 overflow-x-hidden">
           <main className="min-h-svh min-w-0 overflow-x-hidden bg-muted/30 p-4 md:p-6">
             <div className="mx-auto flex w-full min-w-0 max-w-7xl flex-col gap-4">
@@ -1259,12 +1264,14 @@ function AppSidebar({
   runtime,
   onPage,
   language,
+  version,
   t,
 }: {
   page: Page;
   runtime: RuntimeStatus;
   onPage: (page: Page) => void;
   language: Language;
+  version: string;
   t: TranslateFn;
 }) {
   const sidebarEndpoint = runtimeProxyDisplayEndpoint(runtime);
@@ -1296,7 +1303,11 @@ function AppSidebar({
             </div>
             <div className="min-w-0 group-data-[collapsible=icon]:hidden">
               <div className="truncate text-sm leading-snug font-medium">WhiteVPN</div>
-              <p className="truncate text-sm leading-normal text-muted-foreground">v1.0.0</p>
+              {/* Read from the binary, never typed here: a version in two
+                  places is a version that will disagree with itself, and this
+                  one shipped 1.0.1 while saying 1.0.0. Blank until it arrives,
+                  because a stale number is worse than none. */}
+              <p className="truncate text-sm leading-normal text-muted-foreground">{version ? `v${version}` : ""}</p>
             </div>
           </div>
           <ThemeSettingsMenu

--- a/desktop/frontend/src/wails.ts
+++ b/desktop/frontend/src/wails.ts
@@ -81,6 +81,7 @@ type AppApi = {
   SaveWhiteVPNSettings(settings: WhiteVPNSettings): Promise<AppState>;
   GetPrivacyPolicyVersion(): Promise<number>;
   AcceptPrivacyPolicy(): Promise<AppState>;
+  GetAppVersion(): Promise<string>;
   GetLocalProxyEndpoint(): Promise<string>;
   ListWhiteVPNNodes(refresh: boolean): Promise<WhiteVPNNodeList>;
   ListSubscriptionNodes(subscriptionId: string, refresh: boolean): Promise<WhiteVPNNodeList>;
@@ -171,6 +172,7 @@ export const backend = {
   saveWhiteVpnSettings: (settings: WhiteVPNSettings) => app().SaveWhiteVPNSettings(settings),
   getPrivacyPolicyVersion: () => app().GetPrivacyPolicyVersion(),
   acceptPrivacyPolicy: () => app().AcceptPrivacyPolicy(),
+  getAppVersion: () => app().GetAppVersion(),
   getLocalProxyEndpoint: () => app().GetLocalProxyEndpoint(),
   listWhiteVpnNodes: (refresh: boolean) => app().ListWhiteVPNNodes(refresh),
   listSubscriptionNodes: (subscriptionId: string, refresh: boolean) => app().ListSubscriptionNodes(subscriptionId, refresh),

--- a/desktop/version.go
+++ b/desktop/version.go
@@ -1,0 +1,20 @@
+package main
+
+// appVersion is set at link time by the Makefile:
+//
+//	-ldflags "-X main.appVersion=$(APP_VERSION)"
+//
+// It exists because the version used to be typed into the interface by hand,
+// so releasing 1.0.1 shipped an app that said 1.0.0 in its own sidebar. A
+// number a human has to remember to change in two places is a number that will
+// be wrong.
+//
+// A build that goes through the Makefile carries the real version. A plain
+// `wails build` or `go run` carries "dev", which is honest — it is a
+// development build, and saying so beats claiming a release number nobody cut.
+var appVersion = "dev"
+
+// GetAppVersion is what the interface shows beside the app's name.
+func (a *App) GetAppVersion() string {
+	return appVersion
+}

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -11,7 +11,7 @@
     "email": ""
   },
   "info": {
-    "productVersion": "1.0.1",
+    "productVersion": "1.0.2",
     "productName": "WhiteVPN Desktop"
   }
 }

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -9,6 +9,9 @@
   "author": {
     "name": "WhiteDNS",
     "email": ""
+  },
+  "info": {
+    "productVersion": "1.0.1",
+    "productName": "WhiteVPN Desktop"
   }
 }
-


### PR DESCRIPTION
Releasing 1.0.1 shipped an app whose own sidebar said **1.0.0**.

## Why

The number lived in three places that had to agree, and did not:

| Where | Held | Shows up as |
|---|---|---|
| `desktop/Makefile` `DEFAULT_VERSION` | `1.0.0` | release asset filenames |
| `frontend/src/App.tsx` — a string literal | `v1.0.0` | **the sidebar** |
| `desktop/wails.json` | *nothing* | Wails defaulted the Windows file-properties dialog |

The release itself was right — CI passes `VERSION` from the tag — so only the
places nobody passes a version to were wrong.

## What changes

One source. The Makefile links the version into the binary:

```make
VERSION_LDFLAGS := -X main.appVersion=$(APP_VERSION)
```

`GetAppVersion` exposes it and the sidebar shows what it is told. A build that
does not go through the Makefile shows **nothing** rather than a number nobody
cut — a stale version is worse than none, which is the whole lesson here.

`DEFAULT_VERSION` and `wails.json` move to `1.0.1` to match what is released.

## Verified rather than assumed

- The linker accepts the symbol and the value reaches the binary — checked by
  building with `-X main.appVersion=9.9.9-test` and finding it, and by building
  without the flag and not finding it.
- The old literal is gone from the built frontend bundle.
- `VERSION_LDFLAGS` is defined before `WAILS_RELEASE_FLAGS` uses it, and reaches
  the macOS build through `MACOS_GO_LDFLAGS` too.

`go build`, `go vet` and `tsc --noEmit --noUnusedLocals` are clean. The two test
failures that remain are the pre-existing Windows-only ones on `main`.