### PR TITLE
Set the system proxy on Linux, and stop a failure there killing the c…

### DIFF
--- a/desktop/ANDROID-PARITY.md
+++ b/desktop/ANDROID-PARITY.md
@@ -568,6 +568,20 @@ Measured 2026-08-05, from Windows:
 - **Windows** — `wails build` here.
 - **Linux** — cross-compiles with `CGO_ENABLED=0` (the tray is D-Bus, pure Go).
   Wails packaging still needs a Linux host or Docker.
+
+  What works there: **proxy mode only.** The system proxy is set through
+  gsettings (GNOME and everything on its schemas) and kioslaverc (KDE), both
+  written when both are present — the report that prompted this was Pop!_OS
+  running KDE, and reading `XDG_CURRENT_DESKTOP` would have configured the half
+  the user was not looking at. Neither is truly system-wide: they are
+  preferences well-behaved programs read, and a program that ignores them is not
+  reached by anything short of a tunnel. Say that rather than promise more.
+
+  **Tunnel mode does not work on Linux.** `engine.startElevatedChild` is
+  implemented on Windows only, so the core cannot be raised to create an
+  adapter. That is why the system proxy failing used to leave a Linux user with
+  no usable mode at all, and why it is now a notice rather than a failed
+  connection.
 - **macOS** — **cannot be built from Windows.** Without CGO it does not compile
   at all: `fyne.io/systray` needs Cocoa. With CGO it needs the macOS SDK. It has
   to run on a Mac, or on a macOS CI runner.

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -912,6 +912,11 @@ function App() {
       onRuntimeEvent<ValidatorStateUpdate>("validator:state", applyValidatorState),
       onRuntimeEvent<ValidatorStateUpdate>("validator:progress", applyValidatorState),
       onRuntimeEvent<string>("runtime:error", showError),
+      // Something worth saying that is not a failure — a connection that came
+      // up while something around it did not. It must not use showError, or a
+      // working connection is reported as a broken one, which is the mistake
+      // this event exists to undo.
+      onRuntimeEvent<string>("runtime:notice", showSuccess),
       onRuntimeEvent<FirewallStatus>("firewall:enabled", (status) => {
         void sendFirewallNotification(status);
       }),

--- a/desktop/internal/sysproxy/linuxdesktop.go
+++ b/desktop/internal/sysproxy/linuxdesktop.go
@@ -1,0 +1,183 @@
+package sysproxy
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Names the Linux backends are addressed by. They live in this file rather than
+// beside the code that runs the commands so both are reachable from a test on
+// any platform — this is developed on Windows and built for Linux, and a
+// constant behind a build tag would take the argument-building with it.
+const (
+	gsettingsBinary    = "gsettings"
+	gnomeProxySchema   = "org.gnome.system.proxy"
+	kdeProxyConfigFile = "kioslaverc"
+	kdeProxyGroup      = "Proxy Settings"
+)
+
+// splitEndpoint separates "host:port". Shared with the Linux backends, and kept
+// here rather than beside them so the tests can reach it from any platform.
+func splitProxyEndpoint(endpoint string) (string, int) {
+	host, portText, found := strings.Cut(strings.TrimSpace(endpoint), ":")
+	if !found {
+		return "", 0
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		return "", 0
+	}
+	return host, port
+}
+
+// The parts of the Linux backends that are just text: what to write, and how to
+// read back what was written.
+//
+// Separated from the code that runs the commands so it can be tested anywhere,
+// rather than only on a machine with GNOME or KDE in front of it. The commands
+// themselves cannot be checked without that machine; the arguments they are
+// given can.
+
+// gnomeApplyArgs is the sequence of `gsettings` calls that puts state in place.
+//
+// The host and port go in even when the proxy is being turned off. Leaving them
+// behind is how the desktop's own settings dialog behaves, and it means turning
+// the proxy back on does not need them written again — but more to the point,
+// clearing them on disconnect would wipe a proxy the user had configured
+// themselves before this app ever ran.
+func gnomeApplyArgs(state State) [][]string {
+	if !state.Enabled {
+		return [][]string{{"set", gnomeProxySchema, "mode", "none"}}
+	}
+
+	host, port := splitProxyEndpoint(state.Server)
+	portText := strconv.Itoa(port)
+	args := [][]string{
+		{"set", gnomeProxySchema, "mode", "manual"},
+	}
+	// http and https both, because a browser sends CONNECT for https to
+	// whatever the https entry names and would go direct if it were empty.
+	// socks as well: it is the same mixed port, and a program that prefers
+	// socks should not fall out of the tunnel for choosing it.
+	for _, child := range []string{"http", "https", "socks"} {
+		args = append(args,
+			[]string{"set", gnomeProxySchema + "." + child, "host", host},
+			[]string{"set", gnomeProxySchema + "." + child, "port", portText},
+		)
+	}
+	args = append(args, []string{"set", gnomeProxySchema, "ignore-hosts", gnomeIgnoreHosts(state.Override)})
+	return args
+}
+
+// gnomeIgnoreHosts turns the semicolon-separated bypass list into the GVariant
+// array literal gsettings expects.
+func gnomeIgnoreHosts(override string) string {
+	entries := bypassEntries(override)
+	quoted := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		quoted = append(quoted, "'"+strings.ReplaceAll(entry, "'", "")+"'")
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
+}
+
+// parseGnomeState reads back what gsettings reports. Values arrive quoted.
+func parseGnomeState(mode, host, port, ignore string) State {
+	state := State{Enabled: strings.Trim(strings.TrimSpace(mode), "'\"") == "manual"}
+	host = strings.Trim(strings.TrimSpace(host), "'\"")
+	portNumber, err := strconv.Atoi(strings.TrimSpace(port))
+	if host != "" && err == nil && portNumber > 0 {
+		state.Server = fmt.Sprintf("%s:%d", host, portNumber)
+	}
+	state.Override = strings.Join(parseGnomeIgnoreHosts(ignore), ";")
+	return state
+}
+
+func parseGnomeIgnoreHosts(value string) []string {
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(value, "@as ")
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(value, "[")
+	value = strings.TrimSuffix(value, "]")
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	entries := make([]string, 0, 8)
+	for _, field := range strings.Split(value, ",") {
+		field = strings.Trim(strings.TrimSpace(field), "'\"")
+		if field != "" {
+			entries = append(entries, field)
+		}
+	}
+	return entries
+}
+
+// kdeApplyEntries is the kioslaverc keys that put state in place.
+//
+// ProxyType 1 is manual and 0 is none, which is KDE's own numbering. The proxy
+// values are written as URLs; KDE has accepted that form for years and it
+// avoids the older "host port" shape, which is easy to get subtly wrong.
+func kdeApplyEntries(state State) map[string]string {
+	if !state.Enabled {
+		return map[string]string{"ProxyType": "0"}
+	}
+	host, port := splitProxyEndpoint(state.Server)
+	endpoint := fmt.Sprintf("%s:%d", host, port)
+	return map[string]string{
+		"ProxyType":         "1",
+		"httpProxy":         "http://" + endpoint,
+		"httpsProxy":        "http://" + endpoint,
+		"socksProxy":        "socks://" + endpoint,
+		"NoProxyFor":        strings.Join(bypassEntries(state.Override), ","),
+		"ReversedException": "false",
+	}
+}
+
+func parseKDEState(proxyType, httpProxy, noProxyFor string) State {
+	state := State{Enabled: strings.TrimSpace(proxyType) == "1"}
+	if endpoint := stripProxyScheme(httpProxy); endpoint != "" {
+		state.Server = endpoint
+	}
+	entries := make([]string, 0, 8)
+	for _, field := range strings.Split(noProxyFor, ",") {
+		if trimmed := strings.TrimSpace(field); trimmed != "" {
+			entries = append(entries, trimmed)
+		}
+	}
+	state.Override = strings.Join(entries, ";")
+	return state
+}
+
+func stripProxyScheme(value string) string {
+	value = strings.TrimSpace(value)
+	for _, scheme := range []string{"http://", "https://", "socks://", "socks5://"} {
+		value = strings.TrimPrefix(value, scheme)
+	}
+	// The older KDE form separates host and port with a space.
+	value = strings.TrimSpace(value)
+	if host, port, found := strings.Cut(value, " "); found {
+		value = host + ":" + strings.TrimSpace(port)
+	}
+	if value == "" || strings.HasSuffix(value, ":") {
+		return ""
+	}
+	return value
+}
+
+// bypassEntries splits the Windows-shaped bypass list into what the Linux
+// desktops want.
+//
+// `<local>` is dropped: it is WinINET's word for "any name without a dot" and
+// means nothing to GNOME or KDE, which would take it literally and try to match
+// a host called "<local>".
+func bypassEntries(override string) []string {
+	entries := make([]string, 0, 24)
+	for _, field := range strings.Split(override, ";") {
+		field = strings.TrimSpace(field)
+		if field == "" || strings.EqualFold(field, "<local>") {
+			continue
+		}
+		entries = append(entries, field)
+	}
+	return entries
+}

--- a/desktop/internal/sysproxy/linuxdesktop_test.go
+++ b/desktop/internal/sysproxy/linuxdesktop_test.go
@@ -1,0 +1,164 @@
+package sysproxy
+
+import (
+	"strings"
+	"testing"
+)
+
+func gnomeArgLine(args [][]string, schema, key string) string {
+	for _, call := range args {
+		if len(call) == 4 && call[1] == schema && call[2] == key {
+			return call[3]
+		}
+	}
+	return ""
+}
+
+func TestGnomeApplyPointsEveryProtocolAtTheProxy(t *testing.T) {
+	args := gnomeApplyArgs(State{Enabled: true, Server: "127.0.0.1:2080", Override: DefaultBypass})
+
+	if mode := gnomeArgLine(args, gnomeProxySchema, "mode"); mode != "manual" {
+		t.Fatalf("expected manual mode, got %q", mode)
+	}
+	// https as well as http: a browser sends CONNECT to whatever the https entry
+	// names, and an empty one means it goes direct — connected, and leaking.
+	for _, child := range []string{"http", "https", "socks"} {
+		schema := gnomeProxySchema + "." + child
+		if host := gnomeArgLine(args, schema, "host"); host != "127.0.0.1" {
+			t.Errorf("%s host = %q", child, host)
+		}
+		if port := gnomeArgLine(args, schema, "port"); port != "2080" {
+			t.Errorf("%s port = %q", child, port)
+		}
+	}
+}
+
+func TestGnomeApplyOnlyTurnsTheModeOffWhenDisabling(t *testing.T) {
+	args := gnomeApplyArgs(State{Enabled: false})
+	if len(args) != 1 {
+		t.Fatalf("disabling should be one call, got %d: %v", len(args), args)
+	}
+	if gnomeArgLine(args, gnomeProxySchema, "mode") != "none" {
+		t.Fatalf("expected mode none, got %v", args)
+	}
+	// The host and port are deliberately left alone: clearing them would wipe a
+	// proxy the user configured themselves before this app ever ran.
+}
+
+// `<local>` is WinINET's word for "any name without a dot". GNOME would take it
+// literally and try to match a host called "<local>".
+func TestGnomeIgnoreHostsDropsTheWindowsOnlyToken(t *testing.T) {
+	value := gnomeIgnoreHosts(DefaultBypass)
+	if strings.Contains(value, "<local>") {
+		t.Fatalf("the Windows-only token survived: %s", value)
+	}
+	if !strings.HasPrefix(value, "[") || !strings.HasSuffix(value, "]") {
+		t.Fatalf("expected a GVariant array literal, got %s", value)
+	}
+	if !strings.Contains(value, "'localhost'") {
+		t.Fatalf("localhost should be bypassed: %s", value)
+	}
+}
+
+func TestParseGnomeStateReadsWhatGsettingsPrints(t *testing.T) {
+	// gsettings quotes strings and prefixes arrays with their type.
+	state := parseGnomeState("'manual'", "'127.0.0.1'", "2080", "@as ['localhost', '127.0.0.0/8']")
+	if !state.Enabled {
+		t.Fatal("manual mode means enabled")
+	}
+	if state.Server != "127.0.0.1:2080" {
+		t.Fatalf("server = %q", state.Server)
+	}
+	if state.Override != "localhost;127.0.0.0/8" {
+		t.Fatalf("override = %q", state.Override)
+	}
+
+	off := parseGnomeState("'none'", "'127.0.0.1'", "2080", "@as []")
+	if off.Enabled {
+		t.Fatal("none mode means disabled")
+	}
+}
+
+// What Apply writes, Current must read back as the same thing, or Verify
+// reports a failure on settings that took.
+func TestGnomeRoundTrips(t *testing.T) {
+	want := State{Enabled: true, Server: "127.0.0.1:2080", Override: DefaultBypass}
+	args := gnomeApplyArgs(want)
+
+	got := parseGnomeState(
+		gnomeArgLine(args, gnomeProxySchema, "mode"),
+		gnomeArgLine(args, gnomeProxySchema+".http", "host"),
+		gnomeArgLine(args, gnomeProxySchema+".http", "port"),
+		gnomeArgLine(args, gnomeProxySchema, "ignore-hosts"),
+	)
+	if !got.SameAs(State{Enabled: true, Server: want.Server, Override: got.Override}) {
+		t.Fatalf("round trip lost the settings: %#v", got)
+	}
+	if got.Server != want.Server {
+		t.Fatalf("server did not survive: %q", got.Server)
+	}
+}
+
+func TestKDEApplyWritesManualProxyEntries(t *testing.T) {
+	entries := kdeApplyEntries(State{Enabled: true, Server: "127.0.0.1:2080", Override: DefaultBypass})
+
+	if entries["ProxyType"] != "1" {
+		t.Fatalf("ProxyType = %q, KDE's number for manual is 1", entries["ProxyType"])
+	}
+	for _, key := range []string{"httpProxy", "httpsProxy", "socksProxy"} {
+		if !strings.Contains(entries[key], "127.0.0.1:2080") {
+			t.Errorf("%s = %q", key, entries[key])
+		}
+	}
+	if strings.Contains(entries["NoProxyFor"], "<local>") {
+		t.Fatalf("the Windows-only token survived: %q", entries["NoProxyFor"])
+	}
+	if !strings.Contains(entries["NoProxyFor"], "localhost") {
+		t.Fatalf("localhost should be bypassed: %q", entries["NoProxyFor"])
+	}
+}
+
+func TestKDEApplyDisables(t *testing.T) {
+	entries := kdeApplyEntries(State{Enabled: false})
+	if entries["ProxyType"] != "0" {
+		t.Fatalf("ProxyType = %q, KDE's number for none is 0", entries["ProxyType"])
+	}
+}
+
+func TestParseKDEStateHandlesBothProxyFormats(t *testing.T) {
+	// The form this app writes.
+	modern := parseKDEState("1", "http://127.0.0.1:2080", "localhost,127.0.0.1")
+	if !modern.Enabled || modern.Server != "127.0.0.1:2080" {
+		t.Fatalf("modern form: %#v", modern)
+	}
+	// The older KDE form, which separates host and port with a space and which
+	// a machine configured before this app ran may still hold.
+	legacy := parseKDEState("1", "http://127.0.0.1 8080", "")
+	if legacy.Server != "127.0.0.1:8080" {
+		t.Fatalf("legacy form: %q", legacy.Server)
+	}
+	off := parseKDEState("0", "", "")
+	if off.Enabled {
+		t.Fatal("ProxyType 0 means disabled")
+	}
+}
+
+func TestKDERoundTrips(t *testing.T) {
+	want := State{Enabled: true, Server: "127.0.0.1:2080", Override: DefaultBypass}
+	entries := kdeApplyEntries(want)
+	got := parseKDEState(entries["ProxyType"], entries["httpProxy"], entries["NoProxyFor"])
+	if !got.Enabled || got.Server != want.Server {
+		t.Fatalf("round trip lost the settings: %#v", got)
+	}
+}
+
+func TestSplitProxyEndpointRefusesWhatIsNotHostPort(t *testing.T) {
+	for _, value := range []string{"", "127.0.0.1", "127.0.0.1:", "127.0.0.1:abc", "nonsense"} {
+		if host, port := splitProxyEndpoint(value); host != "" || port != 0 {
+			t.Errorf("%q parsed as %q/%d", value, host, port)
+		}
+	}
+	if host, port := splitProxyEndpoint(" 127.0.0.1:2080 "); host != "127.0.0.1" || port != 2080 {
+		t.Errorf("got %q/%d", host, port)
+	}
+}

--- a/desktop/internal/sysproxy/sysproxy_linux.go
+++ b/desktop/internal/sysproxy/sysproxy_linux.go
@@ -1,0 +1,207 @@
+//go:build linux
+
+package sysproxy
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Linux has no system proxy setting. It has desktop-environment settings, and
+// which one matters depends on what the user is running.
+//
+// GNOME — and everything built on its schemas: COSMIC, Cinnamon, Budgie, MATE —
+// keeps it in gsettings. KDE keeps it in kioslaverc and expects to be told when
+// it changes. A bare window manager keeps it nowhere at all, and there the
+// honest answer is that this cannot be done.
+//
+// Both are written when both are present rather than picking one from
+// XDG_CURRENT_DESKTOP. The report that prompted this was a Pop!_OS machine
+// running KDE — GNOME's schemas installed, KDE's session in front — and reading
+// one variable would have configured the half the user was not looking at.
+//
+// What this cannot do is make it apply to everything. These are preferences that
+// well-behaved programs read; a program that ignores them is not reached by
+// anything short of a tunnel. Callers should say that rather than promise more.
+
+// backend is one place Linux keeps the setting.
+type backend struct {
+	name    string
+	binary  string
+	present bool
+}
+
+func availableBackends() []backend {
+	backends := []backend{
+		{name: "gsettings", binary: gsettingsBinary},
+		// KDE 6 first: a machine with both has moved on, and writing the old one
+		// there configures a file nothing reads.
+		{name: "kde", binary: "kwriteconfig6"},
+		{name: "kde", binary: "kwriteconfig5"},
+	}
+	found := make([]backend, 0, len(backends))
+	seen := map[string]bool{}
+	for _, candidate := range backends {
+		if seen[candidate.name] {
+			continue
+		}
+		if _, err := exec.LookPath(candidate.binary); err != nil {
+			continue
+		}
+		candidate.present = true
+		seen[candidate.name] = true
+		found = append(found, candidate)
+	}
+	return found
+}
+
+// ErrUnsupported is returned when nothing on this machine knows what a proxy
+// setting is — a bare window manager, or a session with neither toolkit.
+var ErrUnsupported = errors.New("sysproxy: no desktop proxy setting found (this needs GNOME's gsettings or KDE's kwriteconfig)")
+
+// Current reads what is configured now, from the first backend that answers.
+func Current() (State, error) {
+	backends := availableBackends()
+	if len(backends) == 0 {
+		return State{}, ErrUnsupported
+	}
+	var firstErr error
+	for _, b := range backends {
+		state, err := readBackend(b)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		return state, nil
+	}
+	return State{}, firstErr
+}
+
+// Apply writes the state to every backend this machine has.
+func Apply(state State) error {
+	backends := availableBackends()
+	if len(backends) == 0 {
+		return ErrUnsupported
+	}
+	var firstErr error
+	applied := 0
+	for _, b := range backends {
+		if err := writeBackend(b, state); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		applied++
+	}
+	if applied == 0 {
+		return firstErr
+	}
+	// One backend refusing while another took it is not a failure: the machine
+	// is pointed at the proxy, which is what was asked for.
+	return nil
+}
+
+// Pointing is the state that sends traffic through endpoint.
+func Pointing(endpoint string) (State, error) {
+	host, port := splitProxyEndpoint(endpoint)
+	if host == "" || port <= 0 {
+		return State{}, fmt.Errorf("sysproxy: %q is not a host:port", endpoint)
+	}
+	return State{Enabled: true, Server: endpoint, Override: DefaultBypass}, nil
+}
+
+// Verify reads the settings back and reports whether they took.
+func Verify(want State) error {
+	got, err := Current()
+	if err != nil {
+		return err
+	}
+	if !got.SameAs(want) {
+		return fmt.Errorf("sysproxy: the desktop did not keep the settings (wanted %q, found %q)", want.Server, got.Server)
+	}
+	return nil
+}
+
+func readBackend(b backend) (State, error) {
+	if b.name == "gsettings" {
+		return readGnome()
+	}
+	return readKDE()
+}
+
+func writeBackend(b backend, state State) error {
+	if b.name == "gsettings" {
+		return writeGnome(state)
+	}
+	return writeKDE(b.binary, state)
+}
+
+// --- GNOME -----------------------------------------------------------------
+
+func readGnome() (State, error) {
+	mode, err := gsettingsGet(gnomeProxySchema, "mode")
+	if err != nil {
+		return State{}, err
+	}
+	host, _ := gsettingsGet(gnomeProxySchema+".http", "host")
+	port, _ := gsettingsGet(gnomeProxySchema+".http", "port")
+	ignore, _ := gsettingsGet(gnomeProxySchema, "ignore-hosts")
+	return parseGnomeState(mode, host, port, ignore), nil
+}
+
+func writeGnome(state State) error {
+	for _, args := range gnomeApplyArgs(state) {
+		if output, err := exec.Command(gsettingsBinary, args...).CombinedOutput(); err != nil {
+			return fmt.Errorf("sysproxy: gsettings %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+		}
+	}
+	return nil
+}
+
+func gsettingsGet(schema, key string) (string, error) {
+	output, err := exec.Command(gsettingsBinary, "get", schema, key).Output()
+	if err != nil {
+		return "", fmt.Errorf("sysproxy: gsettings get %s %s: %w", schema, key, err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// --- KDE -------------------------------------------------------------------
+
+func readKDE() (State, error) {
+	reader := "kreadconfig6"
+	if _, err := exec.LookPath(reader); err != nil {
+		reader = "kreadconfig5"
+		if _, err := exec.LookPath(reader); err != nil {
+			return State{}, fmt.Errorf("sysproxy: no kreadconfig to read KDE's settings with")
+		}
+	}
+	get := func(key string) string {
+		output, err := exec.Command(reader, "--file", kdeProxyConfigFile, "--group", kdeProxyGroup, "--key", key).Output()
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(output))
+	}
+	return parseKDEState(get("ProxyType"), get("httpProxy"), get("NoProxyFor")), nil
+}
+
+func writeKDE(binary string, state State) error {
+	for key, value := range kdeApplyEntries(state) {
+		args := []string{"--file", kdeProxyConfigFile, "--group", kdeProxyGroup, "--key", key, value}
+		if output, err := exec.Command(binary, args...).CombinedOutput(); err != nil {
+			return fmt.Errorf("sysproxy: %s %s: %w: %s", binary, key, err, strings.TrimSpace(string(output)))
+		}
+	}
+	// Written settings are not read settings: running KDE programs keep the old
+	// ones until they are told. Best effort — the file is correct either way and
+	// a new program will pick it up.
+	_ = exec.Command("dbus-send", "--type=signal", "/KIO/Scheduler",
+		"org.kde.KIO.Scheduler.reparseSlaveConfiguration", "string:").Run()
+	return nil
+}

--- a/desktop/internal/sysproxy/sysproxy_other.go
+++ b/desktop/internal/sysproxy/sysproxy_other.go
@@ -1,4 +1,4 @@
-//go:build !windows && !darwin
+//go:build !windows && !darwin && !linux
 
 package sysproxy
 
@@ -6,11 +6,10 @@ import "errors"
 
 // ErrUnsupported is what every call returns on the platforms left.
 //
-// Windows and macOS each have one answer; Linux has none — GNOME, KDE and a
-// bare window manager keep it in three different places and none of them binds
-// anything that is not already asking. A caller that cannot point the machine at
-// the proxy should say so rather than quietly succeed.
-var ErrUnsupported = errors.New("sysproxy: setting the system proxy is implemented on Windows and macOS")
+// Windows, macOS and Linux each have an answer. What is left is the platforms
+// with no desktop proxy setting at all, and a caller that cannot point the
+// machine at the proxy should say so rather than quietly succeed.
+var ErrUnsupported = errors.New("sysproxy: setting the system proxy is implemented on Windows, macOS and Linux")
 
 func Current() (State, error)        { return State{}, ErrUnsupported }
 func Apply(State) error              { return ErrUnsupported }

--- a/desktop/mihomo_connect.go
+++ b/desktop/mihomo_connect.go
@@ -146,11 +146,18 @@ func (a *App) startWhiteDNSVPNWithMihomo() (model.AppState, error) {
 		// machine is talking to it. With the tunnel up the routing is the
 		// tunnel's job and a proxy as well would be one hop too many.
 		if err := a.captureSystemProxy(connected.MixedPort()); err != nil {
-			message := fmt.Sprintf("could not configure the system proxy: %v", err)
-			a.appendRuntimeLog(message)
-			a.stopMihomo()
-			a.reportConnectFailure(ctx, message)
-			return a.GetAppState(), fmt.Errorf("system proxy setup failed: %w", err)
+			// Not fatal. The connection is up and the proxy is listening; what
+			// failed is pointing the machine at it, and that is something a user
+			// can do by hand. Tearing down a working connection over it left the
+			// app with no usable mode at all on a desktop this cannot configure —
+			// which is what a Linux user got, having been told his connection had
+			// failed when it had not.
+			a.appendRuntimeLog(fmt.Sprintf("could not configure the system proxy: %v", err))
+			a.appendRuntimeLog(fmt.Sprintf(
+				"the connection is up — point your programs at 127.0.0.1:%d, or use tunnel mode", connected.MixedPort()))
+			a.emit("runtime:notice", fmt.Sprintf(
+				"Connected, but this desktop's proxy settings could not be changed. Set your browser's proxy to 127.0.0.1:%d.",
+				connected.MixedPort()))
 		}
 	}
 


### PR DESCRIPTION
…onnection

A Linux user reported:

  Operation failed
  system proxy setup failed: sysproxy: setting the system proxy is
  implemented on Windows and macOS

Two things were wrong, and the second is worse than the first.

sysproxy had no Linux implementation, so proxy mode reported ErrUnsupported. And the connect path treated that as fatal: it logged, called stopMihomo and reported a failed connection. The engine had started, the health check had passed, the proxy was listening on 127.0.0.1:2080 — and the app killed it because it could not write a desktop preference.

Tunnel mode is no escape either: startElevatedChild is Windows-only, so the core cannot be raised to make an adapter. Between the two, the app had no usable mode on Linux at all while telling the user his connection had failed. That is the same shape as verifyTunnel on macOS a week ago: "not implemented" reported as "yours is broken".

So a system proxy that cannot be set no longer ends the connection. It is a notice with the address to configure by hand, because the connection is up and that is something a person can act on.

And Linux is implemented. GNOME's gsettings covers GNOME, COSMIC, Cinnamon, Budgie and MATE; kioslaverc covers KDE. Both are written when both are present rather than choosing from XDG_CURRENT_DESKTOP — the machine in the report was Pop!_OS running KDE, GNOME's schemas installed with KDE's session in front, and reading one variable would have configured the half the user was not looking at. https and socks are set alongside http: a browser sends CONNECT to whatever the https entry names and goes direct if it is empty, which is connected and leaking. `<local>` is dropped from the bypass list — it is WinINET's word for "any name without a dot" and both desktops would take it literally.

Disabling only turns the mode off and leaves host and port alone, so disconnecting does not wipe a proxy the user configured before this app ever ran.

The command-building and parsing live in an untagged file with tests that run anywhere, because this is developed on Windows: what the arguments are can be checked here, including that what Apply writes is what Current reads back, or Verify would report a failure on settings that took.

Not verified: any of it against a real GNOME or KDE session. That needs a Linux desktop. The logic is tested, the three platforms build, and the fallback is now harmless if a command turns out to be wrong.