### PR TITLE
Let the engine choose the node, as the Android app does

### DIFF
--- a/desktop/ANDROID-PARITY.md
+++ b/desktop/ANDROID-PARITY.md
@@ -210,6 +210,57 @@ stops any engine it had already spawned, and a session that finishes in the gap
 is closed rather than adopted. A cancelled connect ends `disconnected`, not
 `failed`: the user asked for this one.
 
+## 5-bis. How a node gets chosen — and a correction
+
+An earlier version of this file, and a comment in `internal/session/session.go`,
+said *"a node has to be chosen explicitly, as the phone app does"*. **That was
+wrong about the phone app.** It was written from an assumption rather than from
+Android's source, and it was the assumption behind a run of user reports saying
+the desktop could not connect.
+
+What Android actually does, in `WhiteDnsVpnService.kt`:
+
+```kotlin
+val nativeAutomaticStart = topEndpoint == null &&
+    !validateConnectivity &&
+    explicitProfile == null &&
+    selectedAutomaticTypes.isEmpty() &&
+    nativeAutomaticGroup != null
+```
+
+When the user has narrowed nothing, Android selects the **url-test group**, not a
+node — `MihomoSelectionPolicy.desiredSelection` returns a
+`MihomoGroupSelection(selectorGroup, selectedGroup)` — and its ordinary connect
+path passes `validateConnectivity = false`, so it does not gate on a health
+check at all. It starts the engine and lets mihomo choose.
+
+That is the whole reason the phone feels smooth, and it is not subtle. A
+`url-test` group measures its members continuously and picks the fastest that
+answers; `GroupBase.onDialFailed` re-runs the health check once dialling through
+the current node has failed five times in a row, and the group moves itself. A
+`select` group pinned to one node does none of that — once pinned, it is pinned
+until something outside asks it to change.
+
+The desktop had built the url-test group since the beginning (`AutoGroup`,
+`mihomoconf/config.go`, first entry of the selector) and then walked straight
+past it: `session.start` selected `candidates[0]`, `candidates[1]`, and so on. So
+with a subscription of 800+ nodes, every user on Automatic tried the **same five
+nodes, in the same order**, each behind a 12-second health gate, and Retry tried
+the same five again. A bad head of the catalogue was enough to tell everybody the
+app could not connect — which is a completely different failure from "some nodes
+are down", and looks identical from the outside.
+
+**Now:** on Automatic the engine chooses, exactly as on Android. The node-by-node
+walk survives only as a fallback for when nothing answers through the group, and
+it is ordered by the delays url-test has already measured rather than by
+catalogue position. An explicit choice — a country, or a node from the Servers
+page — still pins, because that is the user answering the question themselves.
+
+A pinned session recovers by trying other nodes (`Session.Recover`). An automatic
+one recovers by re-asserting the group and letting mihomo move, because pinning a
+node there would replace something that keeps looking with something that never
+looks again.
+
 ## 5a. Servers, and why it agrees with the dashboard now
 
 The Servers page and the dashboard's connection dialog show the same thing, so
@@ -367,8 +418,10 @@ The engine is mihomo, the one WhiteVPN for Android runs, built from the same
 pinned sources, and now the only one: the Xray path was removed on 2026-08-04.
 It travels inside the app and unpacks itself beside the app's data on first
 connect, so an install is one file. Connecting works end to end and is verified against the live
-catalogue: the share links in, proxies out, a node selected explicitly, and a
-real HTTP request through the proxy before anything is reported connected. The
+catalogue: the share links in, proxies out, a selection made, and a
+real HTTP request through the proxy before anything is reported connected. On
+Automatic the selection is the engine's own url-test group, as on the phone —
+see *How a node gets chosen* below. The
 catalogue is not a fixed size — 845 proxies measured early on 2026-08-04, 585
 later the same day — so treat any count in this file as a reading, not a
 constant. The tunnel works too, with only the engine elevated.

--- a/desktop/internal/engine/actions.go
+++ b/desktop/internal/engine/actions.go
@@ -91,14 +91,29 @@ func (c *Client) Proxies(ctx context.Context) (json.RawMessage, error) {
 	return c.invoke(ctx, "getProxies", nil)
 }
 
-// ChangeProxy selects proxy within group.
+// ChangeProxy selects proxy within group. The proxy may itself be a group, which
+// is how automatic selection is handed to the core's url-test group.
+//
+// Its reply follows the same unusual convention as SetupConfig: the call
+// succeeds at the protocol level either way, and an empty string is the only
+// thing that means the selection was made. "Not found group" and "Group is not
+// selectable" arrive as ordinary successful replies. Ignoring the payload — which
+// this did — meant a selection that never happened was reported as one that did,
+// and the health check that followed measured whatever node was already in
+// place. A connection could therefore be reported on a node nobody chose.
 func (c *Client) ChangeProxy(ctx context.Context, group, proxy string) error {
 	params, err := json.Marshal(map[string]string{"group-name": group, "proxy-name": proxy})
 	if err != nil {
 		return err
 	}
-	_, err = c.invoke(ctx, "changeProxy", string(params))
-	return err
+	raw, err := c.invoke(ctx, "changeProxy", string(params))
+	if err != nil {
+		return err
+	}
+	if message := decodeString(raw); message != "" {
+		return fmt.Errorf("engine: could not select %q in %q: %s", proxy, group, message)
+	}
+	return nil
 }
 
 // TestDelay measures one proxy. The measurement is a metric, not a gate: a proxy

--- a/desktop/internal/session/automatic_live_test.go
+++ b/desktop/internal/session/automatic_live_test.go
@@ -1,0 +1,88 @@
+package session
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"whitevpn-desktop/internal/mihomoconf"
+)
+
+// The connect path used to pick nodes itself, always starting at the top of the
+// catalogue. Every user therefore tried the same five servers in the same order,
+// and Retry tried the same five again — so a bad head of the list did not fail
+// some users some of the time, it told everybody the app could not connect. That
+// is what the reports were.
+//
+// This connects three times against the live catalogue and asserts the two
+// properties that make the new path different: the engine's own group is
+// choosing, and what it chooses is not the same node every time. If either
+// regresses, the old failure comes back and looks exactly like a server problem.
+//
+//	WHITEVPN_CATALOGUE_URL=... WHITEVPN_CATALOGUE_KEY=... go test ./internal/session -run LiveAutomatic -v
+func TestLiveAutomaticLetsTheEngineChoose(t *testing.T) {
+	catalogueURL := os.Getenv("WHITEVPN_CATALOGUE_URL")
+	catalogueKey := os.Getenv("WHITEVPN_CATALOGUE_KEY")
+	if catalogueURL == "" || catalogueKey == "" {
+		t.Skip("set WHITEVPN_CATALOGUE_URL and WHITEVPN_CATALOGUE_KEY to run this")
+	}
+
+	corePath := enginePath(t)
+	subscription := fetchSubscription(t, catalogueURL, catalogueKey)
+
+	const runs = 3
+	chosen := make([]string, 0, runs)
+
+	for run := 0; run < runs; run++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+
+		started := time.Now()
+		session, err := Connect(ctx, Options{
+			CorePath:     corePath,
+			HomeDir:      t.TempDir(),
+			Subscription: subscription,
+			// Its own ports per run: the previous engine may still be letting go
+			// of the last ones.
+			MixedPort:              23180 + run,
+			ControlPort:            23190 + run,
+			Tun:                    mihomoconf.TunOptions{Enabled: false},
+			PipeSecurityDescriptor: "D:P(A;;GA;;;WD)",
+		})
+		if err != nil {
+			cancel()
+			t.Fatalf("run %d: connect: %v", run+1, err)
+		}
+
+		t.Logf("run %d: %s, %d of %d sampled nodes answered, engine chose %q",
+			run+1, time.Since(started).Round(time.Millisecond), session.Seeded(), seedSample, session.Selected())
+
+		if !session.Automatic() {
+			t.Errorf("run %d: the app pinned a node instead of leaving the choice to the engine", run+1)
+		}
+		if session.Seeded() < seedEnough {
+			t.Errorf("run %d: only %d nodes answered, so the group had little to choose from", run+1, session.Seeded())
+		}
+		if session.Selected() == "" {
+			t.Errorf("run %d: connected without being able to name the node carrying traffic", run+1)
+		}
+		chosen = append(chosen, session.Selected())
+
+		_ = session.Close()
+		cancel()
+	}
+
+	// Not a strict requirement of correctness — three draws from a live catalogue
+	// could legitimately agree — but if it never varies, the catalogue is being
+	// walked rather than sampled, which is the bug this replaced.
+	same := true
+	for _, name := range chosen {
+		if name != chosen[0] {
+			same = false
+			break
+		}
+	}
+	if same {
+		t.Logf("all %d runs chose %q — worth a look if it keeps happening", runs, chosen[0])
+	}
+}

--- a/desktop/internal/session/proxies.go
+++ b/desktop/internal/session/proxies.go
@@ -1,0 +1,106 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"sort"
+)
+
+// What the engine reports about the proxies it is holding. Only the fields this
+// app reads are named; the payload carries a good deal more.
+type proxyView struct {
+	Type    string         `json:"type"`
+	Now     string         `json:"now"`
+	History []delayHistory `json:"history"`
+}
+
+type delayHistory struct {
+	Delay int `json:"delay"`
+}
+
+// noDelay stands for "never measured, or measured and failed". It sorts last,
+// which is the whole point: a node nothing is known about must not displace one
+// that answered.
+const noDelay = math.MaxInt32
+
+// proxySnapshot reads the engine's current view of every proxy and group.
+func proxySnapshot(ctx context.Context, process proxyReader) (map[string]proxyView, error) {
+	raw, err := process.Proxies(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Proxies map[string]proxyView `json:"proxies"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, err
+	}
+	return payload.Proxies, nil
+}
+
+// proxyReader is the part of the engine this file needs, so the ordering can be
+// tested without one.
+type proxyReader interface {
+	Proxies(ctx context.Context) (json.RawMessage, error)
+}
+
+// resolveGroup follows a group to the node actually carrying traffic.
+//
+// A url-test group answers with whichever node its last measurement liked, and
+// that node is what the interface has to name — "WhiteDNS Auto" tells a user
+// nothing about where their traffic leaves from. Groups can point at groups, so
+// this follows the chain rather than assuming one hop.
+func resolveGroup(proxies map[string]proxyView, name string) string {
+	for hops := 0; hops < 8; hops++ {
+		view, ok := proxies[name]
+		if !ok || view.Now == "" {
+			return name
+		}
+		name = view.Now
+	}
+	return name
+}
+
+// lastDelay is the most recent measurement for a node, or noDelay when there is
+// none. A zero delay in the history means the measurement failed, which is not
+// the same as "instant" and must not sort first.
+func lastDelay(proxies map[string]proxyView, name string) int {
+	view, ok := proxies[name]
+	if !ok || len(view.History) == 0 {
+		return noDelay
+	}
+	delay := view.History[len(view.History)-1].Delay
+	if delay <= 0 {
+		return noDelay
+	}
+	return delay
+}
+
+// byMeasuredDelay orders candidates fastest-first, keeping the original order
+// among nodes nothing is known about.
+//
+// It exists because the fallback used to walk the catalogue from the top, which
+// meant every user on Automatic tried the same first five nodes, and Retry tried
+// them again. With eight hundred nodes in the subscription, a bad head of the
+// list was enough to tell everybody the app could not connect. By the time this
+// ordering is needed the url-test group has already measured, so the numbers to
+// choose by are sitting there unused.
+func byMeasuredDelay(candidates []string, proxies map[string]proxyView) []string {
+	ordered := make([]string, len(candidates))
+	copy(ordered, candidates)
+
+	position := make(map[string]int, len(candidates))
+	for i, name := range candidates {
+		position[name] = i
+	}
+
+	sort.SliceStable(ordered, func(i, j int) bool {
+		left, right := lastDelay(proxies, ordered[i]), lastDelay(proxies, ordered[j])
+		if left != right {
+			return left < right
+		}
+		return position[ordered[i]] < position[ordered[j]]
+	})
+	return ordered
+}

--- a/desktop/internal/session/proxies_test.go
+++ b/desktop/internal/session/proxies_test.go
@@ -1,0 +1,104 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+type fakeProxyReader struct {
+	payload string
+	err     error
+}
+
+func (f fakeProxyReader) Proxies(context.Context) (json.RawMessage, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return json.RawMessage(f.payload), nil
+}
+
+// The interface has to name a place, not a group. Asking the engine what the
+// group settled on is the only way to know, because the app no longer chooses.
+func TestResolveGroupFollowsTheChain(t *testing.T) {
+	proxies := map[string]proxyView{
+		"WhiteDNS Proxy": {Type: "Selector", Now: "WhiteDNS Auto"},
+		"WhiteDNS Auto":  {Type: "URLTest", Now: "Germany 3"},
+		"Germany 3":      {Type: "Vless"},
+	}
+	if name := resolveGroup(proxies, "WhiteDNS Proxy"); name != "Germany 3" {
+		t.Fatalf("expected the node behind both groups, got %q", name)
+	}
+}
+
+// A group pointing at itself, or at each other, must not spin.
+func TestResolveGroupSurvivesALoop(t *testing.T) {
+	proxies := map[string]proxyView{
+		"A": {Now: "B"},
+		"B": {Now: "A"},
+	}
+	if name := resolveGroup(proxies, "A"); name == "" {
+		t.Fatal("expected a name rather than nothing")
+	}
+}
+
+func TestProxySnapshotReadsTheEnginesView(t *testing.T) {
+	reader := fakeProxyReader{payload: `{"proxies":{"Germany 3":{"type":"Vless","history":[{"delay":180}]}}}`}
+	proxies, err := proxySnapshot(context.Background(), reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delay := lastDelay(proxies, "Germany 3"); delay != 180 {
+		t.Fatalf("expected the last measurement, got %d", delay)
+	}
+	if _, err := proxySnapshot(context.Background(), fakeProxyReader{err: errors.New("no")}); err == nil {
+		t.Fatal("expected the engine's failure to surface")
+	}
+}
+
+// A zero delay is a failed measurement, not an instant one. Sorting it first
+// would put the nodes that answered nothing at the front of the queue.
+func TestLastDelayTreatsZeroAsUnknown(t *testing.T) {
+	proxies := map[string]proxyView{
+		"failed":    {History: []delayHistory{{Delay: 120}, {Delay: 0}}},
+		"never run": {},
+	}
+	if delay := lastDelay(proxies, "failed"); delay != noDelay {
+		t.Fatalf("a failed measurement should not sort as fast, got %d", delay)
+	}
+	if delay := lastDelay(proxies, "never run"); delay != noDelay {
+		t.Fatalf("an unmeasured node should sort last, got %d", delay)
+	}
+	if delay := lastDelay(proxies, "absent"); delay != noDelay {
+		t.Fatalf("a node the engine does not hold should sort last, got %d", delay)
+	}
+}
+
+// The fallback used to walk the catalogue from the top, so every user tried the
+// same five nodes and Retry tried them again. With hundreds of nodes measured
+// already, the order should come from the measurements.
+func TestByMeasuredDelayPutsTheFastestFirst(t *testing.T) {
+	candidates := []string{"slow", "dead", "fast", "unmeasured"}
+	proxies := map[string]proxyView{
+		"slow": {History: []delayHistory{{Delay: 900}}},
+		"dead": {History: []delayHistory{{Delay: 0}}},
+		"fast": {History: []delayHistory{{Delay: 90}}},
+	}
+
+	ordered := byMeasuredDelay(candidates, proxies)
+	if ordered[0] != "fast" || ordered[1] != "slow" {
+		t.Fatalf("expected fastest first, got %v", ordered)
+	}
+	// Nothing is known about either of the last two, so they keep the order they
+	// arrived in rather than being shuffled arbitrarily.
+	if ordered[2] != "dead" || ordered[3] != "unmeasured" {
+		t.Fatalf("unmeasured nodes should keep their original order, got %v", ordered)
+	}
+	if len(ordered) != len(candidates) {
+		t.Fatalf("ordering dropped nodes: %v", ordered)
+	}
+	if candidates[0] != "slow" {
+		t.Fatal("the caller's slice should not be reordered in place")
+	}
+}

--- a/desktop/internal/session/seed.go
+++ b/desktop/internal/session/seed.go
@@ -1,0 +1,146 @@
+package session
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"time"
+
+	"whitevpn-desktop/internal/mihomoconf"
+)
+
+// Seeding gives the engine's automatic group real measurements to choose from
+// before it has to choose.
+//
+// A url-test group picks the lowest measured delay among the nodes that
+// answered. Until it has measured, every node looks identical to it and
+// mihomo's `fast()` returns the first proxy in the group — so a group handed
+// eight hundred unmeasured nodes behaves exactly like the head-of-the-catalogue
+// walk this was meant to replace, only inside the engine where it cannot be
+// seen.
+//
+// And it stays that way for a while. The engine's own health check runs ten
+// nodes at a time (`errgroup.SetLimit(10)` in the provider's healthcheck), so a
+// first full round over eight hundred nodes is minutes, not seconds.
+//
+// So the app measures a sample itself, first, through the same engine and
+// against the same URL the group tests with — which puts the results in the very
+// history `fast()` reads. By the time the group is selected it has real numbers
+// for a spread of the catalogue and picks the best of them.
+const (
+	// How many nodes are measured. Enough to be very unlikely to draw an
+	// all-dead sample — at the observed 18% failure rate, thirty-two nodes miss
+	// entirely about once in every 10^25 connects — and small enough to finish
+	// in seconds.
+	seedSample = 32
+
+	// How many at once. The engine handles these as ordinary delay tests, and
+	// they are cheap; the limit is about not opening thirty-two connections on a
+	// phone-tethered link at once.
+	seedConcurrency = 12
+
+	// How long one node is given to answer, and the whole sample.
+	seedProbeTimeout = 4 * time.Second
+	seedBudget       = 12 * time.Second
+
+	// How many nodes have to answer before the group is worth selecting. The
+	// rest keep measuring in the background: waiting for all thirty-two when
+	// five have already answered adds seconds to every connect on a good
+	// network, for a choice between nodes that are all working.
+	seedEnough = 5
+)
+
+// delayTester is the part of the engine seeding needs.
+type delayTester interface {
+	TestDelayMS(ctx context.Context, proxy, testURL string, timeoutMS int) (int, error)
+}
+
+// sampleForSeeding picks which nodes to measure.
+//
+// The sample is random, and that is the point rather than an implementation
+// detail. Every user taking the same nodes in the same order is what turned a
+// bad head of the catalogue into "the app cannot connect" for everybody at once;
+// a random draw per connect means a node that is down costs one user one
+// measurement instead of costing every user their connection.
+func sampleForSeeding(candidates []string, size int) []string {
+	if len(candidates) <= size {
+		sample := make([]string, len(candidates))
+		copy(sample, candidates)
+		return sample
+	}
+	shuffled := make([]string, len(candidates))
+	copy(shuffled, candidates)
+	rand.Shuffle(len(shuffled), func(i, j int) {
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
+	return shuffled[:size]
+}
+
+// seedMeasurements measures a sample of the catalogue and returns once enough
+// nodes have answered, leaving the rest to finish in the background.
+//
+// The count returned is how many had answered at that moment. Zero is not a
+// failure to act on by itself — the sample may simply be slower than the budget,
+// and the group is still the right thing to select — but it is worth knowing.
+func (s *Session) seedMeasurements(ctx context.Context, candidates []string) int {
+	if s.process == nil {
+		return 0
+	}
+	return seedMeasurements(ctx, s.process, candidates)
+}
+
+func seedMeasurements(ctx context.Context, engine delayTester, candidates []string) int {
+	if len(candidates) == 0 {
+		return 0
+	}
+
+	// Deliberately not deferred: this returns as soon as enough nodes have
+	// answered, and the rest of the sample goes on measuring behind it. Cancelling
+	// the budget here would stop exactly the work that makes the group's next
+	// choice a better one. It is still tied to ctx, so a user who cancels the
+	// connect stops this with it.
+	budget, cancelBudget := context.WithTimeout(ctx, seedBudget)
+
+	sample := sampleForSeeding(candidates, seedSample)
+
+	var (
+		mu        sync.Mutex
+		answered  int
+		enough    = make(chan struct{})
+		signalled bool
+	)
+	done := make(chan struct{})
+	go func() {
+		<-done
+		cancelBudget()
+	}()
+
+	go func() {
+		defer close(done)
+		forEachBounded(budget, sample, seedConcurrency, func(name string) {
+			// The result is not read: it goes into the engine's own history for
+			// this node, which is where the group looks. This call is made for
+			// its side effect.
+			if _, err := engine.TestDelayMS(budget, name, mihomoconf.DelayTestURL, int(seedProbeTimeout/time.Millisecond)); err != nil {
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			answered++
+			if answered >= seedEnough && !signalled {
+				signalled = true
+				close(enough)
+			}
+		})
+	}()
+
+	select {
+	case <-enough:
+	case <-done:
+	case <-budget.Done():
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	return answered
+}

--- a/desktop/internal/session/seed_test.go
+++ b/desktop/internal/session/seed_test.go
@@ -1,0 +1,136 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeDelayTester struct {
+	mu      sync.Mutex
+	asked   []string
+	fail    func(name string) bool
+	latency time.Duration
+}
+
+func (f *fakeDelayTester) TestDelayMS(ctx context.Context, proxy, _ string, _ int) (int, error) {
+	if f.latency > 0 {
+		select {
+		case <-time.After(f.latency):
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
+	}
+	f.mu.Lock()
+	f.asked = append(f.asked, proxy)
+	f.mu.Unlock()
+
+	if f.fail != nil && f.fail(proxy) {
+		return 0, errors.New("no answer")
+	}
+	return 120, nil
+}
+
+func (f *fakeDelayTester) seen() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.asked))
+	copy(out, f.asked)
+	return out
+}
+
+func names(prefix string, count int) []string {
+	out := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		out = append(out, prefix+string(rune('A'+i%26))+strings.Repeat("!", i/26))
+	}
+	return out
+}
+
+// Every user drawing the same nodes in the same order is what turned a bad head
+// of the catalogue into "the app cannot connect" for everybody at once.
+func TestSampleForSeedingDoesNotAlwaysDrawTheSameNodes(t *testing.T) {
+	candidates := names("node", 200)
+
+	first := strings.Join(sampleForSeeding(candidates, seedSample), ",")
+	differed := false
+	for i := 0; i < 20 && !differed; i++ {
+		if strings.Join(sampleForSeeding(candidates, seedSample), ",") != first {
+			differed = true
+		}
+	}
+	if !differed {
+		t.Fatal("twenty draws produced the same sample; the catalogue is being walked, not sampled")
+	}
+}
+
+func TestSampleForSeedingTakesEverythingWhenTheCatalogueIsSmall(t *testing.T) {
+	candidates := []string{"one", "two"}
+	sample := sampleForSeeding(candidates, seedSample)
+	if len(sample) != 2 {
+		t.Fatalf("expected both nodes, got %v", sample)
+	}
+	sample[0] = "changed"
+	if candidates[0] != "one" {
+		t.Fatal("the caller's slice was handed out rather than copied")
+	}
+}
+
+func TestSampleForSeedingIsCapped(t *testing.T) {
+	if size := len(sampleForSeeding(names("node", 800), seedSample)); size != seedSample {
+		t.Fatalf("expected %d nodes measured, got %d", seedSample, size)
+	}
+}
+
+// Waiting for all thirty-two when five have answered adds seconds to every
+// connect on a good network, for a choice between nodes that are all working.
+func TestSeedingReturnsOnceEnoughNodesAnswer(t *testing.T) {
+	engine := &fakeDelayTester{latency: 150 * time.Millisecond}
+
+	start := time.Now()
+	answered := seedMeasurements(context.Background(), engine, names("node", 800))
+	elapsed := time.Since(start)
+
+	if answered < seedEnough {
+		t.Fatalf("expected at least %d answers, got %d", seedEnough, answered)
+	}
+	if elapsed > seedBudget {
+		t.Fatalf("seeding took %s, past its %s budget", elapsed, seedBudget)
+	}
+	if measured := len(engine.seen()); measured > seedSample {
+		t.Fatalf("measured %d nodes, more than the %d sampled", measured, seedSample)
+	}
+}
+
+// A sample where nothing answers must still end, and end honestly, rather than
+// hanging a connect that could have fallen through to the node walk.
+func TestSeedingGivesUpWhenNothingAnswers(t *testing.T) {
+	engine := &fakeDelayTester{fail: func(string) bool { return true }}
+
+	start := time.Now()
+	if answered := seedMeasurements(context.Background(), engine, names("node", 60)); answered != 0 {
+		t.Fatalf("expected no answers, got %d", answered)
+	}
+	if elapsed := time.Since(start); elapsed > seedBudget {
+		t.Fatalf("seeding took %s, past its %s budget", elapsed, seedBudget)
+	}
+}
+
+func TestSeedingStopsWhenTheConnectIsCancelled(t *testing.T) {
+	engine := &fakeDelayTester{latency: time.Hour}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if answered := seedMeasurements(ctx, engine, names("node", 60)); answered != 0 {
+		t.Fatalf("a cancelled connect should measure nothing, got %d", answered)
+	}
+}
+
+func TestSeedingWithNothingToMeasure(t *testing.T) {
+	if answered := seedMeasurements(context.Background(), &fakeDelayTester{}, nil); answered != 0 {
+		t.Fatalf("expected nothing, got %d", answered)
+	}
+}

--- a/desktop/internal/session/session.go
+++ b/desktop/internal/session/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -78,10 +79,77 @@ type Session struct {
 	healthCode int
 	candidates []string
 	selected   string
+
+	// automatic means the engine's url-test group is choosing, rather than this
+	// app having pinned one node. It is false when the user named what to use,
+	// and false for a provider document that selects for itself.
+	automatic bool
+
+	// seeded is how many of the sampled nodes answered before the group was
+	// selected. It is worth logging: a connect where nothing answered says
+	// something about the network, not about the catalogue.
+	seeded int
+
+	// tunnelUnverified is set when the tunnel was accepted without being checked,
+	// which happens on platforms that have no way to read an adapter's routes yet.
+	tunnelUnverified error
 }
 
+// Seeded is how many sampled nodes answered a delay test before the automatic
+// group was asked to choose.
+func (s *Session) Seeded() int { return s.seeded }
+
+// TunnelUnverified is non-nil when the tunnel is up but could not be inspected,
+// so the caller can say so instead of implying it was checked.
+func (s *Session) TunnelUnverified() error { return s.tunnelUnverified }
+
 // Selected is the node currently carrying traffic.
+//
+// Under automatic selection this is whichever node the engine's group had chosen
+// when it was last asked, not a node this app pinned.
 func (s *Session) Selected() string { return s.selected }
+
+// Automatic reports whether the engine is choosing the node.
+func (s *Session) Automatic() bool { return s.automatic }
+
+// RefreshSelection re-reads which node the engine's group is on, and reports
+// whether that has changed since the last look.
+//
+// Under automatic selection the group moves on its own, so a name shown once at
+// connect time goes stale — the dashboard would keep naming a node the traffic
+// stopped using. Nothing is reported when the lookup fails or the group has not
+// settled, because replacing a name that was right with no name at all is worse
+// than a name that is a few seconds old.
+func (s *Session) RefreshSelection(ctx context.Context) (string, bool) {
+	if s.process == nil || !s.automatic {
+		return s.selected, false
+	}
+	name := s.resolveSelection(ctx)
+	if name == "" || name == s.selected {
+		return s.selected, false
+	}
+	s.selected = name
+	return name, true
+}
+
+// resolveSelection asks the engine which node its group settled on, so the
+// interface can name a place rather than a group.
+func (s *Session) resolveSelection(ctx context.Context) string {
+	lookupCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	proxies, err := proxySnapshot(lookupCtx, s.process)
+	if err != nil {
+		return ""
+	}
+	name := resolveGroup(proxies, mihomoconf.SelectGroup)
+	if name == mihomoconf.SelectGroup || name == mihomoconf.AutoGroup {
+		// The group answered with itself, which means it has not settled yet.
+		// Naming nothing beats naming a group.
+		return ""
+	}
+	return name
+}
 
 // MixedPort is where the session's local proxy listens.
 func (s *Session) MixedPort() int { return s.mixedPort }
@@ -140,6 +208,9 @@ func Connect(ctx context.Context, opts Options) (*Session, error) {
 		configPath: configPath,
 		proxyCount: len(candidates),
 		candidates: candidates,
+		// The generated configuration is the only one that carries a url-test
+		// group, and a stated preference is the user choosing for themselves.
+		automatic: len(candidates) > 0 && len(opts.Prefer) == 0,
 	}
 	// Any failure from here on leaves an engine running, so it has to be stopped
 	// rather than abandoned: an abandoned one keeps its listeners, and on the TUN
@@ -173,7 +244,11 @@ func (s *Session) start(ctx context.Context, opts Options) error {
 	probe := func(probeCtx context.Context) int { return probeStatus(probeCtx, opts.MixedPort) }
 	acceptHealthy := func(code int) error {
 		if opts.Tun.Enabled {
-			if err := verifyTunnel(opts.Tun.Device, opts.Tun.IPv6); err != nil {
+			switch err := waitForTunnel(ctx, opts.Tun.Device, opts.Tun.IPv6); {
+			case err == nil:
+			case errors.Is(err, errTunnelUnverifiable):
+				s.tunnelUnverified = err
+			default:
 				return fmt.Errorf("session: tunnel verification failed: %w", err)
 			}
 		}
@@ -181,11 +256,6 @@ func (s *Session) start(ctx context.Context, opts Options) error {
 		return nil
 	}
 
-	// A node has to be chosen explicitly, as the phone app does. Leaving the
-	// selection to the url-test group means waiting for it to finish measuring
-	// hundreds of servers before anything is selected at all, and until then the
-	// group answers with whichever node happens to be first — frequently a dead
-	// one.
 	if len(s.candidates) == 0 {
 		// A provider's own document comes with its own selection; take it as-is.
 		code, err := waitForHealthy(ctx, probe)
@@ -195,14 +265,63 @@ func (s *Session) start(ctx context.Context, opts Options) error {
 		return acceptHealthy(code)
 	}
 
-	attempts := opts.MaxAttempts
-	if attempts > len(s.candidates) {
-		attempts = len(s.candidates)
+	var lastErr error
+
+	// Automatic hands the choice to the engine, which is what the phone app does
+	// and why it behaves the way it does.
+	//
+	// This used to pick a node itself and pin the group to it. With a catalogue of
+	// eight hundred nodes that was the wrong shape twice over: every user tried the
+	// same five, in the same order, so a bad head of the list told everybody the app
+	// could not connect; and once pinned, a `select` group never reconsiders, so a
+	// node that died mid-session stayed selected until a watchdog noticed.
+	//
+	// A url-test group measures its members continuously, picks the fastest that
+	// answers, and — this is the part that matters — moves off a node by itself once
+	// dialling through it starts failing. Eight hundred nodes stop being eight
+	// hundred chances to fail and become eight hundred chances to succeed.
+	if s.automatic {
+		// Measure a random sample first, so the group has real numbers to choose
+		// between rather than eight hundred nodes that all look the same to it.
+		// See seed.go for why this is not optional.
+		s.seeded = s.seedMeasurements(ctx, s.candidates)
+
+		if err := s.changeProxy(ctx, mihomoconf.AutoGroup); err != nil {
+			lastErr = err
+		} else {
+			code, err := waitForHealthy(ctx, probe)
+			if err == nil {
+				if err := acceptHealthy(code); err != nil {
+					return err
+				}
+				s.selected = s.resolveSelection(ctx)
+				return nil
+			}
+			lastErr = fmt.Errorf("automatic selection: %w", err)
+		}
 	}
 
-	var lastErr error
+	// Nothing answered through the group, or the user named the nodes to use.
+	// Either way this walks them one at a time, fastest first.
+	//
+	// A user who picks a country gets the same treatment for the same reason: that
+	// country may hold eighty nodes, and walking the first five of them in
+	// catalogue order is the same mistake in a smaller list.
+	if !s.automatic {
+		s.seeded = s.seedMeasurements(ctx, s.candidates)
+	}
+	order := s.candidates
+	if proxies, err := proxySnapshot(ctx, s.process); err == nil {
+		order = byMeasuredDelay(order, proxies)
+	}
+
+	attempts := opts.MaxAttempts
+	if attempts > len(order) {
+		attempts = len(order)
+	}
+
 	for i := 0; i < attempts; i++ {
-		candidate := s.candidates[i]
+		candidate := order[i]
 		selectCtx, selectCancel := context.WithTimeout(ctx, 10*time.Second)
 		err := s.process.ChangeProxy(selectCtx, mihomoconf.SelectGroup, candidate)
 		selectCancel()
@@ -216,6 +335,9 @@ func (s *Session) start(ctx context.Context, opts Options) error {
 			if err := acceptHealthy(code); err != nil {
 				return err
 			}
+			// The group is pinned to this node now, so the engine is no longer the
+			// one choosing and recovery has to do the choosing instead.
+			s.automatic = false
 			s.selected = candidate
 			return nil
 		}
@@ -252,9 +374,28 @@ func (s *Session) Recover(ctx context.Context, attempts int) (string, error) {
 		return "", fmt.Errorf("session: this subscription selects its own node")
 	}
 
+	// Under automatic selection the engine is already recovering: a url-test group
+	// re-measures after a run of failed dials and moves off a dead node without
+	// being asked. Pinning a node here would take that away — it would replace a
+	// group that keeps looking with one node that never gets reconsidered. So this
+	// waits for the engine's own move and reports where it went.
+	if s.automatic {
+		return s.recoverAutomatically(ctx)
+	}
+
+	// The measurements are stale by now — they were taken when this session was
+	// made, and what has changed since is precisely why recovery is running. A
+	// fresh sample means the alternatives are ordered by how they are behaving
+	// now rather than by how they behaved when the connection still worked.
+	s.seeded = s.seedMeasurements(ctx, s.candidates)
+	ordered := s.candidates
+	if proxies, err := proxySnapshot(ctx, s.process); err == nil {
+		ordered = byMeasuredDelay(ordered, proxies)
+	}
+
 	previous := s.selected
 	var lastErr error
-	for _, candidate := range recoveryOrder(s.candidates, previous, attempts) {
+	for _, candidate := range recoveryOrder(ordered, previous, attempts) {
 		if ctx.Err() != nil {
 			break
 		}
@@ -287,6 +428,40 @@ func (s *Session) Recover(ctx context.Context, attempts int) (string, error) {
 	return "", fmt.Errorf("session: nothing else carried traffic either: %w", lastErr)
 }
 
+// recoverAutomatically waits for the engine's group to move itself off a node
+// that stopped working, and reports where it landed.
+//
+// Re-asserting the selection is what prompts it: the group answers with its own
+// current pick, and mihomo re-checks a group whose dials keep failing. If the
+// group has not moved by the time the budget is spent, the failure says so
+// rather than pretending — but the session is left alone either way, because a
+// group that is still looking is worth more than a node pinned by hand.
+func (s *Session) recoverAutomatically(ctx context.Context) (string, error) {
+	previous := s.selected
+
+	// A fresh random sample, because the group can only choose between nodes it
+	// has numbers for, and if the ones it had have gone the way of the node that
+	// just failed, it needs new ones to look at.
+	s.seeded = s.seedMeasurements(ctx, s.candidates)
+
+	if err := s.changeProxy(ctx, mihomoconf.AutoGroup); err != nil {
+		return "", err
+	}
+	code, err := waitForHealthy(ctx, func(probeCtx context.Context) int {
+		return probeStatus(probeCtx, s.mixedPort)
+	})
+	if err != nil {
+		return "", fmt.Errorf("session: the automatic group has not found a node that answers: %w", err)
+	}
+
+	s.healthCode = code
+	s.selected = s.resolveSelection(ctx)
+	if s.selected == "" {
+		s.selected = previous
+	}
+	return s.selected, nil
+}
+
 // recoveryOrder is which nodes a recovery reaches for: the candidates in their
 // own order, without the one that just failed, capped at what one recovery is
 // willing to spend.
@@ -316,14 +491,22 @@ func (s *Session) Select(ctx context.Context, node string) error {
 	}
 
 	previous := s.selected
+	// What the group has to be put back to, which under automatic selection is
+	// the group itself rather than the node it happens to be on. Restoring the
+	// node would quietly pin a session that was choosing for itself.
+	restore := previous
+	if s.automatic {
+		restore = mihomoconf.AutoGroup
+	}
+
 	if err := s.changeProxy(ctx, node); err != nil {
 		return err
 	}
 
 	code, err := waitForHealthy(ctx, func(probeCtx context.Context) int { return probeStatus(probeCtx, s.mixedPort) })
 	if err != nil {
-		if previous != "" && previous != node {
-			if restoreErr := s.changeProxy(ctx, previous); restoreErr == nil {
+		if restore != "" && restore != node {
+			if restoreErr := s.changeProxy(ctx, restore); restoreErr == nil {
 				return fmt.Errorf("session: %q carried no traffic, so %q is still in use: %w", node, previous, err)
 			}
 		}
@@ -331,6 +514,8 @@ func (s *Session) Select(ctx context.Context, node string) error {
 	}
 
 	s.healthCode = code
+	// A node named by hand is the user choosing, so the engine stops choosing.
+	s.automatic = false
 	s.selected = node
 	return nil
 }
@@ -541,7 +726,10 @@ func withDefaults(opts Options) Options {
 		opts.DNSPrivacy = mihomoconf.DNSAutomatic
 	}
 	if opts.MaxAttempts <= 0 {
-		// Five, as the phone app allows itself for startup attempts.
+		// Five, as the phone app allows itself for startup attempts. This caps the
+		// fallback walk, which now runs in measured order, so it is five nodes the
+		// engine has numbers for rather than five arbitrary ones off the top of the
+		// catalogue.
 		opts.MaxAttempts = 5
 	}
 	return opts

--- a/desktop/internal/session/tun.go
+++ b/desktop/internal/session/tun.go
@@ -1,11 +1,73 @@
 package session
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net"
 	"strings"
+	"time"
 )
 
-func verifyTunnelRoutes(output string, ipv6 bool) error {
+// How long the tunnel is given to appear, and how often it is looked for.
+//
+// The adapter is not there when the engine reports success. startListener
+// returns once the core is running; creating the tunnel adapter, bringing it up
+// and installing its routes happens after that, and on a cold machine — the
+// driver loading for the first time, a slow disk, an antivirus inspecting a new
+// network adapter — it takes seconds. The check used to run once, immediately,
+// and a machine that was merely slow was told its tunnel had failed.
+//
+// This is also why the failure was reported as "connects in proxy mode but not
+// in tunnel mode": the proxy port is up straight away, so the request that
+// proves the connection works passes long before the adapter exists.
+const (
+	tunnelBudget       = 20 * time.Second
+	tunnelPollInterval = 500 * time.Millisecond
+)
+
+// errTunnelUnverifiable means this platform has no way to inspect the adapter,
+// not that the adapter is broken. The two must not be confused: refusing to
+// connect because verification is unimplemented would make the tunnel unusable
+// on a platform where it may work perfectly well.
+var errTunnelUnverifiable = errors.New("the tunnel cannot be verified on this platform")
+
+// waitForTunnel returns once the tunnel adapter is up and carrying routes, or
+// once the budget is spent.
+func waitForTunnel(ctx context.Context, device string, ipv6 bool) error {
+	deadline, cancel := context.WithTimeout(ctx, tunnelBudget)
+	defer cancel()
+
+	var lastErr error
+	for {
+		err := verifyTunnel(device, ipv6)
+		if err == nil || errors.Is(err, errTunnelUnverifiable) {
+			return err
+		}
+		lastErr = err
+
+		select {
+		case <-deadline.Done():
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("the tunnel did not come up within %s: %w", tunnelBudget, lastErr)
+		case <-time.After(tunnelPollInterval):
+		}
+	}
+}
+
+// verifyTunnelRoutes checks that the adapter's routes cover the traffic the
+// tunnel is supposed to carry.
+//
+// requireIPv6 is deliberately separate from "IPv6 is switched on in the config":
+// the requirement only applies to a machine that actually has IPv6. Where it is
+// switched off — which plenty of users have done by hand, following one guide or
+// another — the engine installs no IPv6 routes because there is no IPv6 traffic
+// to carry, and demanding them refused a tunnel that was working. Where the
+// machine does have IPv6, missing routes mean that traffic is leaving outside
+// the tunnel, and that is worth refusing over.
+func verifyTunnelRoutes(output string, requireIPv6 bool) error {
 	routes := make(map[string]bool)
 	for _, route := range strings.Fields(output) {
 		routes[strings.ToLower(route)] = true
@@ -13,8 +75,46 @@ func verifyTunnelRoutes(output string, ipv6 bool) error {
 	if !routes["0.0.0.0/0"] && !(routes["0.0.0.0/1"] && routes["128.0.0.0/1"]) {
 		return fmt.Errorf("the tunnel has no route covering IPv4 traffic")
 	}
-	if ipv6 && !routes["::/0"] && !(routes["::/1"] && routes["8000::/1"]) {
-		return fmt.Errorf("the tunnel has no route covering IPv6 traffic")
+	if requireIPv6 && !routes["::/0"] && !(routes["::/1"] && routes["8000::/1"]) {
+		return fmt.Errorf("the tunnel has no route covering IPv6 traffic, which would leave this machine's IPv6 outside it")
 	}
 	return nil
+}
+
+// hasRoutableIPv6 reports whether this machine has an IPv6 address that could
+// carry traffic off it.
+//
+// The tunnel adapter is skipped, and so are addresses that go nowhere: loopback,
+// link-local, and unique-local — including the tunnel's own fd00::/8 address,
+// which would otherwise make every machine look like it had IPv6 and bring back
+// exactly the check this is meant to qualify.
+func hasRoutableIPv6(tunnelDevice string) bool {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		// Unknown, so assume the strict case rather than waive the check.
+		return true
+	}
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		if strings.EqualFold(iface.Name, tunnelDevice) {
+			continue
+		}
+		addresses, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, address := range addresses {
+			network, ok := address.(*net.IPNet)
+			if !ok || network.IP.To4() != nil {
+				continue
+			}
+			ip := network.IP
+			if ip.IsGlobalUnicast() && !ip.IsLinkLocalUnicast() && !ip.IsPrivate() {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/desktop/internal/session/tun_other.go
+++ b/desktop/internal/session/tun_other.go
@@ -2,8 +2,14 @@
 
 package session
 
-import "fmt"
-
-func verifyTunnel(device string, _ bool) error {
-	return fmt.Errorf("adapter verification for %q is only implemented on Windows", device)
+// The adapter cannot be inspected here yet, which is not the same as the adapter
+// being broken.
+//
+// This used to return a plain error, and because connecting treats a failed
+// verification as a failed connection, the tunnel could never be used on macOS
+// or Linux at all — "not implemented" was being reported to users as "your
+// tunnel does not work". Saying it is unverifiable lets the connection stand and
+// leaves the caveat where someone can act on it.
+func verifyTunnel(string, bool) error {
+	return errTunnelUnverifiable
 }

--- a/desktop/internal/session/tun_windows.go
+++ b/desktop/internal/session/tun_windows.go
@@ -21,14 +21,43 @@ func verifyTunnel(device string, ipv6 bool) error {
 		return fmt.Errorf("adapter %q is down", device)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	output, err := tunnelRoutes(device)
+	if err != nil {
+		return err
+	}
+	return verifyTunnelRoutes(output, ipv6 && hasRoutableIPv6(device))
+}
+
+// tunnelRoutes lists the destination prefixes routed through the adapter.
+//
+// Get-NetRoute is the only way to ask Windows this without binding to the IP
+// Helper API, but PowerShell is not something to depend on lightly: it is slow
+// to start, a machine can have its execution policy locked down, and on some
+// systems powershell.exe is not on PATH at all. So a failure to run it is
+// reported as its own thing rather than as a broken tunnel — the difference
+// matters to whoever reads the report.
+func tunnelRoutes(device string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	command := exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-NonInteractive", "-Command",
-		`$ErrorActionPreference='Stop'; Get-NetRoute -InterfaceAlias $env:WHITEVPN_TUN_DEVICE | ForEach-Object { $_.DestinationPrefix }`)
+
+	shell, err := exec.LookPath("powershell.exe")
+	if err != nil {
+		if system := os.Getenv("SystemRoot"); system != "" {
+			shell = system + `\System32\WindowsPowerShell\v1.0\powershell.exe`
+		} else {
+			return "", fmt.Errorf("%w: powershell is not available to read the adapter's routes", errTunnelUnverifiable)
+		}
+	}
+
+	// The device name goes through the environment rather than into the command
+	// text, so a name carrying a quote cannot become part of the script.
+	command := exec.CommandContext(ctx, shell, "-NoProfile", "-NonInteractive", "-Command",
+		`$ErrorActionPreference='SilentlyContinue'; Get-NetRoute -InterfaceAlias $env:WHITEVPN_TUN_DEVICE | ForEach-Object { $_.DestinationPrefix }`)
 	command.Env = append(os.Environ(), "WHITEVPN_TUN_DEVICE="+device)
+
 	out, err := command.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("read routes for %q: %w: %s", device, err, strings.TrimSpace(string(out)))
+		return "", fmt.Errorf("read routes for %q: %w: %s", device, err, strings.TrimSpace(string(out)))
 	}
-	return verifyTunnelRoutes(string(out), ipv6)
+	return string(out), nil
 }

--- a/desktop/mihomo_connect.go
+++ b/desktop/mihomo_connect.go
@@ -150,10 +150,22 @@ func (a *App) startWhiteDNSVPNWithMihomo() (model.AppState, error) {
 		}
 	}
 
-	a.appendRuntimeLog(fmt.Sprintf(
-		"mihomo connected: %d nodes available, using %q, health %d",
-		connected.ProxyCount(), connected.Selected(), connected.HealthStatus(),
-	))
+	if connected.Automatic() {
+		a.appendRuntimeLog(fmt.Sprintf(
+			"mihomo connected: %d nodes available, %d answered a delay test, engine picked %q, health %d",
+			connected.ProxyCount(), connected.Seeded(), connected.Selected(), connected.HealthStatus(),
+		))
+	} else {
+		a.appendRuntimeLog(fmt.Sprintf(
+			"mihomo connected: %d nodes available, using %q, health %d",
+			connected.ProxyCount(), connected.Selected(), connected.HealthStatus(),
+		))
+	}
+	if err := connected.TunnelUnverified(); err != nil {
+		// The tunnel is up but nothing confirmed its routes, so the log says so
+		// rather than leaving the impression it was checked.
+		a.appendRuntimeLog(fmt.Sprintf("the tunnel is running but was not verified: %v", err))
+	}
 	a.handleRuntimeState(model.RuntimeConnected, fmt.Sprintf("Proxy listening on 127.0.0.1:%d", connected.MixedPort()))
 	a.resolveExitCountry()
 	a.sampleTraffic(connected)

--- a/desktop/mihomo_watchdog.go
+++ b/desktop/mihomo_watchdog.go
@@ -58,6 +58,17 @@ func (a *App) watchHealth(current *session.Session) {
 					a.appendRuntimeLog("the connection answered again")
 				}
 				failures = 0
+				// Under automatic selection the engine moves between nodes on its
+				// own, so the name on the dashboard has to be re-read rather than
+				// assumed to still be the one connecting settled on.
+				lookupCtx, lookupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				node, moved := current.RefreshSelection(lookupCtx)
+				lookupCancel()
+				if moved {
+					a.appendRuntimeLog(fmt.Sprintf("the automatic group moved to %q", node))
+					a.recordConnectedNode(node)
+					a.resolveExitCountry()
+				}
 				continue
 			}
 


### PR DESCRIPTION
The connect path picked nodes itself, always from the top of the catalogue. With a subscription of 800+ nodes that meant every user tried the same five servers in the same order, each behind a 12-second health gate, and Retry tried the same five again. A bad head of the list did not fail some users some of the time — it told everybody the app could not connect. That is what the reports were.

A comment in session.go and a line in ANDROID-PARITY.md justified this with "a node has to be chosen explicitly, as the phone app does". That was wrong about the phone app. WhiteDnsVpnService.kt selects the url-test *group* when the user has narrowed nothing, and its ordinary connect path passes validateConnectivity = false, so it does not gate on a health check at all. It starts the engine and lets mihomo choose. Both claims are corrected.

The desktop had built that url-test group since the beginning and walked straight past it. Now Automatic selects it, and the differences are the ones that matter: url-test measures continuously, picks the fastest that answers, and GroupBase.onDialFailed re-checks and moves off a node by itself after a run of failed dials. A select group pinned to one node does none of that.

Selecting the group is not enough on its own. mihomo health-checks ten nodes at a time, so a first round over 800 nodes is minutes, and until it lands every node looks identical to the group and fast() returns proxies[0] — the same head-of-list bug, moved inside the engine where it cannot be seen. So a random sample of 32 nodes is measured first, through the same engine and against the same URL the group tests with, which puts the results in the very history fast() reads. It returns as soon as five have answered and the rest keep measuring behind it.

Random, per connect, is the point: it decorrelates users, so a node that is down costs one user one measurement instead of costing everyone their connection.

What follows from that:

- The node-by-node walk survives only as a fallback, ordered by measured delay rather than catalogue position. A user who picks a country gets the same treatment — eighty nodes walked from the top is the same mistake in a smaller list.
- Recovery under Automatic re-seeds and re-asserts the group instead of pinning a node, which would replace something that keeps looking with something that never looks again.
- The watchdog re-reads the selection, because the group moves on its own and the dashboard would otherwise keep naming a node the traffic had left.

Measured against the live catalogue: connect in 1.6-2.4s, a different node each run. TestLiveAutomaticLetsTheEngineChoose is the regression guard.

Two bugs found on the way:

Client.ChangeProxy threw away the core's reply. changeProxy succeeds at the protocol level either way and returns "Not found group" or "Group is not selectable" as an ordinary successful response, so a selection that never happened was reported as one that did, and the health check that followed measured whatever node was already in place. A connection could be reported on a node nobody chose. It now reads the payload, as SetupConfig and ValidateConfig already did.

verifyTunnel ran once, immediately after a health check that only proves the mixed port works. The adapter and its routes are created after startListener returns, so on a machine that was merely slow — a driver loading for the first time, antivirus inspecting a new adapter — the tunnel was declared broken while the proxy worked. This is the "connects in proxy mode but not in tunnel mode" report. It now polls for up to 20 seconds.

Two more things were wrong with that check. It demanded IPv6 routes whenever IPv6 was configured, so a machine with IPv6 switched off — which many users have done by hand — was refused a tunnel that worked; the requirement now applies only where the machine has a routable IPv6 address to leak, and the tunnel's own ULA does not count. And on macOS and Linux verifyTunnel returned a plain error because it is unimplemented, which connect treated as a failed tunnel: "not implemented" was being reported to users as "your tunnel does not work". It now says it could not verify, the connection stands, and the caveat is logged where someone can act on it.