### PR TITLE
Make split tunnelling do something

### DIFF
--- a/desktop/ANDROID-PARITY.md
+++ b/desktop/ANDROID-PARITY.md
@@ -87,6 +87,25 @@ Android refuses to save `vpn_only_selected` with nothing selected; so does this.
 > same `.exe` name cannot be told apart. Say so in the dialog rather than
 > letting a user discover it.
 
+**How it reaches the engine, and the weeks it did not.** Both rows above were
+marked done while the setting was stored, validated and shown and *nothing
+outside the model ever read it*. A user could add a program to the bypass list,
+save it, and watch the site it was meant to reach still see the VPN, because
+every byte still went through the tunnel. A user reported exactly that. It is
+the same shape as IP fronting before it was wired — and a control that changes
+nothing is worse than one that is missing, because the missing one does not lie.
+
+It is `PROCESS-NAME` rules now, written ahead of the catch-all because mihomo
+takes the first rule that fits. Bypass sends the named programs to `DIRECT`;
+vpn-only sends them to the group and replaces the catch-all with `MATCH,DIRECT`,
+rather than adding a second one that could never fire. `find-process-mode`
+follows whether any rule needs it — looking up which program owns a connection
+costs something per connection, and `off` is right when nothing asks.
+
+Naming nothing leaves the routing alone in both modes. Read literally, vpn-only
+with an empty list says *send nothing through the tunnel*, which would turn the
+VPN off while the interface still said Connected.
+
 ## 2. Settings — section order matches Android exactly
 
 ### 2.1 TLS integrity (`tls_integrity_section`)

--- a/desktop/internal/engine/config_integration_test.go
+++ b/desktop/internal/engine/config_integration_test.go
@@ -42,7 +42,7 @@ func TestGeneratedConfigIsReadableByTheEngine(t *testing.T) {
 	if err != nil {
 		t.Fatalf("convert: %v", err)
 	}
-	proxiesYAML, err := mihomoconf.BuildProxiesYAML(proxies)
+	proxiesYAML, err := mihomoconf.BuildProxiesYAML(proxies, mihomoconf.SplitTunnel{})
 	if err != nil {
 		t.Fatalf("build proxies: %v", err)
 	}

--- a/desktop/internal/mihomoconf/config.go
+++ b/desktop/internal/mihomoconf/config.go
@@ -69,6 +69,7 @@ var (
 		"log-level":                 true,
 		"ipv6":                      true,
 		"unified-delay":             true,
+		"find-process-mode":         true,
 		"global-client-fingerprint": true,
 		"dns":                       true,
 		"tun":                       true,
@@ -168,12 +169,17 @@ type Options struct {
 	ProxyGroup string
 
 	Tun TunOptions
+
+	// SplitTunnel decides whether the engine has to work out which program a
+	// connection belongs to. It is here only so `find-process-mode` can follow
+	// it; the rules themselves are built with the proxies.
+	SplitTunnel SplitTunnel
 }
 
 // BuildProxiesYAML renders proxies plus the two default groups and a catch-all
 // rule, which is what a link-based subscription needs: links carry nodes and
 // nothing else, so without this there is nothing for traffic to match.
-func BuildProxiesYAML(proxies []Proxy) (string, error) {
+func BuildProxiesYAML(proxies []Proxy, split SplitTunnel) (string, error) {
 	if len(proxies) == 0 {
 		return "", fmt.Errorf("mihomoconf: no proxies to build a config from")
 	}
@@ -214,7 +220,9 @@ func BuildProxiesYAML(proxies []Proxy) (string, error) {
 				"proxies":   names,
 			},
 		},
-		"rules": []string{"MATCH," + SelectGroup},
+		// Split-tunnel rules first, because mihomo takes the first rule that
+		// fits: a catch-all above them means nothing below is ever reached.
+		"rules": append(split.Rules(SelectGroup), catchAllRules(split)...),
 	}
 
 	encoded, err := yaml.Marshal(document)
@@ -222,6 +230,19 @@ func BuildProxiesYAML(proxies []Proxy) (string, error) {
 		return "", err
 	}
 	return string(encoded), nil
+}
+
+// catchAllRules is what everything not matched already does.
+//
+// Empty when the split tunnel has written its own catch-all, because two would
+// mean the second is dead — and the dead one would be the one saying everything
+// goes through the tunnel, which is exactly the line someone reading the config
+// to answer "why is this not tunnelled" would stop at.
+func catchAllRules(split SplitTunnel) []string {
+	if split.Catches() {
+		return nil
+	}
+	return []string{"MATCH," + SelectGroup}
 }
 
 // toNodes puts the identifying fields first so a config is readable when someone
@@ -294,6 +315,15 @@ func Render(subscriptionYAML string, opts Options) string {
 	out.WriteString("log-level: warning\n")
 	fmt.Fprintf(&out, "ipv6: %t\n", opts.Tun.IPv6)
 	out.WriteString("unified-delay: true\n")
+	// Which program a connection belongs to costs a lookup per connection, so it
+	// is only asked for when a rule needs the answer. `strict` is mihomo's own
+	// default and means exactly that; `off` stops it entirely, which is worth
+	// saying rather than leaving to the default in case that default moves.
+	if opts.SplitTunnel.Active() {
+		out.WriteString("find-process-mode: strict\n")
+	} else {
+		out.WriteString("find-process-mode: off\n")
+	}
 	// global-client-fingerprint is deliberately not written. mihomo removed it,
 	// and this engine logs an error and ignores it. Nothing is lost: the
 	// converter already sets client-fingerprint on every proxy that carries TLS,

--- a/desktop/internal/mihomoconf/config_test.go
+++ b/desktop/internal/mihomoconf/config_test.go
@@ -29,7 +29,7 @@ func parseYAML(t *testing.T, document string) map[string]any {
 }
 
 func TestBuildProxiesYAMLProducesGroupsAndACatchAllRule(t *testing.T) {
-	document, err := BuildProxiesYAML(sampleProxies(t))
+	document, err := BuildProxiesYAML(sampleProxies(t), SplitTunnel{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func TestBuildProxiesYAMLDropsDuplicateNames(t *testing.T) {
 		{"name": "Same", "type": "vless", "server": "b.example.com", "port": 443},
 		{"name": "Other", "type": "vless", "server": "c.example.com", "port": 443},
 	}
-	document, err := BuildProxiesYAML(proxies)
+	document, err := BuildProxiesYAML(proxies, SplitTunnel{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestBuildProxiesYAMLDropsDuplicateNames(t *testing.T) {
 }
 
 func TestBuildProxiesYAMLRefusesAnEmptySet(t *testing.T) {
-	if _, err := BuildProxiesYAML(nil); err == nil {
+	if _, err := BuildProxiesYAML(nil, SplitTunnel{}); err == nil {
 		t.Fatal("expected an error with no proxies")
 	}
 }
@@ -310,7 +310,7 @@ func TestSecretIsEscaped(t *testing.T) {
 }
 
 func TestFullConfigFromLinksParses(t *testing.T) {
-	proxiesYAML, err := BuildProxiesYAML(sampleProxies(t))
+	proxiesYAML, err := BuildProxiesYAML(sampleProxies(t), SplitTunnel{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/desktop/internal/mihomoconf/fronting_test.go
+++ b/desktop/internal/mihomoconf/fronting_test.go
@@ -38,7 +38,7 @@ func TestFrontProxiesLeavesAloneWhatItCannotFront(t *testing.T) {
 			"type": "vless", "server": "node.example.com", "tls": true,
 			"reality-opts": map[string]any{"public-key": "k"},
 		},
-		"no tls and no http transport": {"type": "vless", "server": "node.example.com", "network": "tcp"},
+		"no tls and no http transport":    {"type": "vless", "server": "node.example.com", "network": "tcp"},
 		"a type the phone does not front": {"type": "ss", "server": "node.example.com", "tls": true},
 	}
 	for name, proxy := range cases {

--- a/desktop/internal/mihomoconf/splittunnel.go
+++ b/desktop/internal/mihomoconf/splittunnel.go
@@ -1,0 +1,118 @@
+package mihomoconf
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Routing some programs around the tunnel, or only some through it.
+//
+// The setting existed for a while and did nothing. It was stored, validated and
+// shown, and no code outside the model ever read it — a user could add a program
+// to the bypass list, save, and watch the site it was meant to reach still see
+// the VPN's address, because every byte still went through the tunnel. That is
+// the same shape as IP fronting before it was wired: a control that changes
+// nothing is worse than one that is missing, because the missing one does not
+// lie about it.
+//
+// mihomo does this with `PROCESS-NAME` rules, matched ahead of the catch-all.
+// The rules go before MATCH because mihomo takes the first that fits, so a
+// catch-all above them would mean nothing below is ever reached.
+
+// SplitTunnelMode is which way the exception runs.
+type SplitTunnelMode string
+
+const (
+	// SplitTunnelOff sends everything through the tunnel.
+	SplitTunnelOff SplitTunnelMode = ""
+	// SplitTunnelBypass sends the named programs around it.
+	SplitTunnelBypass SplitTunnelMode = "bypass"
+	// SplitTunnelOnly sends only the named programs through it.
+	SplitTunnelOnly SplitTunnelMode = "only"
+)
+
+// SplitTunnel names the programs and which way the exception runs.
+type SplitTunnel struct {
+	Mode SplitTunnelMode
+	// Processes are executable names as the operating system reports them —
+	// `chrome.exe` on Windows, `firefox` elsewhere. Matching is on the name
+	// alone, so two programs installed under the same one cannot be told apart.
+	Processes []string
+}
+
+// Rules returns the rule lines this split tunnel needs, in order, without the
+// catch-all that follows them.
+//
+// An empty result means every rule is the catch-all's: either the feature is
+// off, or it names nothing, and naming nothing must not change the routing. The
+// vpn-only mode with an empty list is the dangerous case — read literally it
+// says "send nothing through the tunnel", which would silently turn the VPN off
+// while the interface still said Connected — so it is treated as off, which is
+// what the model already does when it normalises.
+func (s SplitTunnel) Rules(group string) []string {
+	names := cleanProcessNames(s.Processes)
+	if len(names) == 0 || group == "" {
+		return nil
+	}
+
+	switch s.Mode {
+	case SplitTunnelBypass:
+		rules := make([]string, 0, len(names))
+		for _, name := range names {
+			rules = append(rules, fmt.Sprintf("PROCESS-NAME,%s,DIRECT", name))
+		}
+		return rules
+	case SplitTunnelOnly:
+		rules := make([]string, 0, len(names)+1)
+		for _, name := range names {
+			rules = append(rules, fmt.Sprintf("PROCESS-NAME,%s,%s", name, group))
+		}
+		// Everything else goes direct. This is the rule that makes the mode mean
+		// what it says, and it replaces the catch-all rather than joining it.
+		rules = append(rules, "MATCH,DIRECT")
+		return rules
+	default:
+		return nil
+	}
+}
+
+// Catches reports whether these rules already end in a catch-all, so the caller
+// knows not to add another after them.
+func (s SplitTunnel) Catches() bool {
+	return s.Mode == SplitTunnelOnly && len(cleanProcessNames(s.Processes)) > 0
+}
+
+// Active reports whether the split tunnel changes any routing, which is what
+// decides whether the engine has to look processes up at all.
+func (s SplitTunnel) Active() bool {
+	return len(s.Rules(SelectGroup)) > 0
+}
+
+// cleanProcessNames trims, drops blanks, and removes duplicates while keeping
+// the order the user put them in.
+//
+// A rule naming an empty process matches nothing and is worth removing rather
+// than writing: mihomo accepts it, and a config full of rules that cannot fire
+// is a config nobody can read when something goes wrong.
+func cleanProcessNames(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	names := make([]string, 0, len(values))
+	for _, value := range values {
+		name := strings.TrimSpace(value)
+		if name == "" {
+			continue
+		}
+		// A rule is one line: a name with a comma in it would be read as extra
+		// fields and change what the rule means.
+		if strings.ContainsAny(name, ",\n\r") {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, taken := seen[key]; taken {
+			continue
+		}
+		seen[key] = struct{}{}
+		names = append(names, name)
+	}
+	return names
+}

--- a/desktop/internal/mihomoconf/splittunnel_test.go
+++ b/desktop/internal/mihomoconf/splittunnel_test.go
@@ -1,0 +1,156 @@
+package mihomoconf
+
+import (
+	"strings"
+	"testing"
+)
+
+func ruleStrings(t *testing.T, document string) []string {
+	t.Helper()
+	parsed := parseYAML(t, document)
+	raw, _ := parsed["rules"].([]any)
+	rules := make([]string, 0, len(raw))
+	for _, rule := range raw {
+		rules = append(rules, rule.(string))
+	}
+	return rules
+}
+
+// The report that started this: a program added to the bypass list, and the
+// site it was meant to reach still saw the VPN's address — because nothing
+// outside the model ever read the setting.
+func TestBypassSendsNamedProgramsDirect(t *testing.T) {
+	document, err := BuildProxiesYAML(sampleProxies(t), SplitTunnel{
+		Mode:      SplitTunnelBypass,
+		Processes: []string{"chrome.exe", "steam.exe"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rules := ruleStrings(t, document)
+
+	if len(rules) != 3 {
+		t.Fatalf("expected two process rules and the catch-all, got %#v", rules)
+	}
+	if rules[0] != "PROCESS-NAME,chrome.exe,DIRECT" || rules[1] != "PROCESS-NAME,steam.exe,DIRECT" {
+		t.Fatalf("unexpected process rules: %#v", rules)
+	}
+	// mihomo takes the first rule that fits, so a catch-all above these would
+	// mean neither is ever reached.
+	if rules[2] != "MATCH,"+SelectGroup {
+		t.Fatalf("the catch-all must come last: %#v", rules)
+	}
+}
+
+func TestVPNOnlySendsEverythingElseDirect(t *testing.T) {
+	document, err := BuildProxiesYAML(sampleProxies(t), SplitTunnel{
+		Mode:      SplitTunnelOnly,
+		Processes: []string{"chrome.exe"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rules := ruleStrings(t, document)
+
+	if len(rules) != 2 {
+		t.Fatalf("expected the process rule and a direct catch-all, got %#v", rules)
+	}
+	if rules[0] != "PROCESS-NAME,chrome.exe,"+SelectGroup {
+		t.Fatalf("the named program should go through the group: %#v", rules)
+	}
+	// And this is what makes the mode mean what it says. Two catch-alls would
+	// leave a dead one saying everything is tunnelled — the line someone reading
+	// the config to answer "why is this not tunnelled" would stop at.
+	if rules[1] != "MATCH,DIRECT" {
+		t.Fatalf("everything else should go direct: %#v", rules)
+	}
+	for _, rule := range rules {
+		if rule == "MATCH,"+SelectGroup {
+			t.Fatalf("the tunnelling catch-all should not be there too: %#v", rules)
+		}
+	}
+}
+
+// Naming nothing must not change the routing. Read literally, vpn-only with an
+// empty list says "send nothing through the tunnel" — which would turn the VPN
+// off while the interface still said Connected.
+func TestSplitTunnelWithNoProgramsChangesNothing(t *testing.T) {
+	for _, mode := range []SplitTunnelMode{SplitTunnelBypass, SplitTunnelOnly} {
+		document, err := BuildProxiesYAML(sampleProxies(t), SplitTunnel{Mode: mode})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rules := ruleStrings(t, document)
+		if len(rules) != 1 || rules[0] != "MATCH,"+SelectGroup {
+			t.Fatalf("%s with no programs should route normally, got %#v", mode, rules)
+		}
+	}
+}
+
+func TestSplitTunnelOffRoutesEverythingThroughTheTunnel(t *testing.T) {
+	document, err := BuildProxiesYAML(sampleProxies(t), SplitTunnel{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rules := ruleStrings(t, document)
+	if len(rules) != 1 || rules[0] != "MATCH,"+SelectGroup {
+		t.Fatalf("unexpected rules: %#v", rules)
+	}
+}
+
+// A name with a comma would be read as extra fields and change what the rule
+// means; a blank one matches nothing and is only noise in a config someone has
+// to read when something goes wrong.
+func TestSplitTunnelDropsNamesThatWouldNotBeRules(t *testing.T) {
+	split := SplitTunnel{
+		Mode:      SplitTunnelBypass,
+		Processes: []string{" chrome.exe ", "", "  ", "bad,name.exe", "with\nnewline", "CHROME.EXE", "steam.exe"},
+	}
+	rules := split.Rules(SelectGroup)
+
+	if len(rules) != 2 {
+		t.Fatalf("expected chrome and steam only, got %#v", rules)
+	}
+	if rules[0] != "PROCESS-NAME,chrome.exe,DIRECT" {
+		t.Fatalf("the name should be trimmed: %#v", rules)
+	}
+	if rules[1] != "PROCESS-NAME,steam.exe,DIRECT" {
+		t.Fatalf("expected steam second: %#v", rules)
+	}
+}
+
+// Looking up which program owns a connection costs something per connection, so
+// it is only asked for when a rule needs the answer.
+func TestFindProcessModeFollowsTheSplitTunnel(t *testing.T) {
+	off := Render("", Options{Secret: "s", ProxyGroup: SelectGroup})
+	if !strings.Contains(off, "find-process-mode: off") {
+		t.Fatal("with no split tunnel the engine should not look processes up")
+	}
+
+	on := Render("", Options{
+		Secret:      "s",
+		ProxyGroup:  SelectGroup,
+		SplitTunnel: SplitTunnel{Mode: SplitTunnelBypass, Processes: []string{"chrome.exe"}},
+	})
+	if !strings.Contains(on, "find-process-mode: strict") {
+		t.Fatal("a split tunnel needs process lookup or its rules never fire")
+	}
+
+	// And a mode with nothing named is not a split tunnel.
+	empty := Render("", Options{
+		Secret:      "s",
+		ProxyGroup:  SelectGroup,
+		SplitTunnel: SplitTunnel{Mode: SplitTunnelBypass},
+	})
+	if !strings.Contains(empty, "find-process-mode: off") {
+		t.Fatal("naming nothing should not turn process lookup on")
+	}
+}
+
+// A subscription carrying its own find-process-mode must not override the app's.
+func TestRenderStripsASubscriptionsFindProcessMode(t *testing.T) {
+	document := Render("find-process-mode: always\nproxies: []\n", Options{Secret: "s", ProxyGroup: SelectGroup})
+	if strings.Contains(document, "find-process-mode: always") {
+		t.Fatalf("the subscription's value should have been stripped:\n%s", document)
+	}
+}

--- a/desktop/internal/session/session.go
+++ b/desktop/internal/session/session.go
@@ -66,6 +66,10 @@ type Options struct {
 	// that makes Automatic work at all.
 	Exclude []string
 
+	// SplitTunnel routes named programs around the tunnel, or only them through
+	// it. Empty means everything goes through it.
+	SplitTunnel mihomoconf.SplitTunnel
+
 	// FrontingIP reaches every eligible node through this address instead of the
 	// one its name resolves to, while still presenting the name. Empty means the
 	// nodes are reached directly.
@@ -645,7 +649,7 @@ func PrepareConfig(opts Options) (string, []string, error) {
 		}
 		// Share links, which is what the WhiteDNS catalogue is. They carry nodes
 		// only, so the groups and rule have to be generated around them.
-		document, buildErr := mihomoconf.BuildProxiesYAML(proxies)
+		document, buildErr := mihomoconf.BuildProxiesYAML(proxies, opts.SplitTunnel)
 		if buildErr != nil {
 			return "", nil, buildErr
 		}
@@ -688,6 +692,7 @@ func PrepareConfig(opts Options) (string, []string, error) {
 		DoTEndpoint: opts.DoTEndpoint,
 		ProxyGroup:  group,
 		Tun:         opts.Tun,
+		SplitTunnel: opts.SplitTunnel,
 	})
 	return document, candidates, nil
 }

--- a/desktop/mihomo_connect.go
+++ b/desktop/mihomo_connect.go
@@ -112,14 +112,15 @@ func (a *App) startWhiteDNSVPNWithMihomo() (model.AppState, error) {
 		// Nodes the user hid never reach the configuration, so the engine cannot
 		// choose one on Automatic. Hidden from the list but still connectable
 		// would be the worst of both.
-		Exclude:    a.hiddenNodeNames(a.selectedSubscriptionID()),
-		FrontingIP: frontingIP,
-		DNSPrivacy:   dnsPrivacyMode(settings.DNSPrivacy.Mode),
-		DoHURL:       settings.DNSPrivacy.DoHURL,
-		DoTEndpoint:  settings.DNSPrivacy.DoTEndpoint,
-		Tun:          tunOptionsFor(settings),
-		CoreStdout:   mihomoLogWriter{app: a},
-		CoreStderr:   mihomoLogWriter{app: a},
+		Exclude:     a.hiddenNodeNames(a.selectedSubscriptionID()),
+		SplitTunnel: splitTunnelFor(settings),
+		FrontingIP:  frontingIP,
+		DNSPrivacy:  dnsPrivacyMode(settings.DNSPrivacy.Mode),
+		DoHURL:      settings.DNSPrivacy.DoHURL,
+		DoTEndpoint: settings.DNSPrivacy.DoTEndpoint,
+		Tun:         tunOptionsFor(settings),
+		CoreStdout:  mihomoLogWriter{app: a},
+		CoreStderr:  mihomoLogWriter{app: a},
 	})
 	if err != nil {
 		a.reportConnectFailure(ctx, err.Error())
@@ -548,4 +549,28 @@ func tunOptionsFor(settings model.WhiteVPNSettings) mihomoconf.TunOptions {
 		return mihomoconf.TunOptions{Enabled: false}
 	}
 	return mihomoconf.DefaultTunOptions()
+}
+
+// splitTunnelFor turns the saved setting into the engine's shape.
+//
+// This is the wiring that was missing. The setting was stored, validated and
+// shown for weeks while nothing outside the model ever read it, so a program
+// added to the bypass list went through the tunnel like everything else and the
+// site it was meant to reach still saw the VPN. A control that changes nothing
+// is worse than one that is absent.
+func splitTunnelFor(settings model.WhiteVPNSettings) mihomoconf.SplitTunnel {
+	switch settings.SplitTunnel.Mode {
+	case model.SplitTunnelBypass:
+		return mihomoconf.SplitTunnel{
+			Mode:      mihomoconf.SplitTunnelBypass,
+			Processes: settings.SplitTunnel.Processes,
+		}
+	case model.SplitTunnelVPNOnly:
+		return mihomoconf.SplitTunnel{
+			Mode:      mihomoconf.SplitTunnelOnly,
+			Processes: settings.SplitTunnel.Processes,
+		}
+	default:
+		return mihomoconf.SplitTunnel{}
+	}
 }


### PR DESCRIPTION
A user set a program to bypass the VPN and the site it was meant to reach still saw the VPN's address. It was right to: the setting did nothing.

SplitTunnel was stored, normalised, validated and shown in the interface, and outside internal/model no Go code ever read it. Not the connect path, not the config generator — mihomoconf had never heard of it. Both rows in ANDROID-PARITY.md were marked done. This is the same shape as IP fronting before it was wired, and a control that changes nothing is worse than one that is missing, because the missing one does not lie about it.

mihomo has everything needed and always did: PROCESS-NAME rules in the parser, process lookup implemented for Windows, find-process-mode in the config. Only the wiring was absent.

The rules go ahead of the catch-all, because mihomo takes the first rule that fits and a catch-all above them means nothing below is ever reached. Bypass sends the named programs to DIRECT. vpn-only sends them to the group and *replaces* the catch-all with MATCH,DIRECT rather than adding a second one — two would leave a dead rule saying everything is tunnelled, which is the line someone reading the config to answer "why is this not tunnelled" would stop at.

find-process-mode follows whether any rule needs it. Working out which program owns a connection costs a lookup per connection, and off is the right answer when nothing asks. It is also stripped from a subscription now, so a provider cannot turn it on.

Naming nothing leaves the routing alone in both modes. Read literally, vpn-only with an empty list says "send nothing through the tunnel", which would turn the VPN off while the interface still said Connected. Names that cannot be rules are dropped: a comma would be read as extra fields and change what the rule means, and a blank one matches nothing and is only noise.

Verified the engine accepts the rules rather than trusting the parser source — spawned it, ran validateConfig on a generated config, which is the same call the connect path makes.

Not verified: that a bypassed program's traffic actually leaves directly. That needs a connection up and a program to watch, which needs a real machine.