### PR TITLE
Keep DNS inside the tunnel, and give a subscription's nodes something that works

### DIFF
--- a/desktop/ANDROID-PARITY.md
+++ b/desktop/ANDROID-PARITY.md
@@ -561,6 +561,19 @@ from Wi-Fi to Ethernet must not lose its VPN on the way.
 
 ### Things that will bite
 
+- **`dns-hijack` does not stop a DNS leak on its own.** It catches queries that
+  enter the tunnel. A query to the resolver on the local network never does: the
+  route to that subnet is directly connected on the physical adapter and beats
+  the `0.0.0.0/1` pair the tunnel installs, so lookups went to the home router in
+  the clear and a leak test showed the user's own ISP. Tunnel mode only — through
+  a proxy the machine never resolves anything itself, it hands the name over and
+  mihomo does the lookup, which is why proxy mode looked clean and hid this.
+  `strict-route: true` is what closes it: WFP filters on Windows blocking port 53
+  for everything but the engine and the tunnel adapter, unreachable policy rules
+  on Linux, ignored on macOS. **Android does not set it and does not need to** —
+  `VpnService.Builder.addDnsServer` makes the OS route every query into the
+  tunnel — so this is the second place, after IPv6 containment, where copying the
+  phone literally means shipping a leak.
 - **There are two version numbers, and only one of them is the app's.** The
   sidebar reads `appVersion`, set at link time by `-X main.appVersion` from the
   Makefile's `VERSION`. The number Windows shows in Properties → Details is

--- a/desktop/ANDROID-PARITY.md
+++ b/desktop/ANDROID-PARITY.md
@@ -302,6 +302,45 @@ reading of what a provider is serving: it returns unchanged at the next refresh,
 so a delete button on it would undo itself. Removing a whole subscription is the
 Subscriptions page's job and already exists.
 
+### What a subscription's nodes get instead
+
+Editing one is not a feature built badly — it is a feature that cannot exist.
+`RefreshV2RaySubscription` drops every profile a subscription produced and
+re-imports from the remote body with fresh ids built from a timestamp, so a
+change does not survive and there is not even a stable id to hang it on. A
+subscription served as a mihomo document produces no profiles at all; its nodes
+are read straight out of the body.
+
+So two things that are true instead:
+
+**Copy to my configs** (`CopyNodeToManual`) takes the node into the user's own
+list, where it is theirs and the edit form already applies. It goes through the
+ordinary import so a copied node is parsed by the same code as a pasted one. It
+needs a share link, which a document-shaped subscription does not carry — the
+same limitation the Share button has, shown the same way.
+
+**Hide** (`SetNodesHidden`) takes a node out of the list and out of the engine's
+configuration without claiming to have deleted it. Held by **name**, in
+`AppState.HiddenNodes` keyed by subscription id, precisely because ids do not
+survive a refresh and this has to. A name goes stale if the provider renames the
+node, and then it reappears — the honest failure, and a visible one.
+
+Three things follow from "out of the configuration":
+
+- `session.Options.Exclude` drops the proxies before the config is built, rather
+  than expressing them as `Prefer`. Prefer only narrows what an attempt reaches
+  for and leaves everything in the group, so a hidden node would still be sitting
+  in the url-test group for the engine to pick — and a non-empty Prefer turns
+  Automatic into an explicit selection, losing the group that makes Automatic
+  work.
+- `preferredNodeNames` skips hidden nodes, or a country filter would name nodes
+  the engine does not hold.
+- Hiding every node is refused. It would leave nothing to build a configuration
+  from and surface later as an error about a missing group.
+
+The node stays in the list carrying `Hidden`, rather than being removed from it:
+a node dropped from the list could never be put back.
+
 The node-to-profile match is on the share link, not on position. Both sides come
 from the same exporter, so the strings are identical where they correspond; on
 position they would not be, because the exporter skips profiles it cannot express

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -9,6 +9,8 @@ import {
   Copy,
   Cpu,
   Download,
+  Eye,
+  EyeOff,
   ExternalLink,
   FileText,
   Gauge,
@@ -2502,6 +2504,10 @@ function NodesPage({
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState<WhiteVPNNode[] | null>(null);
   const [deletingBusy, setDeletingBusy] = useState(false);
+  // Hidden nodes are kept out of the way rather than out of reach: this reveals
+  // them so they can be put back, which is the only way back from hiding one.
+  const [showHidden, setShowHidden] = useState(false);
+  const [hidingBusy, setHidingBusy] = useState(false);
   const unknown = t("vpn.nodes.unknownCountry");
   const manualProfileCount = state.v2rayProfiles.filter((profile) => !profile.subscriptionId).length;
 
@@ -2515,6 +2521,11 @@ function NodesPage({
   const visible = useMemo(() => {
     const needle = search.trim().toLowerCase();
     const filtered = nodes.filter((node) => {
+      // A node the user hid is out of the way by default and reachable through
+      // the toggle, because hiding has to be undoable from somewhere.
+      if (node.hidden && !showHidden) {
+        return false;
+      }
       if (country && node.countryCode !== country) {
         return false;
       }
@@ -2563,8 +2574,9 @@ function NodesPage({
       return left - right;
     });
     return sort.direction === "desc" ? sorted.reverse() : sorted;
-  }, [nodes, search, country, protocol, sort, language, unknown]);
+  }, [nodes, search, country, protocol, sort, language, unknown, showHidden]);
 
+  const hiddenCount = useMemo(() => nodes.filter((node) => node.hidden).length, [nodes]);
   const selectedNames = useMemo(() => visible.filter((node) => selected.has(node.name)).map((node) => node.name), [visible, selected]);
   const targets = selectedNames.length ? selectedNames : visible.map((node) => node.name);
 
@@ -2574,6 +2586,23 @@ function NodesPage({
         ? { column, direction: current.direction === "asc" ? "desc" : "asc" }
         : { column, direction: "asc" }
     );
+  }
+
+  const allVisibleSelected = visible.length > 0 && visible.every((node) => selected.has(node.name));
+  const someVisibleSelected = visible.some((node) => selected.has(node.name));
+
+  // Clearing removes only what is on screen, so a selection made under one
+  // filter is not silently thrown away by unticking under another.
+  function toggleSelectAll() {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (allVisibleSelected) {
+        visible.forEach((node) => next.delete(node.name));
+      } else {
+        visible.forEach((node) => next.add(node.name));
+      }
+      return next;
+    });
   }
 
   function toggleSelected(name: string) {
@@ -2637,6 +2666,11 @@ function NodesPage({
     () => editableNodes.filter((node) => selected.has(node.name)),
     [editableNodes, selected]
   );
+  // The mirror of that: a subscription's nodes cannot be deleted, only hidden.
+  const selectedHideable = useMemo(
+    () => visible.filter((node) => !node.profileId && !node.hidden && selected.has(node.name)),
+    [visible, selected]
+  );
 
   async function openEditor(node: WhiteVPNNode) {
     onError("");
@@ -2690,6 +2724,35 @@ function NodesPage({
       onError(messageFromError(err));
     } finally {
       setDeletingBusy(false);
+    }
+  }
+
+  // A subscription's nodes belong to whoever serves them: a refresh rebuilds
+  // them all, so editing one is not something that could work. Copying takes it
+  // into the user's own configs, where it is theirs and the edit form applies.
+  async function copyToManual(node: WhiteVPNNode) {
+    onError("");
+    try {
+      await backend.copyNodeToManual(subscriptionId, node.name);
+      onSuccess(t("servers.copyToManual.done", { name: node.label }));
+    } catch (err) {
+      onError(messageFromError(err));
+    }
+  }
+
+  async function setHidden(targets: WhiteVPNNode[], hidden: boolean) {
+    if (!targets.length || hidingBusy) {
+      return;
+    }
+    onError("");
+    setHidingBusy(true);
+    try {
+      onNodesChanged(await backend.setNodesHidden(subscriptionId, targets.map((node) => node.name), hidden));
+      onSuccess(hidden ? t("servers.hide.done", { count: targets.length }) : t("servers.unhide.done", { count: targets.length }));
+    } catch (err) {
+      onError(messageFromError(err));
+    } finally {
+      setHidingBusy(false);
     }
   }
 
@@ -2757,6 +2820,18 @@ function NodesPage({
             <Button variant="outline" className="text-destructive" onClick={() => setDeleting(selectedEditable)}>
               <Trash2 />
               {t("servers.deleteSelected", { count: selectedEditable.length })}
+            </Button>
+          )}
+          {selectedHideable.length > 0 && (
+            <Button variant="outline" onClick={() => void setHidden(selectedHideable, true)} disabled={hidingBusy}>
+              <EyeOff />
+              {t("servers.hideSelected", { count: selectedHideable.length })}
+            </Button>
+          )}
+          {hiddenCount > 0 && (
+            <Button variant="outline" onClick={() => setShowHidden((shown) => !shown)}>
+              {showHidden ? <EyeOff /> : <Eye />}
+              {showHidden ? t("servers.hideHidden") : t("servers.showHidden", { count: hiddenCount })}
             </Button>
           )}
           <Button variant="outline" onClick={onReload} disabled={loading}>
@@ -2918,10 +2993,27 @@ function NodesPage({
       <Card className="min-h-0">
         <CardContent className="p-0">
           <ScrollArea className="h-[calc(100svh-24rem)]">
-            <table className="w-full min-w-[860px] table-fixed text-start text-sm">
+            <table className="w-full min-w-[980px] table-fixed text-start text-sm">
               <thead className="sticky top-0 z-10 bg-muted/95 text-xs uppercase text-muted-foreground backdrop-blur">
                 <tr>
-                  <th className="w-10 px-2 py-2"></th>
+                  <th className="w-10 px-2 py-2">
+                    <input
+                      type="checkbox"
+                      className="size-4"
+                      // Only what is on screen. Selecting behind an active
+                      // filter would hand a test or a delete rows the user
+                      // cannot see.
+                      checked={allVisibleSelected}
+                      ref={(element) => {
+                        if (element) {
+                          element.indeterminate = someVisibleSelected && !allVisibleSelected;
+                        }
+                      }}
+                      onChange={toggleSelectAll}
+                      disabled={!visible.length}
+                      aria-label={t("servers.selectAll")}
+                    />
+                  </th>
                   <NodeHeader column="country" sort={sort} onSort={toggleSort} className="w-32">
                     {t("vpn.location")}
                   </NodeHeader>
@@ -2941,12 +3033,25 @@ function NodesPage({
                   <NodeHeader column="speed" sort={sort} onSort={toggleSort} className="w-28 text-end">
                     {t("servers.test.speed")}
                   </NodeHeader>
-                  <th className="w-24 px-2 py-2 text-end font-medium">{t("servers.column.actions")}</th>
+                  {/* Wide enough for five 28px buttons and the gaps between
+                      them. It was w-24 when a row had two, and adding edit and
+                      delete pushed them out over the Speed column instead of
+                      making the column bigger. */}
+                  <th className="w-44 px-2 py-2 text-end font-medium">{t("servers.column.actions")}</th>
                 </tr>
               </thead>
               <tbody>
                 {visible.map((node) => (
-                  <tr key={node.name} className="border-b last:border-b-0 hover:bg-muted/40">
+                  <tr
+                    key={node.name}
+                    className={cn(
+                      "border-b last:border-b-0 hover:bg-muted/40",
+                      // Only ever on screen while hidden nodes are being shown,
+                      // and it has to look different from the rest or there is
+                      // no telling which ones they are.
+                      node.hidden && "opacity-50"
+                    )}
+                  >
                     <td className="px-2 py-1.5">
                       <input
                         type="checkbox"
@@ -3046,6 +3151,44 @@ function NodesPage({
                           </TooltipTrigger>
                           <TooltipContent>{node.link ? t("servers.share") : t("servers.share.none")}</TooltipContent>
                         </Tooltip>
+                        {/* A subscription's node cannot be edited — a refresh
+                            rebuilds it — so it gets the two things that do
+                            work: take a copy, or put it out of the way. */}
+                        {!node.profileId && (
+                          <>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="icon-sm"
+                                  onClick={() => void copyToManual(node)}
+                                  disabled={!node.link}
+                                  aria-label={t("servers.copyToManual")}
+                                >
+                                  <Copy />
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                {node.link ? t("servers.copyToManual") : t("servers.copyToManual.none")}
+                              </TooltipContent>
+                            </Tooltip>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="icon-sm"
+                                  className={cn(!node.hidden && "text-destructive hover:text-destructive")}
+                                  onClick={() => void setHidden([node], !node.hidden)}
+                                  disabled={hidingBusy}
+                                  aria-label={node.hidden ? t("servers.unhide") : t("servers.hide")}
+                                >
+                                  {node.hidden ? <Eye /> : <EyeOff />}
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>{node.hidden ? t("servers.unhide") : t("servers.hide")}</TooltipContent>
+                            </Tooltip>
+                          </>
+                        )}
                         {/* Offered only where there is a stored config behind
                             the row. See editableNodes. */}
                         {node.profileId && (

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -481,6 +481,27 @@ const strings = {
   "servers.edit.wgReserved": { en: "Reserved", fa: "Reserved" },
   "servers.edit.wgKeepAlive": { en: "Keep-alive (s)", fa: "Keep-alive (ثانیه)" },
 
+  "servers.selectAll": { en: "Select all", fa: "انتخاب همه" },
+
+  // What can be done to a node that belongs to a subscription. Not editing: a
+  // refresh rebuilds every one of them, so a change would not survive.
+  "servers.copyToManual": { en: "Copy to my configs", fa: "کپی به کانفیگ‌های من" },
+  "servers.copyToManual.none": {
+    en: "This node came from a configuration file, so there is no link to copy.",
+    fa: "این سرور از یک فایل کانفیگ آمده، پس لینکی برای کپی کردن ندارد.",
+  },
+  "servers.copyToManual.done": {
+    en: "{name} copied to your configs, where you can edit it.",
+    fa: "«{name}» به کانفیگ‌های شما کپی شد و حالا قابل ویرایش است.",
+  },
+  "servers.hide": { en: "Hide", fa: "مخفی کردن" },
+  "servers.unhide": { en: "Show again", fa: "بازگرداندن" },
+  "servers.hideSelected": { en: "Hide {count}", fa: "مخفی کردن {count} مورد" },
+  "servers.showHidden": { en: "Show hidden ({count})", fa: "نمایش مخفی‌شده‌ها ({count})" },
+  "servers.hideHidden": { en: "Hide them again", fa: "پنهان کردن دوباره" },
+  "servers.hide.done": { en: "Hidden {count}.", fa: "{count} مورد مخفی شد." },
+  "servers.unhide.done": { en: "Restored {count}.", fa: "{count} مورد بازگردانده شد." },
+
   "servers.delete": { en: "Delete", fa: "حذف" },
   "servers.delete.title": { en: "Delete config", fa: "حذف کانفیگ" },
   "servers.delete.one": {

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -663,6 +663,10 @@ export type WhiteVPNNode = {
   tls: boolean;
   // The share link this node arrived as, which is what sharing hands back.
   link: string;
+  // The user took this node out of the subscription. It stays in the list so it
+  // can be put back, is filtered from view unless hidden nodes are shown, and
+  // never reaches the engine's configuration.
+  hidden: boolean;
   // The stored config this node was made from, set only for configs added by
   // hand. A node from the catalogue or a subscription has none — it is a
   // reading of what the provider is serving and comes back unchanged at the

--- a/desktop/frontend/src/wails.ts
+++ b/desktop/frontend/src/wails.ts
@@ -86,6 +86,8 @@ type AppApi = {
   ListWhiteVPNNodes(refresh: boolean): Promise<WhiteVPNNodeList>;
   ListSubscriptionNodes(subscriptionId: string, refresh: boolean): Promise<WhiteVPNNodeList>;
   ManualNodeProfile(profileId: string): Promise<V2RayProfile>;
+  CopyNodeToManual(subscriptionId: string, nodeName: string): Promise<V2RayImportResult>;
+  SetNodesHidden(subscriptionId: string, nodeNames: string[], hidden: boolean): Promise<WhiteVPNNodeList>;
   SaveManualNode(profile: V2RayProfile): Promise<WhiteVPNNodeList>;
   DeleteManualNodes(profileIds: string[]): Promise<WhiteVPNNodeList>;
   MeasureWhiteVPNNodeDelays(names: string[]): Promise<WhiteVPNNodeList>;
@@ -180,6 +182,9 @@ export const backend = {
   listWhiteVpnNodes: (refresh: boolean) => app().ListWhiteVPNNodes(refresh),
   listSubscriptionNodes: (subscriptionId: string, refresh: boolean) => app().ListSubscriptionNodes(subscriptionId, refresh),
   manualNodeProfile: (profileId: string) => app().ManualNodeProfile(profileId),
+  copyNodeToManual: (subscriptionId: string, nodeName: string) => app().CopyNodeToManual(subscriptionId, nodeName),
+  setNodesHidden: (subscriptionId: string, nodeNames: string[], hidden: boolean) =>
+    app().SetNodesHidden(subscriptionId, nodeNames, hidden),
   saveManualNode: (profile: V2RayProfile) => app().SaveManualNode(profile),
   deleteManualNodes: (profileIds: string[]) => app().DeleteManualNodes(profileIds),
   measureWhiteVpnNodeDelays: (names: string[]) => app().MeasureWhiteVPNNodeDelays(names),

--- a/desktop/internal/mihomoconf/config.go
+++ b/desktop/internal/mihomoconf/config.go
@@ -110,6 +110,31 @@ type TunOptions struct {
 	// which is why containment has to be verified after connecting and never
 	// assumed.
 	Inet6Address string
+
+	// StrictRoute stops traffic finding its way around the tunnel, and it is what
+	// closes the DNS leak the desktop had in tunnel mode.
+	//
+	// dns-hijack is not enough on its own, because it can only catch what enters
+	// the tunnel. A resolver on the local network does not: the route to
+	// 192.168.0.0/16 is directly connected on the physical adapter and beats the
+	// 0.0.0.0/1 pair the tunnel installs, so every query to the home router left
+	// the machine in the clear. That is why the leak showed in tunnel mode and not
+	// in proxy mode — through a proxy the machine never resolves anything itself,
+	// it hands over the name and mihomo does the lookup.
+	//
+	// The phone has no equivalent setting and does not need one: VpnService takes
+	// DNS servers directly (`addDnsServer`), so Android routes every query into
+	// the tunnel itself. Windows offers nothing like that. So this is the second
+	// place, after IPv6 containment, where matching the phone literally would mean
+	// shipping a leak.
+	//
+	// What it costs: on Windows, WFP filters that block port 53 for everything
+	// except the engine and the tunnel adapter. On Linux, unreachable policy rules
+	// to the same end. macOS ignores it. The Windows filters live in a session
+	// opened with FWPM_SESSION_FLAG_DYNAMIC, so they are removed when the engine
+	// exits — including when it is killed, which matters: filters that outlived a
+	// crash would leave a machine unable to resolve anything until it rebooted.
+	StrictRoute bool
 }
 
 // DefaultTunOptions are the desktop's tunnel settings, IPv6 contained.
@@ -122,6 +147,7 @@ func DefaultTunOptions() TunOptions {
 		AutoRoute:    true,
 		IPv6:         true,
 		Inet6Address: "fdfe:dcba:9876::1/126",
+		StrictRoute:  true,
 	}
 }
 
@@ -307,6 +333,9 @@ func renderTun(tun TunOptions) string {
 	// bypasses the tunnel's DNS entirely, which both leaks the query and defeats
 	// fake-ip.
 	out.WriteString("  dns-hijack:\n    - any:53\n")
+	// And hijacking is only half of it: it catches what enters the tunnel, and a
+	// query to the router on the local network never does. See StrictRoute.
+	fmt.Fprintf(&out, "  strict-route: %t\n", tun.StrictRoute)
 	if tun.IPv6 && tun.Inet6Address != "" {
 		fmt.Fprintf(&out, "  inet6-address:\n    - %s\n", tun.Inet6Address)
 	}

--- a/desktop/internal/mihomoconf/config_test.go
+++ b/desktop/internal/mihomoconf/config_test.go
@@ -121,6 +121,40 @@ func TestRenderEnablesTunAndContainsIPv6(t *testing.T) {
 	}
 }
 
+// The DNS leak this was shipped with, and the reason dns-hijack alone is not the
+// answer.
+//
+// Hijacking catches queries that enter the tunnel. A query to the resolver on
+// the local network never enters it: the route to that subnet is directly
+// connected on the physical adapter and beats the 0.0.0.0/1 pair the tunnel
+// installs. So every lookup went to the home router in the clear, and a leak
+// test showed the user's own ISP — in tunnel mode only, because through a proxy
+// the machine never resolves anything itself.
+//
+// If this ever goes back to false, that leak returns and nothing else in the
+// suite notices.
+func TestRenderKeepsDNSInsideTheTunnel(t *testing.T) {
+	document := Render("", Options{Secret: "s3cret", ProxyGroup: SelectGroup, Tun: DefaultTunOptions()})
+	tun := parseYAML(t, document)["tun"].(map[string]any)
+
+	if tun["strict-route"] != true {
+		t.Fatalf("without strict-route, DNS to a resolver on the local network leaves the tunnel: %#v", tun["strict-route"])
+	}
+}
+
+// It follows the tunnel: with nothing routed there is nothing to keep inside,
+// and the filters would only be blocking the machine's own DNS.
+func TestRenderLeavesStrictRouteOffWithTheTunnel(t *testing.T) {
+	tun := DefaultTunOptions()
+	tun.StrictRoute = false
+	document := Render("", Options{Secret: "s", ProxyGroup: SelectGroup, Tun: tun})
+
+	parsed := parseYAML(t, document)["tun"].(map[string]any)
+	if parsed["strict-route"] != false {
+		t.Fatalf("expected strict-route to follow the option: %#v", parsed["strict-route"])
+	}
+}
+
 func TestRenderCanLeaveTunOff(t *testing.T) {
 	document := Render("", Options{Secret: "s"})
 	parsed := parseYAML(t, document)

--- a/desktop/internal/model/types.go
+++ b/desktop/internal/model/types.go
@@ -361,8 +361,18 @@ type AppState struct {
 	V2RaySubscriptions     []V2RaySubscription    `json:"v2raySubscriptions"`
 	V2RaySettingsProfiles  []V2RaySettingsProfile `json:"v2raySettingsProfiles"`
 	WhiteDNSVPNFrontingIPs []string               `json:"whiteDNSVPNFrontingIps"`
-	WhiteVPN               WhiteVPNSettings       `json:"whiteVpn"`
-	Runtime                RuntimeStatus          `json:"runtime"`
+	// HiddenNodes are the nodes a user has taken out of a subscription, keyed by
+	// subscription id and held by node name.
+	//
+	// By name, because a subscription's own identity is not stable: refreshing one
+	// drops every profile it produced and re-imports with new ids built from a
+	// timestamp, so anything keyed by id would come undone at the next refresh —
+	// which is the whole thing this has to survive. A name can go stale if the
+	// provider renames a node, and then it reappears; that is the honest failure
+	// and it is visible, unlike silently hiding some other node.
+	HiddenNodes map[string][]string `json:"hiddenNodes"`
+	WhiteVPN    WhiteVPNSettings    `json:"whiteVpn"`
+	Runtime     RuntimeStatus       `json:"runtime"`
 }
 
 type ConnectionImportResult struct {
@@ -529,6 +539,13 @@ type WhiteVPNNode struct {
 	// Link is the share link this node arrived as, which is what sharing it
 	// hands back.
 	Link string `json:"link"`
+
+	// Hidden means the user took this node out of the subscription. It stays in
+	// the list so it can be put back, is skipped by the interface unless hidden
+	// nodes are being shown, and never reaches the engine's configuration at all —
+	// a node hidden from the list but still connectable would be the worst of
+	// both.
+	Hidden bool `json:"hidden"`
 
 	// ProfileID names the stored profile this node was made from, and is set
 	// only for manually added configs.

--- a/desktop/internal/profiles/store.go
+++ b/desktop/internal/profiles/store.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -255,6 +256,7 @@ func NormalizeState(state model.AppState) model.AppState {
 	state.V2RaySettingsProfiles = normalizeV2RaySettingsProfiles(state.V2RaySettingsProfiles)
 	state.WhiteVPN = model.NormalizeWhiteVPNSettings(state.WhiteVPN)
 	state.WhiteDNSVPNFrontingIPs = NormalizeWhiteDNSVPNFrontingIPs(state.WhiteDNSVPNFrontingIPs)
+	state.HiddenNodes = NormalizeHiddenNodes(state.HiddenNodes)
 
 	if !hasConnection(state.ConnectionProfiles, state.SelectedConnectionProfileID) {
 		state.SelectedConnectionProfileID = state.ConnectionProfiles[0].ID
@@ -310,6 +312,40 @@ func NormalizeWhiteDNSVPNFrontingIPs(values []string) []string {
 	}
 	if len(out) == 0 {
 		return []string{}
+	}
+	return out
+}
+
+// NormalizeHiddenNodes keeps the hidden list tidy: no blanks, no duplicates, no
+// subscription left holding an empty list, and a stable order so two saves of
+// the same state produce the same file.
+func NormalizeHiddenNodes(hidden map[string][]string) map[string][]string {
+	out := make(map[string][]string, len(hidden))
+	for subscription, names := range hidden {
+		subscription = strings.TrimSpace(subscription)
+		if subscription == "" {
+			continue
+		}
+		seen := make(map[string]struct{}, len(names))
+		kept := make([]string, 0, len(names))
+		for _, name := range names {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			if _, taken := seen[name]; taken {
+				continue
+			}
+			seen[name] = struct{}{}
+			kept = append(kept, name)
+		}
+		if len(kept) == 0 {
+			// An empty entry is the same as no entry, and dropping it stops the
+			// map growing a key for every subscription ever looked at.
+			continue
+		}
+		sort.Strings(kept)
+		out[subscription] = kept
 	}
 	return out
 }

--- a/desktop/internal/session/session.go
+++ b/desktop/internal/session/session.go
@@ -55,6 +55,17 @@ type Options struct {
 	// another without being told.
 	Prefer []string
 
+	// Exclude drops nodes from the configuration entirely, by name. It is how a
+	// node the user hid stays hidden.
+	//
+	// Dropped rather than merely not preferred, and that distinction matters:
+	// Prefer narrows what an attempt reaches for while leaving everything in the
+	// group, so a hidden node expressed as a preference would still be sitting in
+	// the url-test group for the engine to choose. It would also make Prefer
+	// non-empty and turn Automatic into an explicit selection, losing the group
+	// that makes Automatic work at all.
+	Exclude []string
+
 	// FrontingIP reaches every eligible node through this address instead of the
 	// one its name resolves to, while still presenting the name. Empty means the
 	// nodes are reached directly.
@@ -487,6 +498,35 @@ func (s *Session) recoverAutomatically(ctx context.Context) (string, error) {
 	return s.selected, nil
 }
 
+// withoutNodes removes the named nodes from a subscription's proxies.
+//
+// Hiding everything is refused rather than allowed to produce an empty
+// configuration: the engine would fail to start and the error would be about a
+// missing group, which says nothing about what the user actually did.
+func withoutNodes(proxies []mihomoconf.Proxy, exclude []string) ([]mihomoconf.Proxy, error) {
+	drop := make(map[string]struct{}, len(exclude))
+	for _, name := range exclude {
+		if trimmed := strings.TrimSpace(name); trimmed != "" {
+			drop[trimmed] = struct{}{}
+		}
+	}
+	if len(drop) == 0 {
+		return proxies, nil
+	}
+
+	kept := make([]mihomoconf.Proxy, 0, len(proxies))
+	for _, proxy := range proxies {
+		if _, hidden := drop[proxy.Name()]; hidden {
+			continue
+		}
+		kept = append(kept, proxy)
+	}
+	if len(kept) == 0 {
+		return nil, fmt.Errorf("session: every node in this subscription is hidden")
+	}
+	return kept, nil
+}
+
 // recoveryOrder is which nodes a recovery reaches for: the candidates in their
 // own order, without the one that just failed, capped at what one recovery is
 // willing to spend.
@@ -590,6 +630,13 @@ func PrepareConfig(opts Options) (string, []string, error) {
 	// user picking a node on the Servers page expects that node, not whatever
 	// the provider's url-test group decides.
 	if proxies, _, err := mihomoconf.ParseSubscription(body); err == nil {
+		if len(opts.Exclude) > 0 {
+			kept, err := withoutNodes(proxies, opts.Exclude)
+			if err != nil {
+				return "", nil, err
+			}
+			proxies = kept
+		}
 		if opts.FrontingIP != "" {
 			// Nodes fronting cannot be applied to are left reachable at their own
 			// address rather than dropped: a front that covers most of the list is

--- a/desktop/mihomo_connect.go
+++ b/desktop/mihomo_connect.go
@@ -109,7 +109,11 @@ func (a *App) startWhiteDNSVPNWithMihomo() (model.AppState, error) {
 		MixedPort:    chooseProxyPort(),
 		Subscription: subscription,
 		Prefer:       prefer,
-		FrontingIP:   frontingIP,
+		// Nodes the user hid never reach the configuration, so the engine cannot
+		// choose one on Automatic. Hidden from the list but still connectable
+		// would be the worst of both.
+		Exclude:    a.hiddenNodeNames(a.selectedSubscriptionID()),
+		FrontingIP: frontingIP,
 		DNSPrivacy:   dnsPrivacyMode(settings.DNSPrivacy.Mode),
 		DoHURL:       settings.DNSPrivacy.DoHURL,
 		DoTEndpoint:  settings.DNSPrivacy.DoTEndpoint,

--- a/desktop/subscription_nodes.go
+++ b/desktop/subscription_nodes.go
@@ -1,0 +1,166 @@
+package main
+
+// What a user can do to a node that is not theirs.
+//
+// A subscription's nodes belong to whoever serves them. Refreshing one drops
+// every profile it produced and re-imports from the remote body with fresh ids
+// built from a timestamp, so editing a subscription node is not a feature that
+// could be built badly — it is a feature that cannot exist. Whatever was changed
+// is gone at the next refresh, and there is not even a stable id to hang the
+// change on. Subscriptions served as a mihomo document produce no profiles at
+// all; their nodes are read straight out of the body.
+//
+// So instead of pretending, two things that are true:
+//
+// Copy takes the node out of the subscription and into the user's own configs,
+// where it is theirs and the edit form already works. It needs the node's share
+// link, which a document-shaped subscription does not carry — the same
+// limitation the Share button already has, and shown the same way.
+//
+// Hide takes a node out of the list and out of the engine's configuration
+// without claiming to have deleted anything, and survives a refresh because it
+// is held by name rather than by an id that will not exist tomorrow.
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"whitevpn-desktop/internal/model"
+)
+
+// CopyNodeToManual adds a subscription's node to the user's own configs.
+func (a *App) CopyNodeToManual(subscriptionID string, nodeName string) (model.V2RayImportResult, error) {
+	subscriptionID = strings.TrimSpace(subscriptionID)
+	nodeName = strings.TrimSpace(nodeName)
+	if subscriptionID == "" || nodeName == "" {
+		return model.V2RayImportResult{State: a.GetAppState()}, fmt.Errorf("no node to copy")
+	}
+
+	var link string
+	for _, node := range a.whiteVPNNodesSnapshot(subscriptionID) {
+		if node.Name == nodeName {
+			link = strings.TrimSpace(node.Link)
+			break
+		}
+	}
+	if link == "" {
+		// Either the node is gone, or it came from a configuration document and
+		// has no link. Both leave nothing to copy, and the second is worth saying
+		// plainly rather than reporting as a missing node.
+		return model.V2RayImportResult{State: a.GetAppState()},
+			fmt.Errorf("this node came from a configuration file, so there is no link to copy")
+	}
+
+	// Through the ordinary import, so a copied node is parsed by exactly the same
+	// code as one pasted in by hand and cannot end up in a shape nothing else
+	// produces.
+	result, err := a.ImportV2RayProfiles(link)
+	if err != nil {
+		return result, err
+	}
+	a.forgetWhiteVPNNodes(model.ManualServerSourceID)
+	return result, nil
+}
+
+// SetNodesHidden takes nodes out of a subscription, or puts them back.
+func (a *App) SetNodesHidden(subscriptionID string, nodeNames []string, hidden bool) (model.WhiteVPNNodeList, error) {
+	subscriptionID = strings.TrimSpace(subscriptionID)
+	if subscriptionID == "" {
+		return a.snapshotWhiteVPNNodes(subscriptionID), fmt.Errorf("no subscription named")
+	}
+	wanted := make([]string, 0, len(nodeNames))
+	for _, name := range nodeNames {
+		if trimmed := strings.TrimSpace(name); trimmed != "" {
+			wanted = append(wanted, trimmed)
+		}
+	}
+	if len(wanted) == 0 {
+		return a.snapshotWhiteVPNNodes(subscriptionID), nil
+	}
+
+	if hidden {
+		// Hiding everything would leave the engine nothing to build a
+		// configuration from, and the failure would arrive later as an error about
+		// a missing group. Refusing here says what actually happened.
+		if remaining := a.visibleNodeCount(subscriptionID, wanted); remaining == 0 {
+			return a.snapshotWhiteVPNNodes(subscriptionID),
+				fmt.Errorf("that would hide every node in this subscription; leave at least one")
+		}
+	}
+
+	a.mu.Lock()
+	if a.state.HiddenNodes == nil {
+		a.state.HiddenNodes = map[string][]string{}
+	}
+	current := append([]string(nil), a.state.HiddenNodes[subscriptionID]...)
+	for _, name := range wanted {
+		if hidden {
+			if !slices.Contains(current, name) {
+				current = append(current, name)
+			}
+			continue
+		}
+		current = slices.DeleteFunc(current, func(existing string) bool { return existing == name })
+	}
+	a.state.HiddenNodes[subscriptionID] = current
+	_, err := a.saveLocked()
+	a.mu.Unlock()
+	if err != nil {
+		return a.snapshotWhiteVPNNodes(subscriptionID), err
+	}
+
+	// The flags live on the cached list, so they are updated in place. Dropping
+	// the cache instead would send this local change back to the network for a
+	// list it already has, and would fail outright with no connection.
+	return a.reapplyHiddenNodes(subscriptionID), nil
+}
+
+// reapplyHiddenNodes brings the cached list's flags back in line with what is
+// stored, and hands the list back.
+func (a *App) reapplyHiddenNodes(subscriptionID string) model.WhiteVPNNodeList {
+	hidden := a.hiddenNodeNames(subscriptionID)
+	lookup := make(map[string]struct{}, len(hidden))
+	for _, name := range hidden {
+		lookup[name] = struct{}{}
+	}
+
+	a.nodesMu.Lock()
+	defer a.nodesMu.Unlock()
+	for i := range a.nodes[subscriptionID] {
+		_, a.nodes[subscriptionID][i].Hidden = lookup[a.nodes[subscriptionID][i].Name]
+	}
+	return a.nodeListLocked(subscriptionID)
+}
+
+// visibleNodeCount is how many nodes would still be usable if these were hidden.
+func (a *App) visibleNodeCount(subscriptionID string, alsoHiding []string) int {
+	hiding := make(map[string]struct{}, len(alsoHiding))
+	for _, name := range alsoHiding {
+		hiding[name] = struct{}{}
+	}
+	for _, name := range a.hiddenNodeNames(subscriptionID) {
+		hiding[name] = struct{}{}
+	}
+
+	nodes := a.whiteVPNNodesSnapshot(subscriptionID)
+	if len(nodes) == 0 {
+		// Nothing is known about this subscription yet, so there is nothing to
+		// protect and no reason to refuse.
+		return 1
+	}
+	remaining := 0
+	for _, node := range nodes {
+		if _, gone := hiding[node.Name]; !gone {
+			remaining++
+		}
+	}
+	return remaining
+}
+
+// hiddenNodeNames is what the user has taken out of one subscription.
+func (a *App) hiddenNodeNames(subscriptionID string) []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]string(nil), a.state.HiddenNodes[subscriptionID]...)
+}

--- a/desktop/subscription_nodes_test.go
+++ b/desktop/subscription_nodes_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"whitevpn-desktop/internal/model"
+	"whitevpn-desktop/internal/profiles"
+	"whitevpn-desktop/internal/session"
+)
+
+const subscriptionLinks = "vless://11111111-2222-3333-4444-555555555555@one.example.com:443?security=reality&pbk=k&sid=00#Alpha\n" +
+	"trojan://password@two.example.com:443?sni=two.example.com#Beta\n" +
+	"trojan://password@three.example.com:443?sni=three.example.com#Gamma"
+
+func hiddenNodesApp(t *testing.T) *App {
+	t.Helper()
+	state := model.DefaultAppState()
+	app := &App{
+		store: profiles.NewStore(filepath.Join(t.TempDir(), "state.json")),
+		state: state,
+	}
+	nodes, err := whiteVPNNodesFromSubscription(subscriptionLinks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app.storeWhiteVPNNodes("sub-1", nodes, time.Now().UTC())
+	return app
+}
+
+func nodeNamed(t *testing.T, list model.WhiteVPNNodeList, name string) model.WhiteVPNNode {
+	t.Helper()
+	for _, node := range list.Nodes {
+		if node.Name == name {
+			return node
+		}
+	}
+	t.Fatalf("node %q is not in the list", name)
+	return model.WhiteVPNNode{}
+}
+
+// Hidden, not deleted: the node stays in the list carrying a flag, because one
+// removed outright could never be put back.
+func TestHidingANodeFlagsItRatherThanDroppingIt(t *testing.T) {
+	app := hiddenNodesApp(t)
+
+	list, err := app.SetNodesHidden("sub-1", []string{"Beta"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Nodes) != 3 {
+		t.Fatalf("the node should still be listed, got %d", len(list.Nodes))
+	}
+	if !nodeNamed(t, list, "Beta").Hidden {
+		t.Fatal("Beta should be marked hidden")
+	}
+	if nodeNamed(t, list, "Alpha").Hidden {
+		t.Fatal("Alpha should be untouched")
+	}
+}
+
+func TestHidingIsReversible(t *testing.T) {
+	app := hiddenNodesApp(t)
+	if _, err := app.SetNodesHidden("sub-1", []string{"Beta"}, true); err != nil {
+		t.Fatal(err)
+	}
+	list, err := app.SetNodesHidden("sub-1", []string{"Beta"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nodeNamed(t, list, "Beta").Hidden {
+		t.Fatal("Beta should be visible again")
+	}
+	if names := app.hiddenNodeNames("sub-1"); len(names) != 0 {
+		t.Fatalf("nothing should be left hidden, got %v", names)
+	}
+}
+
+// The point of holding these by name: a refresh drops every profile a
+// subscription produced and re-imports with new ids, so anything keyed by id
+// would come undone exactly when it needs to survive.
+func TestHidingSurvivesARefreshOfTheNodeList(t *testing.T) {
+	app := hiddenNodesApp(t)
+	if _, err := app.SetNodesHidden("sub-1", []string{"Gamma"}, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// What a refresh does: the cache is dropped and the list rebuilt from the
+	// subscription body.
+	app.forgetWhiteVPNNodes("sub-1")
+	nodes, err := whiteVPNNodesFromSubscription(subscriptionLinks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app.markHiddenNodes("sub-1", nodes)
+	list := app.storeWhiteVPNNodes("sub-1", nodes, time.Now().UTC())
+
+	if !nodeNamed(t, list, "Gamma").Hidden {
+		t.Fatal("hiding did not survive the refresh")
+	}
+}
+
+// Hidden from the list but still connectable would be the worst of both.
+func TestHiddenNodesNeverReachTheEngineConfig(t *testing.T) {
+	document, candidates, err := session.PrepareConfig(session.Options{
+		Subscription: subscriptionLinks,
+		Exclude:      []string{"Beta"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range candidates {
+		if name == "Beta" {
+			t.Fatal("a hidden node is still selectable")
+		}
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("expected the other two nodes, got %v", candidates)
+	}
+	// Not merely unpreferred — gone, so the engine's url-test group cannot pick
+	// it either.
+	if contains(document, "Beta") {
+		t.Fatal("a hidden node is still in the configuration")
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (func() bool {
+		for i := 0; i+len(needle) <= len(haystack); i++ {
+			if haystack[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	})()
+}
+
+// Hiding the last node would leave the engine nothing to build from, and the
+// failure would surface later as an error about a missing group.
+func TestHidingEverythingIsRefused(t *testing.T) {
+	app := hiddenNodesApp(t)
+	if _, err := app.SetNodesHidden("sub-1", []string{"Alpha", "Beta", "Gamma"}, true); err == nil {
+		t.Fatal("expected hiding every node to be refused")
+	}
+	if names := app.hiddenNodeNames("sub-1"); len(names) != 0 {
+		t.Fatalf("the refused change was stored anyway: %v", names)
+	}
+}
+
+func TestPreferredNodeNamesSkipsHiddenNodes(t *testing.T) {
+	nodes, err := whiteVPNNodesFromSubscription(subscriptionLinks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range nodes {
+		if nodes[i].Name == "Beta" {
+			nodes[i].Hidden = true
+		}
+	}
+
+	settings := model.NormalizeWhiteVPNSettings(model.WhiteVPNSettings{})
+	settings.Connection.Types = []string{"trojan"}
+	names := preferredNodeNames(nodes, settings)
+	for _, name := range names {
+		if name == "Beta" {
+			t.Fatalf("a hidden node was preferred: %v", names)
+		}
+	}
+
+	// And naming one directly finds nothing rather than naming a node the engine
+	// does not hold.
+	settings = model.NormalizeWhiteVPNSettings(model.WhiteVPNSettings{})
+	settings.Connection.Node = "Beta"
+	if names := preferredNodeNames(nodes, settings); len(names) != 0 {
+		t.Fatalf("expected a hidden node to be unavailable, got %v", names)
+	}
+}
+
+// A document-shaped subscription carries no share links, so there is nothing to
+// copy and the reason is worth saying.
+func TestCopyingANodeWithoutALinkExplainsItself(t *testing.T) {
+	app := hiddenNodesApp(t)
+	nodes := app.whiteVPNNodesSnapshot("sub-1")
+	for i := range nodes {
+		nodes[i].Link = ""
+	}
+	app.storeWhiteVPNNodes("sub-1", nodes, time.Now().UTC())
+
+	_, err := app.CopyNodeToManual("sub-1", "Alpha")
+	if err == nil {
+		t.Fatal("expected copying a node with no link to be refused")
+	}
+	if !contains(err.Error(), "configuration file") {
+		t.Fatalf("the reason should say why: %v", err)
+	}
+}
+
+func TestCopyingANodeAddsItToTheManualConfigs(t *testing.T) {
+	app := hiddenNodesApp(t)
+
+	if _, err := app.CopyNodeToManual("sub-1", "Alpha"); err != nil {
+		t.Fatal(err)
+	}
+	manual := app.manualProfiles()
+	if len(manual) != 1 {
+		t.Fatalf("expected one manual config, got %d", len(manual))
+	}
+	if manual[0].Server != "one.example.com" {
+		t.Fatalf("the wrong node was copied: %#v", manual[0])
+	}
+	// A copy is the user's own, so a refresh of the subscription cannot touch it.
+	if manual[0].SubscriptionID != "" {
+		t.Fatalf("a copied node should not belong to the subscription: %q", manual[0].SubscriptionID)
+	}
+}

--- a/desktop/whitevpn_nodes.go
+++ b/desktop/whitevpn_nodes.go
@@ -85,7 +85,26 @@ func (a *App) ListSubscriptionNodes(subscriptionID string, refresh bool) (model.
 	if subscriptionID == model.ManualServerSourceID {
 		a.attachManualProfileIDs(nodes)
 	}
+	a.markHiddenNodes(subscriptionID, nodes)
 	return a.storeWhiteVPNNodes(subscriptionID, nodes, time.Now().UTC()), nil
+}
+
+// markHiddenNodes flags the nodes the user has taken out of this subscription.
+//
+// Flagged rather than dropped: a node removed from the list could never be put
+// back, so hiding would be a one-way door with no way out of it.
+func (a *App) markHiddenNodes(subscriptionID string, nodes []model.WhiteVPNNode) {
+	hidden := a.hiddenNodeNames(subscriptionID)
+	if len(hidden) == 0 {
+		return
+	}
+	lookup := make(map[string]struct{}, len(hidden))
+	for _, name := range hidden {
+		lookup[name] = struct{}{}
+	}
+	for i := range nodes {
+		_, nodes[i].Hidden = lookup[nodes[i].Name]
+	}
 }
 
 // attachManualProfileIDs points each manually added node back at the profile it
@@ -400,9 +419,12 @@ func isFlagOnly(value string) bool {
 // the whole catalogue — a user who asked for Germany and silently got Japan has
 // been lied to about where their traffic goes.
 func preferredNodeNames(nodes []model.WhiteVPNNode, settings model.WhiteVPNSettings) []string {
+	// A hidden node is not in the configuration, so preferring one would name a
+	// node the engine does not hold and fail the connect with a confusing error
+	// about a choice matching nothing.
 	if node := strings.TrimSpace(settings.Connection.Node); node != "" {
 		for _, candidate := range nodes {
-			if candidate.Name == node {
+			if candidate.Name == node && !candidate.Hidden {
 				return []string{candidate.Name}
 			}
 		}
@@ -424,6 +446,9 @@ func preferredNodeNames(nodes []model.WhiteVPNNode, settings model.WhiteVPNSetti
 
 	names := make([]string, 0, len(nodes))
 	for _, candidate := range nodes {
+		if candidate.Hidden {
+			continue
+		}
 		if country != "" && candidate.CountryCode != country {
 			continue
 		}


### PR DESCRIPTION
Two changes that were on separate branches; this is both, cherry-picked onto
`main`. The two originals (`fix/tun-dns-leak`, `feat/subscription-node-copy-and-hide`)
are fully contained here and can be deleted.

## Keep DNS inside the tunnel

Tunnel mode leaked DNS; proxy mode did not, and that difference is the
explanation. Through a proxy the machine never resolves anything itself — it
hands the name to mihomo. In tunnel mode it resolves normally, and those
queries have to be caught.

`dns-hijack` was already set and is not enough: it catches what enters the
tunnel, and a query to the resolver on the local network never does. The route
to `192.168.0.0/16` is directly connected on the physical adapter and beats the
`0.0.0.0/1` pair the tunnel installs, so every lookup went to the home router in
the clear.

`strict-route: true` closes it — WFP filters on Windows blocking port 53 for
everything but the engine and the tunnel adapter, unreachable policy rules on
Linux, ignored on macOS. The Windows filters use `FWPM_SESSION_FLAG_DYNAMIC`, so
the kernel removes them when the engine exits, including on a kill; filters
outliving a crash would leave a machine unable to resolve anything.

Android does not set this and does not need to — `VpnService.addDnsServer` makes
the OS route every query into the tunnel. Second place after IPv6 containment
where copying the phone literally means shipping a leak.

## Servers page

**Actions column overlap** — it was `w-24`, sized for the two buttons a row had.
Edit and delete made four, needing 124px in 80px, so they spilled over the Speed
column. Mine to fix, from the previous change.

**Select all**, over what is on screen rather than the whole list: selecting
behind a filter would hand a test or a delete rows the user cannot see.

**Copy / hide for a subscription's nodes.** Editing one cannot work:
`RefreshV2RaySubscription` drops every profile a subscription produced and
re-imports with fresh ids from a timestamp, and document-shaped subscriptions
produce no profiles at all. So instead:

- *Copy to my configs* takes the node into the user's own list, where the edit
  form already applies. Needs a share link, which a mihomo-document subscription
  does not carry — same limitation the Share button has.
- *Hide* takes it out of the list and out of the engine's configuration, held by
  **name** because ids do not survive a refresh. Uses `session.Options.Exclude`
  rather than `Prefer`: Prefer would leave the node in the url-test group for the
  engine to pick, and would turn Automatic into an explicit selection, losing the
  group that makes Automatic work.

Hiding every node is refused. Nodes keep their place in the list carrying a flag
rather than being removed, so hiding is undoable.

## Verified

- The running engine accepts `strict-route` — spawned unelevated, `validateConfig`
  on a generated tun config, the same call the connect path makes.
- `TestRenderKeepsDNSInsideTheTunnel` pins the setting; if it reverts to false the
  leak returns and nothing else would notice.
- Backend tests for hide/copy, including that hiding survives a list refresh and
  that hidden nodes never reach the configuration.
- Frontend typecheck, full build.

**Not verified here:** that the DNS leak is gone end to end. That needs a tunnel
up on a real machine, which needs Administrator. Confirmed by the reporter on a
build carrying this change.

Two pre-existing test failures are unrelated and untouched:
`TestEnsureAppDataWritableRepairsDarwinWithAdministratorPrompt` (a macOS test run
on Windows) and `TestFindMihomoCoreExplainsItselfWhenAbsent`.