### PR TITLE
Tell people a newer version exists

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -62,6 +62,9 @@ type App struct {
 	mihomo  mihomoState
 	tray    trayState
 	measure measureState
+	// Cached so opening a page does not spend one of GitHub's sixty
+	// unauthenticated requests an hour.
+	updates updateCheckCache
 
 	connectMu     sync.Mutex
 	connectCancel context.CancelFunc

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import {
   Activity,
   AlertCircle,
+  ArrowUpCircle,
   Check,
   ChevronDown,
   ChevronRight,
@@ -137,6 +138,7 @@ import type {
   RuntimeStatus,
   RuntimeStatusName,
   ConnectionSelection,
+  UpdateStatus,
   WhiteVPNNode,
   WhiteVPNNodeList,
   NodeTestRequest,
@@ -679,6 +681,11 @@ function App() {
   // name it while disconnected — that is when someone is setting a browser up.
   const [engineProxyEndpoint, setEngineProxyEndpoint] = useState("");
   const [appVersion, setAppVersion] = useState("");
+  // What the app knows about newer releases. Null until the check has run, and
+  // a check that could not reach GitHub leaves available false rather than
+  // saying anything — it is blocked in the places this app is used, and a
+  // failed check must not become a message.
+  const [update, setUpdate] = useState<UpdateStatus | null>(null);
   const [page, setPage] = useState<Page>("vpn");
   const [errorToast, setErrorToast] = useState<AppErrorToast | null>(null);
   const [successToast, setSuccessToast] = useState<AppErrorToast | null>(null);
@@ -839,6 +846,13 @@ function App() {
       .getLocalProxyEndpoint()
       .then(setEngineProxyEndpoint)
       .catch(() => setEngineProxyEndpoint(""));
+    // Not on the critical path: nothing waits for it, and a slow or blocked
+    // GitHub delays nothing. The backend caches for six hours, so this costs a
+    // request on the first launch of a session and nothing after.
+    backend
+      .checkForUpdate(false)
+      .then(setUpdate)
+      .catch(() => setUpdate(null));
     backend
       .getPrivacyPolicyVersion()
       .then(setPolicyVersion)
@@ -1000,7 +1014,7 @@ function App() {
   return (
     <TooltipProvider>
       <SidebarProvider defaultOpen>
-        <AppSidebar page={activePage} runtime={state.runtime} onPage={setPage} language={language} version={appVersion} t={t} />
+        <AppSidebar page={activePage} runtime={state.runtime} onPage={setPage} language={language} version={appVersion} update={update} t={t} />
         <SidebarInset className="min-w-0 overflow-x-hidden">
           <main className="min-h-svh min-w-0 overflow-x-hidden bg-muted/30 p-4 md:p-6">
             <div className="mx-auto flex w-full min-w-0 max-w-7xl flex-col gap-4">
@@ -1280,6 +1294,7 @@ function AppSidebar({
   onPage,
   language,
   version,
+  update,
   t,
 }: {
   page: Page;
@@ -1287,6 +1302,7 @@ function AppSidebar({
   onPage: (page: Page) => void;
   language: Language;
   version: string;
+  update: UpdateStatus | null;
   t: TranslateFn;
 }) {
   const sidebarEndpoint = runtimeProxyDisplayEndpoint(runtime);
@@ -1322,7 +1338,23 @@ function AppSidebar({
                   places is a version that will disagree with itself, and this
                   one shipped 1.0.1 while saying 1.0.0. Blank until it arrives,
                   because a stale number is worse than none. */}
-              <p className="truncate text-sm leading-normal text-muted-foreground">{version ? `v${version}` : ""}</p>
+              {update?.available ? (
+                // The version becomes the way to the new one. Whoever is still
+                // on an old build is not in the Telegram channel — that is who
+                // this reaches — and the number they already glance at is the
+                // right place to say so.
+                <button
+                  type="button"
+                  onClick={() => openExternalUrl(update.url)}
+                  className="flex items-center gap-1 truncate text-sm leading-normal text-primary hover:underline"
+                  title={t("update.available", { version: update.latest })}
+                >
+                  <ArrowUpCircle className="size-3.5 shrink-0" />
+                  <span className="truncate">{t("update.badge", { version: update.latest })}</span>
+                </button>
+              ) : (
+                <p className="truncate text-sm leading-normal text-muted-foreground">{version ? `v${version}` : ""}</p>
+              )}
             </div>
           </div>
           <ThemeSettingsMenu
@@ -6217,7 +6249,58 @@ function WhiteVPNSettingsPage({
           </Field>
         </FieldGroup>
       </SettingsSection>
+
+      <SettingsSection title={t("settings.update.title")} description={t("settings.update.description")}>
+        <UpdateCheckRow t={t} />
+      </SettingsSection>
     </PageShell>
+  );
+}
+
+// Asking for the check rather than waiting for it.
+//
+// The automatic one runs at startup and is cached for six hours, which is right
+// for something nobody asked for. Someone who has just been told there is a new
+// version and wants to see it should not have to wait out that cache, so this
+// forces it — and then says what it found, including that it could not look,
+// which on these networks is a normal answer rather than an error.
+function UpdateCheckRow({ t }: { t: TranslateFn }) {
+  const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [checking, setChecking] = useState(false);
+
+  async function check() {
+    setChecking(true);
+    try {
+      setStatus(await backend.checkForUpdate(true));
+    } catch {
+      setStatus(null);
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <Button variant="outline" onClick={() => void check()} disabled={checking}>
+        <ArrowUpCircle className={cn(checking && "animate-pulse")} />
+        {checking ? t("update.checking") : t("update.check")}
+      </Button>
+      {status && !checking && (
+        <span className="text-sm text-muted-foreground">
+          {status.available ? (
+            <button type="button" onClick={() => openExternalUrl(status.url)} className="text-primary hover:underline">
+              {t("update.available", { version: status.latest })}
+            </button>
+          ) : status.current === "dev" ? (
+            t("update.dev")
+          ) : status.error ? (
+            t("update.failed")
+          ) : (
+            t("update.upToDate", { version: status.current })
+          )}
+        </span>
+      )}
+    </div>
   );
 }
 

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -526,6 +526,33 @@ const strings = {
     fa: "«در دسترس» آدرس را مستقیم می‌زند، بدون وی‌پی‌ان و بدون موتور — پس سروری که از محل شما مسدود است در این آزمون رد می‌شود، در حالی که از راه موتور کاملاً کار می‌کند. تأخیر و سرعت روی موتور جداگانه‌ای اجرا می‌شوند و هرگز اتصال زنده را مختل نمی‌کنند، و سرعت هر بار یک سرور است، پس تا ۲۵ مورد محدود می‌شود.",
   },
 
+  // Telling someone a newer version exists. The app does not download or
+  // install anything — it runs as Administrator and nothing it ships is signed,
+  // so fetching a binary and running it is not something to do without verified
+  // signatures. Whoever is still on an old build is not in the Telegram
+  // channel; this is what reaches them.
+  "settings.update.title": { en: "Updates", fa: "بروزرسانی" },
+  "settings.update.description": {
+    en: "The app checks for a newer version at startup. It never downloads or installs anything by itself.",
+    fa: "اپ هنگام اجرا نسخهٔ جدید را بررسی می‌کند. هیچ‌وقت خودش چیزی دانلود یا نصب نمی‌کند.",
+  },
+  "update.badge": { en: "Update to v{version}", fa: "بروزرسانی به نسخهٔ {version}" },
+  "update.available": {
+    en: "Version {version} is out. Click to open the download page.",
+    fa: "نسخهٔ {version} منتشر شده. برای باز کردن صفحهٔ دانلود کلیک کنید.",
+  },
+  "update.check": { en: "Check for updates", fa: "بررسی بروزرسانی" },
+  "update.checking": { en: "Checking…", fa: "در حال بررسی…" },
+  "update.upToDate": { en: "You are on the latest version ({version}).", fa: "شما روی آخرین نسخه هستید ({version})." },
+  "update.failed": {
+    en: "Could not reach the release list. Connect first and try again.",
+    fa: "دسترسی به فهرست نسخه‌ها ممکن نشد. اول وصل شوید و دوباره امتحان کنید.",
+  },
+  "update.dev": {
+    en: "This is a development build, so there is nothing to update to.",
+    fa: "این یک بیلد توسعه است، پس چیزی برای بروزرسانی وجود ندارد.",
+  },
+
   "common.close": { en: "Close", fa: "بستن" },
   "common.copy": { en: "Copy", fa: "کپی" },
   "common.cancel": { en: "Cancel", fa: "انصراف" },

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -650,6 +650,23 @@ export type ConnectionSelection = {
   delaySort: boolean;
 };
 
+// What the app knows about newer releases.
+//
+// error is a string rather than a thrown failure: not reaching GitHub is
+// ordinary where this app is used and is not worth interrupting anyone over.
+// available stays false in that case, so a failed check never nags.
+export type UpdateStatus = {
+  // The running version, or "dev" for a build that did not come from a
+  // release — which is never offered an update.
+  current: string;
+  latest: string;
+  available: boolean;
+  url: string;
+  notes: string;
+  checkedAt: string;
+  error: string;
+};
+
 // One node of the catalogue. `name` is its identity — what the engine selects
 // by — and `label` is the same name with the flag and channel marker removed.
 export type WhiteVPNNode = {

--- a/desktop/frontend/src/wails.ts
+++ b/desktop/frontend/src/wails.ts
@@ -21,6 +21,7 @@ import type {
   LegacyImportOffer,
   WhiteVPNSettings,
   WhiteVPNNodeList,
+  UpdateStatus,
   ConnectionSelection,
   NodeTestRequest,
 } from "./types";
@@ -82,6 +83,7 @@ type AppApi = {
   GetPrivacyPolicyVersion(): Promise<number>;
   AcceptPrivacyPolicy(): Promise<AppState>;
   GetAppVersion(): Promise<string>;
+  CheckForUpdate(force: boolean): Promise<UpdateStatus>;
   GetLocalProxyEndpoint(): Promise<string>;
   ListWhiteVPNNodes(refresh: boolean): Promise<WhiteVPNNodeList>;
   ListSubscriptionNodes(subscriptionId: string, refresh: boolean): Promise<WhiteVPNNodeList>;
@@ -178,6 +180,7 @@ export const backend = {
   getPrivacyPolicyVersion: () => app().GetPrivacyPolicyVersion(),
   acceptPrivacyPolicy: () => app().AcceptPrivacyPolicy(),
   getAppVersion: () => app().GetAppVersion(),
+  checkForUpdate: (force: boolean) => app().CheckForUpdate(force),
   getLocalProxyEndpoint: () => app().GetLocalProxyEndpoint(),
   listWhiteVpnNodes: (refresh: boolean) => app().ListWhiteVPNNodes(refresh),
   listSubscriptionNodes: (subscriptionId: string, refresh: boolean) => app().ListSubscriptionNodes(subscriptionId, refresh),

--- a/desktop/internal/model/types.go
+++ b/desktop/internal/model/types.go
@@ -375,6 +375,25 @@ type AppState struct {
 	Runtime     RuntimeStatus       `json:"runtime"`
 }
 
+// UpdateStatus is what the app knows about newer releases.
+//
+// Error is a string rather than a failure of the call, because not reaching
+// GitHub is ordinary where this app is used and is not worth interrupting anyone
+// over. Available stays false in that case, so a failed check never nags.
+type UpdateStatus struct {
+	// Current is the running version, or "dev" for a build that did not come
+	// from a release — which is never offered an update.
+	Current string `json:"current"`
+	// Latest is the newest published release, empty when the check did not get
+	// an answer.
+	Latest    string `json:"latest"`
+	Available bool   `json:"available"`
+	URL       string `json:"url"`
+	Notes     string `json:"notes"`
+	CheckedAt string `json:"checkedAt"`
+	Error     string `json:"error"`
+}
+
 type ConnectionImportResult struct {
 	State    AppState `json:"state"`
 	Imported int      `json:"imported"`

--- a/desktop/update_check.go
+++ b/desktop/update_check.go
@@ -1,0 +1,253 @@
+package main
+
+// Telling a user a newer version exists.
+//
+// This checks and reports. It does not download anything and does not replace
+// anything, and that is deliberate rather than unfinished: the app runs as
+// Administrator and nothing it ships is code-signed, so an updater that fetched
+// a binary and ran it would hand whoever could interfere with that download a
+// machine with full privileges. Doing that safely needs signed artifacts and
+// verification before the swap, which is its own piece of work.
+//
+// What is left is still most of the value. The problem is not that people cannot
+// replace a file — it is that they do not know there is anything to replace. The
+// users still on an old version are the ones who are not in the Telegram channel,
+// which is exactly who an in-app notice reaches.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"whitevpn-desktop/internal/model"
+)
+
+const (
+	// The releases API, unauthenticated. Sixty requests an hour per address,
+	// which is why the result is cached rather than fetched whenever something
+	// asks.
+	latestReleaseURL = "https://api.github.com/repos/WhiteDNS/WhiteVPN-Desktop/releases/latest"
+
+	updateCheckInterval = 6 * time.Hour
+	updateCheckTimeout  = 12 * time.Second
+)
+
+type updateCheckCache struct {
+	mu        sync.Mutex
+	result    model.UpdateStatus
+	checkedAt time.Time
+}
+
+// CheckForUpdate reports whether a newer release exists.
+//
+// force skips the cache, for the case where a user asks rather than the app
+// asking on its own.
+func (a *App) CheckForUpdate(force bool) (model.UpdateStatus, error) {
+	return a.checkForUpdateAt(latestReleaseURL, force)
+}
+
+// checkForUpdateAt is CheckForUpdate with the address as an argument, so the
+// behaviour around it — the cache, a dev build, an unreachable list — can be
+// tested without reaching GitHub.
+func (a *App) checkForUpdateAt(releaseURL string, force bool) (model.UpdateStatus, error) {
+	if !force {
+		if cached, ok := a.updates.get(); ok {
+			return cached, nil
+		}
+	}
+
+	current := strings.TrimSpace(appVersion)
+	if current == "" || current == "dev" {
+		// A development build has no release to compare against, and offering to
+		// "update" one to the version it was built after would be nonsense.
+		status := model.UpdateStatus{Current: current, CheckedAt: time.Now().UTC().Format(time.RFC3339)}
+		a.updates.put(status)
+		return status, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), updateCheckTimeout)
+	defer cancel()
+
+	release, err := a.fetchLatestRelease(ctx, releaseURL)
+	if err != nil {
+		// Not being able to reach GitHub is ordinary — it is blocked in the
+		// places this app is used — so it is reported as a failed check rather
+		// than as an error worth interrupting anyone over.
+		status := model.UpdateStatus{
+			Current:   current,
+			CheckedAt: time.Now().UTC().Format(time.RFC3339),
+			Error:     err.Error(),
+		}
+		a.updates.put(status)
+		return status, nil
+	}
+
+	latest := strings.TrimPrefix(strings.TrimSpace(release.TagName), "v")
+	status := model.UpdateStatus{
+		Current:   current,
+		Latest:    latest,
+		URL:       strings.TrimSpace(release.HTMLURL),
+		Notes:     strings.TrimSpace(release.Body),
+		CheckedAt: time.Now().UTC().Format(time.RFC3339),
+		Available: newerVersion(latest, current),
+	}
+	a.updates.put(status)
+	return status, nil
+}
+
+type githubRelease struct {
+	TagName    string `json:"tag_name"`
+	HTMLURL    string `json:"html_url"`
+	Body       string `json:"body"`
+	Draft      bool   `json:"draft"`
+	Prerelease bool   `json:"prerelease"`
+}
+
+// fetchLatestRelease asks GitHub, through the tunnel when there is one.
+//
+// Through the tunnel first because GitHub is often unreachable from the networks
+// this app exists to get around, and a user who is connected has a working path
+// to it. Falling back to a direct request covers the other case — checking
+// before connecting, on a network where GitHub is fine.
+func (a *App) fetchLatestRelease(ctx context.Context, releaseURL string) (githubRelease, error) {
+	var lastErr error
+	for _, client := range a.updateCheckClients() {
+		release, err := requestLatestReleaseFrom(ctx, client, releaseURL)
+		if err == nil {
+			return release, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no way to reach the release list")
+	}
+	return githubRelease{}, lastErr
+}
+
+func (a *App) updateCheckClients() []*http.Client {
+	clients := make([]*http.Client, 0, 2)
+	if proxied, err := a.proxyHTTPClient(); err == nil && proxied != nil {
+		clients = append(clients, proxied)
+	}
+	return append(clients, &http.Client{Timeout: updateCheckTimeout})
+}
+
+// proxyHTTPClient is a client that goes through the running connection, or nil
+// when nothing is running.
+func (a *App) proxyHTTPClient() (*http.Client, error) {
+	current := a.mihomo.current()
+	if current == nil {
+		return nil, nil
+	}
+	return httpClientThroughProxy(runtimeProxyConfig{
+		Protocol: "http",
+		Address:  fmt.Sprintf("127.0.0.1:%d", current.MixedPort()),
+	})
+}
+
+func requestLatestReleaseFrom(ctx context.Context, client *http.Client, releaseURL string) (githubRelease, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, releaseURL, nil)
+	if err != nil {
+		return githubRelease{}, err
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("User-Agent", "WhiteVPN-Desktop")
+
+	response, err := client.Do(request)
+	if err != nil {
+		return githubRelease{}, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return githubRelease{}, fmt.Errorf("the release list answered %d", response.StatusCode)
+	}
+
+	// Bounded: this is a small JSON document and the body is whatever the other
+	// end decides to send.
+	body, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if err != nil {
+		return githubRelease{}, err
+	}
+	var release githubRelease
+	if err := json.Unmarshal(body, &release); err != nil {
+		return githubRelease{}, fmt.Errorf("the release list could not be read: %w", err)
+	}
+	if release.Draft || release.Prerelease {
+		return githubRelease{}, fmt.Errorf("the latest release is not a published one")
+	}
+	if strings.TrimSpace(release.TagName) == "" {
+		return githubRelease{}, fmt.Errorf("the release list named no version")
+	}
+	return release, nil
+}
+
+// newerVersion compares two dotted versions numerically.
+//
+// Not a string comparison, which would put 1.0.10 below 1.0.9 and stop offering
+// updates at exactly the point a project has shipped ten patches. Anything that
+// does not parse sorts as older, so a version this app cannot understand never
+// prompts an upgrade to it.
+func newerVersion(candidate, current string) bool {
+	left, leftOK := versionParts(candidate)
+	right, rightOK := versionParts(current)
+	if !leftOK || !rightOK {
+		return false
+	}
+	for i := 0; i < len(left) || i < len(right); i++ {
+		a, b := 0, 0
+		if i < len(left) {
+			a = left[i]
+		}
+		if i < len(right) {
+			b = right[i]
+		}
+		if a != b {
+			return a > b
+		}
+	}
+	return false
+}
+
+func versionParts(value string) ([]int, bool) {
+	value = strings.TrimPrefix(strings.TrimSpace(value), "v")
+	// A suffix like 1.0.0-beta2 compares on its numbers; the suffix itself says
+	// nothing this needs.
+	if cut := strings.IndexAny(value, "-+"); cut >= 0 {
+		value = value[:cut]
+	}
+	if value == "" {
+		return nil, false
+	}
+	fields := strings.Split(value, ".")
+	parts := make([]int, 0, len(fields))
+	for _, field := range fields {
+		number, err := strconv.Atoi(strings.TrimSpace(field))
+		if err != nil || number < 0 {
+			return nil, false
+		}
+		parts = append(parts, number)
+	}
+	return parts, true
+}
+
+func (c *updateCheckCache) get() (model.UpdateStatus, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.checkedAt.IsZero() || time.Since(c.checkedAt) >= updateCheckInterval {
+		return model.UpdateStatus{}, false
+	}
+	return c.result, true
+}
+
+func (c *updateCheckCache) put(status model.UpdateStatus) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.result = status
+	c.checkedAt = time.Now()
+}

--- a/desktop/update_check_test.go
+++ b/desktop/update_check_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"whitevpn-desktop/internal/model"
+)
+
+// A string comparison puts 1.0.10 below 1.0.9 and stops offering updates at
+// exactly the point a project has shipped ten patches.
+func TestNewerVersionComparesNumbersNotText(t *testing.T) {
+	for _, testCase := range []struct {
+		candidate, current string
+		want               bool
+	}{
+		{"1.0.4", "1.0.3", true},
+		{"1.0.10", "1.0.9", true},
+		{"1.1.0", "1.0.9", true},
+		{"2.0.0", "1.9.9", true},
+		{"1.0.3", "1.0.3", false},
+		{"1.0.2", "1.0.3", false},
+		{"1.0.9", "1.0.10", false},
+		// Shorter is not older when the missing parts are zero.
+		{"1.1", "1.1.0", false},
+		{"1.1.1", "1.1", true},
+		// A leading v is how the tags are written.
+		{"v1.0.4", "1.0.3", true},
+		// A prerelease compares on its numbers.
+		{"1.0.4-beta1", "1.0.3", true},
+	} {
+		if got := newerVersion(testCase.candidate, testCase.current); got != testCase.want {
+			t.Errorf("newerVersion(%q, %q) = %v, want %v", testCase.candidate, testCase.current, got, testCase.want)
+		}
+	}
+}
+
+// Anything unparseable must sort as older, so a version this app cannot
+// understand never prompts an upgrade to it.
+func TestNewerVersionRefusesWhatItCannotRead(t *testing.T) {
+	for _, testCase := range [][2]string{
+		{"", "1.0.3"},
+		{"latest", "1.0.3"},
+		{"1.0.x", "1.0.3"},
+		{"1.0.4", "dev"},
+		{"1.0.4", ""},
+	} {
+		if newerVersion(testCase[0], testCase[1]) {
+			t.Errorf("newerVersion(%q, %q) should be false", testCase[0], testCase[1])
+		}
+	}
+}
+
+// A development build has no release to compare against, and offering to
+// "update" one would be nonsense. It also must not spend a request finding that
+// out.
+func TestCheckForUpdateLeavesDevelopmentBuildsAlone(t *testing.T) {
+	restore := appVersion
+	appVersion = "dev"
+	defer func() { appVersion = restore }()
+
+	app := &App{}
+	status, err := app.CheckForUpdate(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Available {
+		t.Fatalf("a dev build should never be offered an update: %#v", status)
+	}
+	if status.Current != "dev" {
+		t.Fatalf("expected the running version to be reported, got %q", status.Current)
+	}
+}
+
+func TestRequestLatestReleaseReadsAPublishedRelease(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v1.0.4","html_url":"https://example.com/v1.0.4","body":"notes","draft":false,"prerelease":false}`))
+	}))
+	defer server.Close()
+
+	release, err := requestLatestReleaseFrom(context.Background(), server.Client(), server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if release.TagName != "v1.0.4" || release.HTMLURL != "https://example.com/v1.0.4" {
+		t.Fatalf("unexpected release: %#v", release)
+	}
+}
+
+// A draft or a prerelease is not something to send people to.
+func TestRequestLatestReleaseSkipsUnpublished(t *testing.T) {
+	for _, body := range []string{
+		`{"tag_name":"v1.0.5","draft":true}`,
+		`{"tag_name":"v1.0.5","prerelease":true}`,
+		`{"tag_name":""}`,
+	} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(body))
+		}))
+		if _, err := requestLatestReleaseFrom(context.Background(), server.Client(), server.URL); err == nil {
+			t.Errorf("%s should have been refused", body)
+		}
+		server.Close()
+	}
+}
+
+func TestRequestLatestReleaseReportsARefusal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	if _, err := requestLatestReleaseFrom(context.Background(), server.Client(), server.URL); err == nil {
+		t.Fatal("expected a rate-limited or refused response to be an error")
+	}
+}
+
+// Not reaching GitHub is ordinary where this app is used. It must not surface as
+// a failed call, and it must not claim an update is available.
+func TestCheckForUpdateSurvivesAnUnreachableGitHub(t *testing.T) {
+	restore := appVersion
+	appVersion = "1.0.3"
+	defer func() { appVersion = restore }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	server.Close() // nothing is listening now
+
+	app := &App{}
+	status, err := app.checkForUpdateAt(server.URL, true)
+	if err != nil {
+		t.Fatalf("an unreachable release list should not fail the call: %v", err)
+	}
+	if status.Available {
+		t.Fatal("a failed check must not offer an update")
+	}
+	if status.Error == "" {
+		t.Fatal("the failure should be reported so the interface can say the check did not run")
+	}
+}
+
+func TestCheckForUpdateCachesItsAnswer(t *testing.T) {
+	restore := appVersion
+	appVersion = "1.0.3"
+	defer func() { appVersion = restore }()
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		_, _ = w.Write([]byte(`{"tag_name":"v1.0.4","html_url":"https://example.com","body":"","draft":false,"prerelease":false}`))
+	}))
+	defer server.Close()
+
+	app := &App{}
+	first, err := app.checkForUpdateAt(server.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.Available || first.Latest != "1.0.4" {
+		t.Fatalf("expected 1.0.4 to be offered: %#v", first)
+	}
+
+	// Sixty requests an hour, unauthenticated, so asking again must not ask
+	// GitHub again.
+	if _, err := app.checkForUpdateAt(server.URL, false); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected the answer to be cached, made %d requests", calls)
+	}
+
+	// Unless the user asks, which is the point of force.
+	if _, err := app.checkForUpdateAt(server.URL, true); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("a forced check should have gone out, made %d requests", calls)
+	}
+}
+
+func TestUpdateCacheExpires(t *testing.T) {
+	cache := &updateCheckCache{}
+	cache.put(model.UpdateStatus{Latest: "1.0.4", Available: true})
+	if _, ok := cache.get(); !ok {
+		t.Fatal("a fresh answer should be served from the cache")
+	}
+	cache.checkedAt = time.Now().Add(-updateCheckInterval - time.Minute)
+	if _, ok := cache.get(); ok {
+		t.Fatal("a stale answer should not be served")
+	}
+}


### PR DESCRIPTION
The app checks GitHub for a newer release and says so. It does not download
anything and does not install anything.

That is a decision, not an unfinished job. The app runs as Administrator and
nothing it ships is code-signed, so an updater that fetched a binary and ran it
would hand whoever could interfere with that download a machine with full
privileges — the highest-value target this app has. Doing it safely needs signed
artifacts and verification before the swap, which is its own piece of work.

What is left is still most of the value. The problem is not that people cannot
replace a file; it is that they do not know there is one to replace. Whoever is
still on an old build is not in the Telegram channel — that is exactly who an
in-app notice reaches, and they are the ones running the versions with the DNS
leak.

## What it does

The version in the sidebar becomes the way to the new one when there is one, and
clicking opens the release page in a browser. Settings gains a check that forces
past the cache, for someone who has just heard there is a new version.

## Details that matter

- Versions compare **numerically**, or `1.0.10` sorts below `1.0.9` and updates
  stop being offered at the point ten patches have shipped. Anything unparseable
  sorts as older, so a version the app cannot read never prompts an upgrade.
- A `dev` build is never offered an update and does not spend a request finding
  that out.
- The check goes **through the tunnel** when one is up, falling back to a direct
  request. GitHub is often unreachable from the networks this app exists to get
  around, and a connected user has a working path to it.
- **Failing to reach GitHub is not an error.** It is ordinary here, so it is
  recorded on the status and `available` stays false — a failed check never nags
  and never claims an update exists.
- Cached six hours; the API allows sixty unauthenticated requests an hour.
  Asking explicitly bypasses it. Drafts and prereleases are skipped.
- Off the critical path: nothing waits for it and a blocked GitHub delays
  nothing.

## Verified

- Nine tests on the comparison, the cache, the dev-build case, an unreachable
  list, and drafts/prereleases.
- Against the real GitHub API: reported 1.0.4 available while pretending to be
  on 1.0.2.
- The interface, on a build made to report an old version: the sidebar banner
  appears, clicking opens the browser, and the Settings check reports correctly.
- No direction-fixed CSS in the new markup, so the right-to-left layout holds.

Two pre-existing test failures are unrelated and untouched:
`TestEnsureAppDataWritableRepairsDarwinWithAdministratorPrompt` (a macOS test run
on Windows) and `TestFindMihomoCoreExplainsItselfWhenAbsent`.