### PR TITLE
Keep DNS inside the tunnel

### DIFF
--- a/desktop/ANDROID-PARITY.md
+++ b/desktop/ANDROID-PARITY.md
@@ -561,6 +561,19 @@ from Wi-Fi to Ethernet must not lose its VPN on the way.
 
 ### Things that will bite
 
+- **`dns-hijack` does not stop a DNS leak on its own.** It catches queries that
+  enter the tunnel. A query to the resolver on the local network never does: the
+  route to that subnet is directly connected on the physical adapter and beats
+  the `0.0.0.0/1` pair the tunnel installs, so lookups went to the home router in
+  the clear and a leak test showed the user's own ISP. Tunnel mode only — through
+  a proxy the machine never resolves anything itself, it hands the name over and
+  mihomo does the lookup, which is why proxy mode looked clean and hid this.
+  `strict-route: true` is what closes it: WFP filters on Windows blocking port 53
+  for everything but the engine and the tunnel adapter, unreachable policy rules
+  on Linux, ignored on macOS. **Android does not set it and does not need to** —
+  `VpnService.Builder.addDnsServer` makes the OS route every query into the
+  tunnel — so this is the second place, after IPv6 containment, where copying the
+  phone literally means shipping a leak.
 - **There are two version numbers, and only one of them is the app's.** The
   sidebar reads `appVersion`, set at link time by `-X main.appVersion` from the
   Makefile's `VERSION`. The number Windows shows in Properties → Details is

--- a/desktop/internal/mihomoconf/config.go
+++ b/desktop/internal/mihomoconf/config.go
@@ -110,6 +110,31 @@ type TunOptions struct {
 	// which is why containment has to be verified after connecting and never
 	// assumed.
 	Inet6Address string
+
+	// StrictRoute stops traffic finding its way around the tunnel, and it is what
+	// closes the DNS leak the desktop had in tunnel mode.
+	//
+	// dns-hijack is not enough on its own, because it can only catch what enters
+	// the tunnel. A resolver on the local network does not: the route to
+	// 192.168.0.0/16 is directly connected on the physical adapter and beats the
+	// 0.0.0.0/1 pair the tunnel installs, so every query to the home router left
+	// the machine in the clear. That is why the leak showed in tunnel mode and not
+	// in proxy mode — through a proxy the machine never resolves anything itself,
+	// it hands over the name and mihomo does the lookup.
+	//
+	// The phone has no equivalent setting and does not need one: VpnService takes
+	// DNS servers directly (`addDnsServer`), so Android routes every query into
+	// the tunnel itself. Windows offers nothing like that. So this is the second
+	// place, after IPv6 containment, where matching the phone literally would mean
+	// shipping a leak.
+	//
+	// What it costs: on Windows, WFP filters that block port 53 for everything
+	// except the engine and the tunnel adapter. On Linux, unreachable policy rules
+	// to the same end. macOS ignores it. The Windows filters live in a session
+	// opened with FWPM_SESSION_FLAG_DYNAMIC, so they are removed when the engine
+	// exits — including when it is killed, which matters: filters that outlived a
+	// crash would leave a machine unable to resolve anything until it rebooted.
+	StrictRoute bool
 }
 
 // DefaultTunOptions are the desktop's tunnel settings, IPv6 contained.
@@ -122,6 +147,7 @@ func DefaultTunOptions() TunOptions {
 		AutoRoute:    true,
 		IPv6:         true,
 		Inet6Address: "fdfe:dcba:9876::1/126",
+		StrictRoute:  true,
 	}
 }
 
@@ -307,6 +333,9 @@ func renderTun(tun TunOptions) string {
 	// bypasses the tunnel's DNS entirely, which both leaks the query and defeats
 	// fake-ip.
 	out.WriteString("  dns-hijack:\n    - any:53\n")
+	// And hijacking is only half of it: it catches what enters the tunnel, and a
+	// query to the router on the local network never does. See StrictRoute.
+	fmt.Fprintf(&out, "  strict-route: %t\n", tun.StrictRoute)
 	if tun.IPv6 && tun.Inet6Address != "" {
 		fmt.Fprintf(&out, "  inet6-address:\n    - %s\n", tun.Inet6Address)
 	}

--- a/desktop/internal/mihomoconf/config_test.go
+++ b/desktop/internal/mihomoconf/config_test.go
@@ -121,6 +121,40 @@ func TestRenderEnablesTunAndContainsIPv6(t *testing.T) {
 	}
 }
 
+// The DNS leak this was shipped with, and the reason dns-hijack alone is not the
+// answer.
+//
+// Hijacking catches queries that enter the tunnel. A query to the resolver on
+// the local network never enters it: the route to that subnet is directly
+// connected on the physical adapter and beats the 0.0.0.0/1 pair the tunnel
+// installs. So every lookup went to the home router in the clear, and a leak
+// test showed the user's own ISP — in tunnel mode only, because through a proxy
+// the machine never resolves anything itself.
+//
+// If this ever goes back to false, that leak returns and nothing else in the
+// suite notices.
+func TestRenderKeepsDNSInsideTheTunnel(t *testing.T) {
+	document := Render("", Options{Secret: "s3cret", ProxyGroup: SelectGroup, Tun: DefaultTunOptions()})
+	tun := parseYAML(t, document)["tun"].(map[string]any)
+
+	if tun["strict-route"] != true {
+		t.Fatalf("without strict-route, DNS to a resolver on the local network leaves the tunnel: %#v", tun["strict-route"])
+	}
+}
+
+// It follows the tunnel: with nothing routed there is nothing to keep inside,
+// and the filters would only be blocking the machine's own DNS.
+func TestRenderLeavesStrictRouteOffWithTheTunnel(t *testing.T) {
+	tun := DefaultTunOptions()
+	tun.StrictRoute = false
+	document := Render("", Options{Secret: "s", ProxyGroup: SelectGroup, Tun: tun})
+
+	parsed := parseYAML(t, document)["tun"].(map[string]any)
+	if parsed["strict-route"] != false {
+		t.Fatalf("expected strict-route to follow the option: %#v", parsed["strict-route"])
+	}
+}
+
 func TestRenderCanLeaveTunOff(t *testing.T) {
 	document := Render("", Options{Secret: "s"})
 	parsed := parseYAML(t, document)


### PR DESCRIPTION
Tunnel mode leaked DNS. Proxy mode did not, and that difference is the whole explanation: through a proxy the machine never resolves anything itself — it hands the name to mihomo, which does the lookup through the group. In tunnel mode the machine resolves normally, and those queries have to be caught.

dns-hijack was already set and is not enough. It catches what enters the tunnel, and a query to the resolver on the local network never enters it: the route to 192.168.0.0/16 is directly connected on the physical adapter and beats the 0.0.0.0/1 pair the tunnel installs. So every lookup went straight to the home router in the clear, and a leak test showed the user's own ISP.

strict-route: true is what closes it. On Windows that is WFP filters blocking port 53 for everything except the engine and the tunnel adapter; on Linux, unreachable policy rules to the same end; macOS ignores it. The Windows filters are added in a session opened with FWPM_SESSION_FLAG_DYNAMIC, so the kernel removes them when the engine exits — including when it is killed, which is the case that matters: filters outliving a crash would leave a machine unable to resolve anything until it rebooted.

Android does not set this and does not need to. VpnService takes DNS servers directly through addDnsServer, so the OS routes every query into the tunnel. Windows has no equivalent. This is the second place, after IPv6 containment, where matching the phone literally would mean shipping a leak — both are now written down in ANDROID-PARITY.md.

Verified the running engine accepts the option rather than trusting the schema: spawned unelevated, validateConfig on a generated tun config, which is the same call the connect path makes. TestRenderKeepsDNSInsideTheTunnel pins it, because if this reverts to false the leak comes back and nothing else in the suite would notice.

Not verified here: that the leak is actually gone end to end. That needs a tunnel up on a real machine, which needs Administrator.