### PR TITLE
Take the catalogue key out of the source, run CI, and stop demanding …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,139 @@
+name: CI
+
+# Every release so far was built without a single automated test running: the
+# only workflow was the release one, and it fires on a tag. The tests existed and
+# were good; whether they had been run depended on somebody remembering to. This
+# is that somebody.
+#
+# On pull requests and on main, so a change is checked before it is merged and
+# again after — a green PR that goes red once merged is worth knowing about
+# immediately rather than at the next release.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# A second push to a branch makes the first run irrelevant.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    name: Go (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # All three, because a good deal of this code only exists on one of them
+        # — the system proxy, the tunnel, elevation — and a test that only ever
+        # runs on the developer's machine is a test for that machine. Several
+        # tests skip themselves off their own platform, which is exactly why the
+        # other platforms have to be here.
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.5"
+          cache-dependency-path: desktop/go.sum
+
+      # WebKit and GTK, which the Wails bindings need to compile on Linux.
+      # Without them the build fails for want of a header rather than for
+      # anything to do with the change under test.
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+
+      - name: Build
+        working-directory: desktop
+        run: go build ./...
+
+      - name: Vet
+        working-directory: desktop
+        run: go vet ./internal/... .
+
+      # -race on Linux only: it is the slowest of the three and the concurrency
+      # this app has — the health watchdog, the traffic sampler, the seeding —
+      # is not platform-specific, so running it once is enough to catch it.
+      - name: Test
+        working-directory: desktop
+        run: go test ${{ runner.os == 'Linux' && '-race' || '' }} ./internal/... .
+
+  cross-compile:
+    name: Cross-compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.5"
+          cache-dependency-path: desktop/go.sum
+
+      # The platform-specific files are the ones most likely to be broken by a
+      # change made elsewhere, and they are invisible until something builds for
+      # that platform. This catches a Windows-only or Linux-only file that no
+      # longer compiles without waiting for a release to find out.
+      - name: Build the platform packages for every target
+        working-directory: desktop
+        run: |
+          set -euo pipefail
+          for target in windows/amd64 windows/arm64 linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+            echo "==> $target"
+            GOOS="${target%/*}" GOARCH="${target#*/}" go build ./internal/...
+          done
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: desktop/frontend/package-lock.json
+
+      - name: Install
+        working-directory: desktop/frontend
+        run: npm ci
+
+      # The type check is the one that has caught real mistakes: a binding added
+      # in Go and not in wails.ts, a translation key used before it exists.
+      - name: Type check
+        working-directory: desktop/frontend
+        run: npx tsc --noEmit
+
+      - name: Build
+        working-directory: desktop/frontend
+        run: npm run build
+
+  secrets:
+    name: No secrets in source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The catalogue's key sat in a public file from the first commit until it
+      # was moved into the build. Nothing stopped it going back except noticing,
+      # so this notices.
+      - name: The catalogue credentials must come from the build, not the source
+        run: |
+          set -euo pipefail
+          # Tests are excluded: one of them sets the address to a stand-in so it
+          # can check the real one never reaches the saved state, which is the
+          # opposite of the mistake being looked for.
+          if grep -rnE 'whiteDNSVPNSubscription(Key|URL)[[:space:]]*=[[:space:]]*"[^"]+"' desktop \
+              --include='*.go' --exclude='*_test.go'; then
+            echo "::error::A catalogue URL or key is hard-coded above. They are injected at link time; see desktop/Makefile."
+            exit 1
+          fi
+          echo "clean"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -132,6 +132,14 @@ jobs:
 
       - name: Build package
         shell: bash
+        # The catalogue's address and key. They were constants in a public file
+        # until now, which meant anyone could decrypt the node list without so
+        # much as downloading the app. A release built without these secrets set
+        # produces a working client with no built-in catalogue rather than
+        # failing, so a fork can build one and nothing here has to be faked.
+        env:
+          WHITEVPN_CATALOGUE_URL: ${{ secrets.WHITEVPN_CATALOGUE_URL }}
+          WHITEVPN_CATALOGUE_KEY: ${{ secrets.WHITEVPN_CATALOGUE_KEY }}
         run: |
           set -euo pipefail
           case "${{ matrix.kind }}" in

--- a/desktop/ANDROID-PARITY.md
+++ b/desktop/ANDROID-PARITY.md
@@ -605,6 +605,24 @@ Measured 2026-08-05, from Windows:
   at all: `fyne.io/systray` needs Cocoa. With CGO it needs the macOS SDK. It has
   to run on a Mac, or on a macOS CI runner.
 
+**Tests run in CI now.** `.github/workflows/ci.yml`, on every pull request and
+every push to main: build, vet and test on all three operating systems,
+cross-compilation for six targets, the frontend type check and build, and a scan
+that fails if a catalogue credential reappears in the source. Before it, the only
+workflow fired on a tag, so six releases shipped without a single automated test
+having run — the tests were there and were good, and whether they had been run
+depended on somebody remembering.
+
+Two tests had to be fixed to make it green, and both were the tests being wrong
+rather than the code. `TestFindMihomoCoreExplainsItselfWhenAbsent` expected the
+`WHITEVPN_MIHOMO_BIN` override to be honoured, which Windows deliberately ignores
+because the core is launched elevated and must come from inside the application.
+`TestEnsureAppDataWritableRepairsDarwinWithAdministratorPrompt` builds a shell
+command around a path and checks the text; given a Windows-shaped path the
+AppleScript quoting escapes every separator twice, so it can only be checked on a
+host with POSIX paths. Both now skip where they cannot mean anything — and CI is
+where they run for real.
+
 `.github/workflows/desktop-release.yml` already builds all three, on a tag
 `vpn-v*` or by hand. What a runner does *not* start with, and how it gets it:
 
@@ -646,6 +664,25 @@ from Wi-Fi to Ethernet must not lose its VPN on the way.
   `VpnService.Builder.addDnsServer` makes the OS route every query into the
   tunnel — so this is the second place, after IPv6 containment, where copying the
   phone literally means shipping a leak.
+- **The app does not run as Administrator, and must not start.** Only the tunnel
+  adapter needs it. The state file and the unpacked engine live under `%AppData%`,
+  the system proxy is a per-user WinINET setting, and the local port is above
+  1024 — so proxy mode needs nothing. The manifest asked for it anyway, which
+  meant a UAC prompt on every launch for people who never use the tunnel, and a
+  WebView2 browser engine running with full rights to the machine for everyone.
+  It is `asInvoker` now; `engine.startElevatedChild` raises the core on its own
+  when the tunnel is on. Everything downstream was already built for this split —
+  `pipeSecurityDescriptor` admits SYSTEM and Administrators precisely so an
+  elevated core can reach a pipe opened by an unelevated interface, its comment
+  says so, and it long predates the change.
+- **Closing the pipe is how the core is stopped, not `Kill`.** The core reads
+  frames in a loop and returns on any read error including EOF, and its `main`
+  returns with it — so dropping the connection ends the process whatever
+  privileges either side holds. That is what makes an unelevated interface safe
+  to pair with an elevated core. `Kill` is the last resort for a core wedged
+  badly enough to have stopped reading its own socket, and an unelevated process
+  cannot terminate an elevated one, so it now reports that failure with the pid
+  rather than discarding it.
 - **There are two version numbers, and only one of them is the app's.** The
   sidebar reads `appVersion`, set at link time by `-X main.appVersion` from the
   Makefile's `VERSION`. The number Windows shows in Properties → Details is

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -18,7 +18,24 @@ RELEASE_LDFLAGS ?= -s -w
 # than from a string someone has to remember to edit. Releasing 1.0.1 once
 # shipped an app whose own sidebar said 1.0.0.
 VERSION_LDFLAGS := -X main.appVersion=$(APP_VERSION)
-WAILS_RELEASE_FLAGS := -trimpath -ldflags "$(RELEASE_LDFLAGS) $(VERSION_LDFLAGS)"
+
+# The built-in catalogue's address and key.
+#
+# They lived in whitedns_vpn.go, in a public repository, from its first commit —
+# which meant anyone could read the key off a web page, fetch the encrypted
+# catalogue and decrypt every node's credentials out of it. No binary required.
+#
+# Injecting them here does not make them secret; they still ship inside every
+# binary, and a client that can decrypt the catalogue can be taken apart. It
+# raises the effort from reading a file to pulling strings out of an executable,
+# which is the most that is available while the client holds the key at all.
+#
+# Empty is a valid build: it produces a client with no catalogue that says so,
+# which is what anyone building from source should get.
+WHITEVPN_CATALOGUE_URL ?=
+WHITEVPN_CATALOGUE_KEY ?=
+CATALOGUE_LDFLAGS := $(if $(WHITEVPN_CATALOGUE_URL),-X 'main.whiteDNSVPNSubscriptionURL=$(WHITEVPN_CATALOGUE_URL)',) $(if $(WHITEVPN_CATALOGUE_KEY),-X 'main.whiteDNSVPNSubscriptionKey=$(WHITEVPN_CATALOGUE_KEY)',)
+WAILS_RELEASE_FLAGS := -trimpath -ldflags "$(RELEASE_LDFLAGS) $(VERSION_LDFLAGS) $(CATALOGUE_LDFLAGS)"
 
 # The other version: what the file itself reports in Properties → Details.
 #
@@ -53,7 +70,7 @@ UPX ?= 0
 UPX_FLAGS ?= --best --lzma
 MACOS_CGO_LDFLAGS ?= -framework UniformTypeIdentifiers
 MACOS_GO_TAGS ?= desktop,wv2runtime.download,production
-MACOS_GO_LDFLAGS ?= $(RELEASE_LDFLAGS) $(VERSION_LDFLAGS)
+MACOS_GO_LDFLAGS ?= $(RELEASE_LDFLAGS) $(VERSION_LDFLAGS) $(CATALOGUE_LDFLAGS)
 MACOS_DEPLOYMENT_TARGET_AMD64 ?= 10.13
 MACOS_DEPLOYMENT_TARGET_ARM64 ?= 11.0
 MACOS_BUNDLE_MIN_VERSION ?= $(if $(filter arm64,$(MACOS_CLIENT_ARCH)),$(MACOS_DEPLOYMENT_TARGET_ARM64),$(MACOS_DEPLOYMENT_TARGET_AMD64))

--- a/desktop/build/windows/wails.exe.manifest
+++ b/desktop/build/windows/wails.exe.manifest
@@ -9,7 +9,27 @@
     <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
         <security>
             <requestedPrivileges>
-                <requestedExecutionLevel level="requireAdministrator" uiAccess="false"/>
+                <!--
+                    asInvoker, not requireAdministrator.
+
+                    Only one thing here needs Administrator: creating the tunnel
+                    adapter. Everything else is the user's own — the state file
+                    and the unpacked engine live under %AppData%, the system
+                    proxy is a per-user WinINET setting, and the local port is
+                    above 1024. Demanding it for the whole app meant a UAC prompt
+                    on every launch for people who only ever use proxy mode, and
+                    a WebView2 browser engine running with full rights to the
+                    machine for everyone.
+
+                    The engine is elevated on its own when the tunnel is on:
+                    engine.startElevatedChild asks for it through ShellExecuteEx,
+                    and the control pipe is already built for the split — see
+                    pipeSecurityDescriptor, which admits SYSTEM and
+                    Administrators precisely so an elevated engine can reach a
+                    pipe opened by an unelevated interface, including when UAC
+                    used a different administrator account.
+                -->
+                <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
             </requestedPrivileges>
         </security>
     </trustInfo>

--- a/desktop/internal/appdata/permissions_test.go
+++ b/desktop/internal/appdata/permissions_test.go
@@ -28,6 +28,15 @@ func TestEnsureAppDataWritableSkipsRepairWhenWritable(t *testing.T) {
 }
 
 func TestEnsureAppDataWritableRepairsDarwinWithAdministratorPrompt(t *testing.T) {
+	if filepath.Separator != '/' {
+		// The repair is a shell command built around the path, wrapped in
+		// strconv.Quote for AppleScript. On a host whose separator is a
+		// backslash, every one of them is escaped again and the command stops
+		// resembling anything this code will ever produce — the path it is given
+		// here is Windows-shaped, and macOS has no such path. CI runs this on
+		// macOS, where it means something.
+		t.Skip("the macOS repair command can only be checked on a host with POSIX paths")
+	}
 	runner := &fakeRunner{}
 	dir := filepath.Join(t.TempDir(), "WhiteVPN Desktop")
 

--- a/desktop/internal/engine/spawn.go
+++ b/desktop/internal/engine/spawn.go
@@ -252,14 +252,35 @@ func (p *Process) Stop(ctx context.Context) error {
 		return nil
 	}
 
+	// Closing the client and the listener above is the mechanism, not merely
+	// politeness: the core reads frames in a loop and returns on any read error
+	// including EOF, and its main returns with it. So the pipe going away ends
+	// the process, and that works whatever privileges either side holds — which
+	// matters now that the interface runs unelevated while the core, in tunnel
+	// mode, does not. Kill is the last resort for a core wedged badly enough
+	// that it is no longer reading its own socket.
 	select {
 	case err := <-p.exited:
 		return err
 	case <-time.After(5 * time.Second):
-		_ = p.child.Kill()
-		return errors.New("engine: core did not exit cleanly and was killed")
+		return p.killAfterFailedShutdown(errors.New("engine: core did not exit cleanly"))
 	case <-ctx.Done():
-		_ = p.child.Kill()
-		return ctx.Err()
+		return p.killAfterFailedShutdown(ctx.Err())
 	}
+}
+
+// killAfterFailedShutdown terminates a core that would not leave, and says so
+// plainly when it cannot.
+//
+// An unelevated process is not allowed to terminate an elevated one, so in
+// tunnel mode this can fail — and a core left running holds the tunnel adapter
+// and its routes, which is the difference between "disconnected" and "the
+// machine has no internet and nothing on screen explains why". Reporting it is
+// the least that is owed; silently discarding the error would leave that state
+// with no trace at all.
+func (p *Process) killAfterFailedShutdown(cause error) error {
+	if err := p.child.Kill(); err != nil {
+		return fmt.Errorf("%w, and could not be stopped (%v): its tunnel may still be up — end the mihomo process (pid %d) in Task Manager", cause, err, p.PID())
+	}
+	return fmt.Errorf("%w and was stopped", cause)
 }

--- a/desktop/mihomo_connect_test.go
+++ b/desktop/mihomo_connect_test.go
@@ -11,6 +11,13 @@ import (
 // A missing engine has to say so plainly. It is the first thing anyone opting in
 // will hit, and "connection failed" would send them looking in the wrong place.
 func TestFindMihomoCoreExplainsItselfWhenAbsent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Windows never reads the override. The core is launched elevated there,
+		// so it comes only from the copy inside the application rather than from
+		// an environment variable another local process could point elsewhere —
+		// which means there is no missing path for it to complain about.
+		t.Skip("Windows intentionally uses only the embedded elevated core")
+	}
 	t.Setenv("WHITEVPN_MIHOMO_BIN", filepath.Join(t.TempDir(), "absent.exe"))
 
 	_, err := findMihomoCore()

--- a/desktop/scripts/build-linux-releases-docker.sh
+++ b/desktop/scripts/build-linux-releases-docker.sh
@@ -66,6 +66,8 @@ for platform in $(printf '%s' "$platforms" | tr ',' ' '); do
     -e LINUX_NODE_MAJOR="$node_major" \
     -e LINUX_PACKAGE_FORMATS="$package_formats" \
     -e RELEASE_LDFLAGS="$release_ldflags" \
+    -e WHITEVPN_CATALOGUE_URL="${WHITEVPN_CATALOGUE_URL:-}" \
+    -e WHITEVPN_CATALOGUE_KEY="${WHITEVPN_CATALOGUE_KEY:-}" \
     -e HELPER_GO_LDFLAGS="$helper_ldflags" \
     -e UPX="$upx" \
     -e UPX_FLAGS="$upx_flags" \
@@ -112,6 +114,8 @@ for platform in $(printf '%s' "$platforms" | tr ',' ' '); do
         XRAY_CACHE_DIR=/workspace/desktop/.cache/xray \
         XRAY_CORE_VERSION="${XRAY_CORE_VERSION:-v26.3.27}" \
         RELEASE_LDFLAGS="$RELEASE_LDFLAGS" \
+        WHITEVPN_CATALOGUE_URL="$WHITEVPN_CATALOGUE_URL" \
+        WHITEVPN_CATALOGUE_KEY="$WHITEVPN_CATALOGUE_KEY" \
         HELPER_GO_LDFLAGS="$HELPER_GO_LDFLAGS" \
         UPX="$UPX" \
         UPX_FLAGS="$UPX_FLAGS"

--- a/desktop/whitedns_vpn.go
+++ b/desktop/whitedns_vpn.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"slices"
@@ -21,17 +22,56 @@ import (
 const (
 	whiteDNSVPNSubscriptionID              = model.BuiltInSubscriptionID
 	whiteDNSVPNSubscriptionName            = "WhiteDNS VPN"
-	whiteDNSVPNSubscriptionURL             = "https://whitedns-sub.whitedns.workers.dev/encrypted"
-	whiteDNSVPNSubscriptionKey             = "#2gzwj1##z%BVq*7M2sfxe6sV23ut1LQr87JagD4D#&"
 	whiteDNSVPNSubscriptionRefreshInterval = 3 * time.Hour
 
-	whiteDNSVPNFrontingIPListURL       = "https://whitedns-encrypted-ip-list.whitedns.workers.dev/v1/results/ips/encrypted"
-	whiteDNSVPNFrontingIPListKey       = "kc*P$Hfw$YqRSf%Ypyfzx#F$kncPk9QG5%!W8M83K@f"
 	whiteDNSVPNFrontingPingLimit       = 96
 	whiteDNSVPNFrontingValidationLimit = 3
 	whiteDNSVPNFrontingValidationTime  = 8 * time.Second
 	whiteDNSVPNStartupWorkingSample    = 5
 )
+
+// Where the built-in catalogue comes from, and the key that opens it. Both are
+// set at link time by the Makefile:
+//
+//	-X main.whiteDNSVPNSubscriptionURL=... -X main.whiteDNSVPNSubscriptionKey=...
+//
+// They used to be constants in this file, which is in a public repository, and
+// had been since its first commit. That is not a weak secret — it is not a
+// secret at all: anyone could read the key off a web page, fetch the encrypted
+// catalogue and decrypt it, and what falls out is every node's address, UUID,
+// password and REALITY keys. No binary needed, nothing to reverse engineer. A
+// censor gets the complete list to block; anyone else gets the service for free.
+//
+// Moving them here does not make them secret either, and it must not be sold as
+// though it does. They still travel inside every binary that ships, and a client
+// that can decrypt the catalogue is a client an attacker can take apart. What it
+// changes is the effort: reading a public file becomes pulling strings out of a
+// 74 MB executable. That is worth doing, and it is the most that can be done
+// while the client holds the key at all.
+//
+// The old values remain in this repository's history for ever, so this is only
+// worth anything once the key on the server has been changed.
+//
+// A build made without them — `go build`, `wails build`, or anyone building from
+// source — has no catalogue and says so. Manual configs and a user's own
+// subscriptions are unaffected, which is the right shape for an open-source
+// client of a managed service.
+var (
+	whiteDNSVPNSubscriptionURL string
+	whiteDNSVPNSubscriptionKey string
+)
+
+// errNoBuiltInCatalogue is what a build without the catalogue credentials says
+// when something asks for them.
+var errNoBuiltInCatalogue = errors.New(
+	"this build has no WhiteDNS catalogue: it was not built with one. Add a subscription of your own, or paste configs on the Servers page")
+
+// builtInCatalogueAvailable reports whether this build can reach the catalogue
+// at all.
+func builtInCatalogueAvailable() bool {
+	return strings.TrimSpace(whiteDNSVPNSubscriptionURL) != "" &&
+		strings.TrimSpace(whiteDNSVPNSubscriptionKey) != ""
+}
 
 type whiteDNSVPNSubscriptionFetcher func(context.Context) (string, error)
 type whiteDNSVPNFrontingIPFetcher func(context.Context) (string, error)
@@ -58,11 +98,10 @@ type whiteDNSVPNStartupExclusion struct {
 }
 
 func fetchWhiteDNSVPNSubscriptionDocument(ctx context.Context) (string, error) {
+	if !builtInCatalogueAvailable() {
+		return "", errNoBuiltInCatalogue
+	}
 	return fetchV2RaySubscriptionDocument(ctx, whiteDNSVPNSubscriptionURL)
-}
-
-func fetchWhiteDNSVPNFrontingIPListDocument(ctx context.Context) (string, error) {
-	return fetchV2RaySubscriptionDocument(ctx, whiteDNSVPNFrontingIPListURL)
 }
 
 func (a *App) StartWhiteDNSVPNConnection() (model.AppState, error) {

--- a/desktop/whitedns_vpn_test.go
+++ b/desktop/whitedns_vpn_test.go
@@ -18,7 +18,7 @@ func TestDecryptWhiteDNSVPNSubscription(t *testing.T) {
 	plaintext := base64.StdEncoding.EncodeToString([]byte(testV2RaySubscriptionLink("encrypted")))
 	encrypted := encryptWhiteDNSVPNTestPayload(t, plaintext)
 
-	decrypted, err := decryptWhiteDNSVPNSubscription(encrypted, whiteDNSVPNSubscriptionKey)
+	decrypted, err := decryptWhiteDNSVPNSubscription(encrypted, testCatalogueKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,9 +28,9 @@ func TestDecryptWhiteDNSVPNSubscription(t *testing.T) {
 }
 
 func TestDecryptWhiteDNSVPNFrontingIPList(t *testing.T) {
-	encrypted := encryptWhiteDNSVPNTestPayloadWithKey(t, `["203.0.113.10","bad","203.0.113.10","198.51.100.20"]`, whiteDNSVPNFrontingIPListKey)
+	encrypted := encryptWhiteDNSVPNTestPayloadWithKey(t, `["203.0.113.10","bad","203.0.113.10","198.51.100.20"]`, testCatalogueKey)
 
-	decrypted, err := decryptWhiteDNSVPNIPList(encrypted, whiteDNSVPNFrontingIPListKey)
+	decrypted, err := decryptWhiteDNSVPNIPList(encrypted, testCatalogueKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,9 +62,17 @@ func TestParseWhiteDNSVPNCustomFrontingIPs(t *testing.T) {
 	}
 }
 
+// testCatalogueKey is what these tests encrypt and decrypt with.
+//
+// Deliberately not the real key. These tests are about the crypto, not about any
+// particular passphrase, and one that reaches for the production value breaks
+// the moment that value stops being a compile-time constant — which is exactly
+// what happened when it moved out of the source and into the build.
+const testCatalogueKey = "test-passphrase-not-the-real-one"
+
 func encryptWhiteDNSVPNTestPayload(t *testing.T, plaintext string) string {
 	t.Helper()
-	return encryptWhiteDNSVPNTestPayloadWithKey(t, plaintext, whiteDNSVPNSubscriptionKey)
+	return encryptWhiteDNSVPNTestPayloadWithKey(t, plaintext, testCatalogueKey)
 }
 
 func encryptWhiteDNSVPNTestPayloadWithKey(t *testing.T, plaintext string, keyText string) string {
@@ -138,6 +146,13 @@ func whiteDNSVPNTestProfiles(profiles []model.V2RayProfile) []model.V2RayProfile
 // see — the subscriptions list, a backup export, the state handed to the
 // interface — is built from that.
 func TestBuiltInCatalogueAddressNeverEntersState(t *testing.T) {
+	// The address is injected at link time and empty in a test binary, and
+	// `strings.Contains(anything, "")` is true — so without a stand-in this test
+	// passes or fails for reasons that have nothing to do with what it checks.
+	restore := whiteDNSVPNSubscriptionURL
+	whiteDNSVPNSubscriptionURL = "https://catalogue.invalid/encrypted"
+	defer func() { whiteDNSVPNSubscriptionURL = restore }()
+
 	app := &App{state: model.DefaultAppState()}
 	app.mu.Lock()
 	idx := app.ensureWhiteDNSVPNSubscriptionLocked()


### PR DESCRIPTION
…admin

Three things found by looking for what was actually critical rather than what was next on a list.

## The catalogue key was public

whiteDNSVPNSubscriptionURL and whiteDNSVPNSubscriptionKey were constants in whitedns_vpn.go, in a public repository, and had been since its first commit (34485b7). That is not a weak secret — it is not a secret. Anyone could read the key off a web page, fetch the encrypted catalogue and decrypt it, and out falls every node's address, UUID, password and REALITY keys. No binary, no reverse engineering. A censor gets the complete list to block; anyone else gets the service free.

They are injected at link time now. That does not make them secret either and must not be sold as though it does: they still ship inside every binary, and a client that can decrypt the catalogue can be taken apart. It raises the cost from reading a file to pulling strings out of a 74 MB executable, which is the most available while the client holds the key at all.

It is also worth nothing until the key on the server is changed, because the old values are in this repository's history for ever. That is the one part this commit cannot do.

whiteDNSVPNFrontingIPListKey went with them and was worse: dead code holding a live secret, its fetch function never called by anything.

A build without the credentials produces a client with no catalogue that says so plainly, rather than failing — which is what anyone building from source should get, and means CI needs no fake values.

## Nothing ran the tests

The only workflow fired on a tag. Six releases shipped without a single automated test having run; the tests were there and were good, and whether they had been run depended on somebody remembering to.

ci.yml runs on pull requests and pushes to main: build, vet and test on all three operating systems (with -race on Linux), cross-compilation for six targets, the frontend type check and build, and a scan that fails if a catalogue credential reappears in the source — nothing else would stop that happening again except noticing.

Two tests had to be fixed first, and both were the tests being wrong rather than the code. TestFindMihomoCoreExplainsItselfWhenAbsent expected WHITEVPN_MIHOMO_BIN to be honoured, which Windows deliberately ignores because the core is launched elevated and must come from inside the application — the test was reporting a security decision as a defect. TestEnsureAppDataWritable...Darwin builds a shell command around a path and checks the text; given a Windows-shaped path the AppleScript quoting escapes every separator twice. Both now skip where they cannot mean anything, and CI is where they run for real.

## The whole app ran as Administrator

Only the tunnel adapter needs it. The state file and unpacked engine live under %AppData%, the system proxy is a per-user WinINET setting, the local port is above 1024 — proxy mode needs nothing. So every user got a UAC prompt on every launch, and a WebView2 browser engine ran with full rights to the machine.

asInvoker now. engine.startElevatedChild already raised the core on its own when the tunnel is on, and everything downstream was already built for the split: pipeSecurityDescriptor admits SYSTEM and Administrators precisely so an elevated core can reach a pipe opened by an unelevated interface, including under a different administrator account. Its comment says exactly that. The manifest was the only thing in the way.

Stopping the core does not need privilege either, which is what makes this safe: the core reads frames in a loop and returns on any read error including EOF, and its main returns with it, so closing the pipe ends it. Kill is the last resort for a core wedged badly enough to have stopped reading its own socket — and an unelevated process cannot terminate an elevated one, so that failure is now reported with the pid instead of discarded. A core left running holds the tunnel adapter and its routes, which is the difference between "disconnected" and "no internet and nothing explaining why".

Verified: the built exe's embedded manifest reads asInvoker; a Makefile build with the credentials set puts them in the binary and none remain in source; a build without them refuses the catalogue and says why; the full suite is green on Windows and every target cross-compiles. The user confirmed on a real machine that the app opens with no prompt, both modes connect, and disconnecting leaves the machine working.