### PR TITLE
Take the file version from the build instead of typing it into wails.…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@
 **/*.log
 **/*.tmp
 **/*.bak
+# The build writes the real version into wails.json and puts the original back
+# when it finishes; this is that original, and it only survives a build the
+# machine did not live through.
+desktop/wails.json.version-backup
 **/.cache/
 **/.gradle/
 **/coverage/

--- a/desktop/ANDROID-PARITY.md
+++ b/desktop/ANDROID-PARITY.md
@@ -561,6 +561,24 @@ from Wi-Fi to Ethernet must not lose its VPN on the way.
 
 ### Things that will bite
 
+- **There are two version numbers, and only one of them is the app's.** The
+  sidebar reads `appVersion`, set at link time by `-X main.appVersion` from the
+  Makefile's `VERSION`. The number Windows shows in Properties → Details is
+  `productVersion` in `wails.json`, which the Wails CLI reads directly and which
+  no build flag can reach. That second one used to be typed in by hand and had
+  already drifted — a build from a `v1.0.3` tag would have carried `1.0.2` in its
+  metadata. The Makefile now writes it in for the duration of the build and puts
+  the file back afterwards, so the committed value is `0.0.0`: a build that did
+  not come through the Makefile is not a release, which is the same thing
+  `appVersion` says when it stays at `dev`. Do not "fix" that `0.0.0`.
+- **A `0000` language ID makes every string in the exe unreadable.**
+  `build/windows/info.json` keys its string table by language, and Wails ships it
+  keyed `0000` — language-neutral. The strings are written correctly and are
+  there in the binary, but neither Explorer nor .NET's `FileVersionInfo` resolves
+  a neutral table, so Properties → Details came up blank for every field while
+  the numeric `FileVersionRaw` worked. Keyed `0409` (en-US) they all appear. If
+  the table ever looks empty again, check that key first — the resource is
+  probably fine.
 - **`validateConfig` only catches unparseable YAML.** Measured. It accepts
   unknown proxy types, impossible ports, groups naming absent proxies and empty
   documents. Never treat it as evidence a config will work; the health check is

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -19,6 +19,35 @@ RELEASE_LDFLAGS ?= -s -w
 # shipped an app whose own sidebar said 1.0.0.
 VERSION_LDFLAGS := -X main.appVersion=$(APP_VERSION)
 WAILS_RELEASE_FLAGS := -trimpath -ldflags "$(RELEASE_LDFLAGS) $(VERSION_LDFLAGS)"
+
+# The other version: what the file itself reports in Properties → Details.
+#
+# It does not come from a build flag. The Wails CLI reads `productVersion` out of
+# wails.json and templates it into build/windows/info.json and the exe manifest,
+# and nothing on the command line can override it — so it was typed in by hand, a
+# second number beside DEFAULT_VERSION, kept in step by memory. It was already
+# out of step: a release built from a v1.0.3 tag would have carried 1.0.2 in its
+# metadata. That is the same failure as the sidebar reading 1.0.0 on a 1.0.1
+# build, and it wants the same answer — one number, derived, not remembered.
+#
+# So the committed wails.json says 0.0.0 and this writes the real version in for
+# the duration of the build. 0.0.0 is honest rather than a placeholder: a build
+# that did not come through here is not a release, which is exactly what the
+# ldflags say too when they leave appVersion at "dev".
+#
+# sed writing to a temp file rather than `sed -i`, because -i takes an argument
+# on BSD sed and none on GNU, and this runs on both.
+WAILS_JSON := wails.json
+WAILS_JSON_BACKUP := wails.json.version-backup
+
+define wails_build_with_version
+	set -e; \
+	cp $(WAILS_JSON) $(WAILS_JSON_BACKUP); \
+	trap 'mv -f $(WAILS_JSON_BACKUP) $(WAILS_JSON)' EXIT INT TERM; \
+	sed 's/"productVersion"[[:space:]]*:[[:space:]]*"[^"]*"/"productVersion": "$(APP_VERSION)"/' $(WAILS_JSON_BACKUP) > $(WAILS_JSON); \
+	grep -q '"productVersion": "$(APP_VERSION)"' $(WAILS_JSON) || { echo "could not set productVersion in $(WAILS_JSON)" >&2; exit 1; }; \
+	$(1)
+endef
 HELPER_GO_LDFLAGS ?= $(RELEASE_LDFLAGS)
 UPX ?= 0
 UPX_FLAGS ?= --best --lzma
@@ -209,7 +238,7 @@ package: validate-version
 	else \
 		$(MAKE) prepare-package; \
 		$(MAKE) prepare-embedded-core TARGET_GOOS="$(GOOS_VALUE)" TARGET_GOARCH="$(GOARCH_VALUE)"; \
-		GOCACHE="$(GO_BUILD_CACHE)" $(WAILS) build $(WAILS_RELEASE_FLAGS) $(WAILS_OPTIONAL_UPX_FLAGS); \
+		( $(call wails_build_with_version,GOCACHE="$(GO_BUILD_CACHE)" $(WAILS) build $(WAILS_RELEASE_FLAGS) $(WAILS_OPTIONAL_UPX_FLAGS)) ); \
 		$(MAKE) package-assets; \
 	fi
 
@@ -334,7 +363,7 @@ macos-app-bundle:
 
 package-windows: validate-version prepare-package
 	$(MAKE) prepare-embedded-core TARGET_GOOS=windows TARGET_GOARCH="$(WINDOWS_CLIENT_ARCH)"
-	GOCACHE="$(GO_BUILD_CACHE)" $(WAILS) build -clean $(WAILS_RELEASE_FLAGS) $(WAILS_OPTIONAL_UPX_FLAGS) -platform $(WINDOWS_PLATFORMS)
+	@$(call wails_build_with_version,GOCACHE="$(GO_BUILD_CACHE)" $(WAILS) build -clean $(WAILS_RELEASE_FLAGS) $(WAILS_OPTIONAL_UPX_FLAGS) -platform $(WINDOWS_PLATFORMS))
 	$(MAKE) package-assets
 
 package-linux: validate-version prepare-package
@@ -343,7 +372,7 @@ package-linux: validate-version prepare-package
 		exit 1; \
 	fi
 	$(MAKE) prepare-embedded-core TARGET_GOOS=linux TARGET_GOARCH="$(LINUX_CLIENT_ARCH)"
-	GOCACHE="$(GO_BUILD_CACHE)" $(WAILS) build -clean $(WAILS_RELEASE_FLAGS) $(LINUX_WAILS_TAG_FLAGS) $(WAILS_OPTIONAL_UPX_FLAGS) -platform $(LINUX_PLATFORMS)
+	@$(call wails_build_with_version,GOCACHE="$(GO_BUILD_CACHE)" $(WAILS) build -clean $(WAILS_RELEASE_FLAGS) $(LINUX_WAILS_TAG_FLAGS) $(WAILS_OPTIONAL_UPX_FLAGS) -platform $(LINUX_PLATFORMS))
 	$(MAKE) package-assets
 
 package-linux-distros: package-linux

--- a/desktop/build/windows/info.json
+++ b/desktop/build/windows/info.json
@@ -3,8 +3,9 @@
 		"file_version": "{{.Info.ProductVersion}}"
 	},
 	"info": {
-		"0000": {
+		"0409": {
 			"ProductVersion": "{{.Info.ProductVersion}}",
+			"FileVersion": "{{.Info.ProductVersion}}",
 			"CompanyName": "{{.Info.CompanyName}}",
 			"FileDescription": "{{.Info.ProductName}}",
 			"LegalCopyright": "{{.Info.Copyright}}",

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -11,7 +11,10 @@
     "email": ""
   },
   "info": {
-    "productVersion": "1.0.2",
-    "productName": "WhiteVPN Desktop"
+    "companyName": "WhiteDNS",
+    "productName": "WhiteVPN Desktop",
+    "productVersion": "0.0.0",
+    "copyright": "GPL-3.0-or-later",
+    "comments": "https://github.com/WhiteDNS/WhiteVPN-Desktop"
   }
 }


### PR DESCRIPTION
…json

Two version numbers, only one of which the app controls. The sidebar reads appVersion, set at link time from the Makefile's VERSION. The number Windows shows in Properties → Details is productVersion in wails.json, which the Wails CLI reads directly and which no build flag can reach — so it was typed in by hand, a second number beside DEFAULT_VERSION, kept in step by memory.

It was already out of step. A release built from a v1.0.3 tag would have carried 1.0.2 in its metadata, because the tag drives VERSION and VERSION never touched wails.json. That is the same failure as the sidebar reading 1.0.0 on a 1.0.1 build, and it wants the same answer: one number, derived, not remembered.

The committed wails.json now says 0.0.0 and the build writes the real version in for its duration, putting the file back when it finishes — verified: the tree is clean after both `package` and `package-windows`, and after a build that fails. 0.0.0 is honest rather than a placeholder, in the same way appVersion staying at "dev" is: a build that did not come through the Makefile is not a release.

Measured on a real build, VERSION=1.0.3:

  FileVersionRaw : 1.0.3.0
  ProductVersion : 1.0.3

Separately, every string field in the exe was empty — ProductName, CompanyName, FileDescription, the lot — while the numeric version worked. The strings were being written correctly and are present in the binary; the problem is that build/windows/info.json keys its string table 0000, meaning language-neutral, and neither Explorer nor .NET's FileVersionInfo will resolve a neutral table. Keyed 0409 they all appear. wails.json was missing companyName, copyright and comments as well, so there was nothing to put in three of them either.

  ProductName     : WhiteVPN Desktop
  CompanyName     : WhiteDNS
  LegalCopyright  : GPL-3.0-or-later
  Language        : English (United States)

Both traps are written down in ANDROID-PARITY.md, including "do not fix that 0.0.0", which is exactly what someone will want to do.