### PR TITLE
Make two more settings do something, and stop the console flashing

### DIFF
--- a/desktop/ANDROID-PARITY.md
+++ b/desktop/ANDROID-PARITY.md
@@ -114,8 +114,34 @@ VPN off while the interface still said Connected.
 |---|---|---|---|
 | TLS integrity | `white_dns_tls_integrity` / `enabled` | `false` | `[x]` |
 
-Probes certificate validity and quarantines a failing endpoint for 24 h
-(`white_dns_scan_state` → `tls_quarantine:*`).
+**What it actually is, because the name misleads.** Not a check on the server's
+own certificate before connecting — it is a check for *interception*. After the
+connection is up it makes an HTTPS request through the proxy and looks at whether
+the certificate verifies. If something between this machine and the internet is
+terminating TLS and re-issuing certificates, every request succeeds, the health
+check passes, the dashboard is green, and the connection is being read. The
+certificate is the only thing that says so.
+
+It fails **closed** on a certificate failure and **open** on anything else, which
+is the line Android draws too (`"all probes unreachable; allowing connection"`).
+The asymmetry is deliberate: a rejected certificate is evidence, while
+unreachable is the ordinary condition of these networks, and refusing to connect
+whenever three URLs are blocked would make the setting unusable exactly where it
+matters. `TestInterceptedTLSIsRefused` stands up a real intercepting proxy with
+its own authority and checks the connection is refused.
+
+A node that fails is rejected and the walk moves to the next, rather than the
+connect being abandoned.
+
+Android's 24-hour quarantine (`white_dns_scan_state` → `tls_quarantine:*`) is not
+ported: it keys on clean-IP scan endpoints, and the scan is `[ ]` here.
+
+**Both of these were stored and never read**, like split tunnelling and IP
+fronting before them: shown, validated, saved, and connected to nothing. The
+noise settings reach WireGuard proxies and nothing else — that is not a shortcut,
+the noise is AmneziaWG's and mihomo has nowhere to put it on a vless or trojan
+proxy, and Android draws the same line. The interface says so rather than letting
+someone turn it on and wonder.
 
 ### 2.2 WARP / Amnezia noise (`settings_warp_section`)
 

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -597,8 +597,8 @@ const strings = {
   },
   "settings.tlsIntegrity": { en: "TLS integrity", fa: "یکپارچگی TLS" },
   "settings.tlsIntegrity.description": {
-    en: "Verifies a server's certificate before connecting, and sets aside any that fail for a day.",
-    fa: "گواهی سرور را پیش از اتصال بررسی می‌کند و هر سروری را که رد شود یک روز کنار می‌گذارد.",
+    en: "After connecting, checks that certificates still verify through the tunnel. A node where they do not is being read, and is refused.",
+    fa: "بعد از اتصال بررسی می‌کند که گواهی‌ها از داخل تونل معتبر بمانند. سروری که این بررسی را رد کند در حال شنود شدن است و پذیرفته نمی‌شود.",
   },
 
   "settings.dns.title": { en: "DNS privacy", fa: "حریم خصوصی DNS" },
@@ -655,8 +655,8 @@ const strings = {
 
   "settings.noise.title": { en: "Obfuscation", fa: "Amnezia Noise" },
   "settings.noise.description": {
-    en: "Pad the connection with noise so its shape is less recognisable.",
-    fa: "اتصال را با نویز پر می‌کند تا الگویش کمتر قابل تشخیص باشد.",
+    en: "Pad the connection with noise so its shape is less recognisable. Applies to WireGuard servers only — it has no effect on any other kind.",
+    fa: "اتصال را با نویز پر می‌کند تا الگویش کمتر قابل تشخیص باشد. فقط روی سرورهای WireGuard اثر دارد و روی بقیهٔ انواع هیچ تأثیری ندارد.",
   },
   "settings.noise.enable": { en: "Amnezia noise", fa: "فعال‌سازی Amnezia Noise" },
   "settings.noise.count": { en: "Packets", fa: "تعداد" },

--- a/desktop/internal/mihomoconf/noise.go
+++ b/desktop/internal/mihomoconf/noise.go
@@ -1,0 +1,80 @@
+package mihomoconf
+
+import "strings"
+
+// Padding a WireGuard connection with junk so its shape is less recognisable.
+//
+// This is the phone's WARP/Amnezia noise setting, and like split tunnelling and
+// IP fronting before it, the desktop stored it, validated it, showed it, and
+// never read it — three numeric fields and a switch that changed nothing.
+//
+// It applies to WireGuard and nothing else. That is not a shortcut: the noise is
+// AmneziaWG's, implemented in the WireGuard outbound, and mihomo has nowhere to
+// put it on a vless or trojan proxy. Android draws the same line —
+//
+//	amneziaNoise = if (options.amneziaNoiseEnabled && profile.type.equals("wireguard", true))
+//
+// — so a subscription with no WireGuard nodes is one where this setting still
+// changes nothing, correctly. The interface has to say that rather than let
+// someone turn it on and wonder.
+
+// AmneziaNoise is how much junk to pad a WireGuard handshake with.
+//
+// The three numbers are mihomo's jc, jmin and jmax: how many junk packets, and
+// the smallest and largest each may be.
+type AmneziaNoise struct {
+	Enabled bool
+	Count   int
+	MinSize int
+	MaxSize int
+}
+
+// usable reports whether this would change anything if applied.
+//
+// A count of zero is off however the switch is set — mihomo would take it as "no
+// junk packets", which is what not enabling it means anyway, and writing the
+// option to say nothing only makes the config harder to read.
+func (n AmneziaNoise) usable() bool {
+	return n.Enabled && n.Count > 0 && n.MinSize > 0 && n.MaxSize >= n.MinSize
+}
+
+// ApplyAmneziaNoise pads every WireGuard proxy in the list, and reports how many
+// it reached.
+//
+// The count is worth having rather than discarding: a user who turned this on
+// against a catalogue of vless nodes has changed nothing, and the only way to
+// tell them so is to know.
+func ApplyAmneziaNoise(proxies []Proxy, noise AmneziaNoise) ([]Proxy, int) {
+	if !noise.usable() {
+		return proxies, 0
+	}
+
+	out := make([]Proxy, 0, len(proxies))
+	changed := 0
+	for _, proxy := range proxies {
+		if !isWireGuard(proxy) {
+			out = append(out, proxy)
+			continue
+		}
+		// Copied rather than written through: the caller's slice holds the
+		// proxies parsed from the subscription, and a setting should not edit
+		// what the subscription said.
+		next := make(Proxy, len(proxy)+1)
+		for key, value := range proxy {
+			next[key] = value
+		}
+		next["amnezia-wg-option"] = map[string]any{
+			"jc":   noise.Count,
+			"jmin": noise.MinSize,
+			"jmax": noise.MaxSize,
+		}
+		out = append(out, next)
+		changed++
+	}
+	return out, changed
+}
+
+func isWireGuard(proxy Proxy) bool {
+	value, _ := proxy["type"].(string)
+	return strings.EqualFold(strings.TrimSpace(value), "wireguard")
+}

--- a/desktop/internal/mihomoconf/noise_test.go
+++ b/desktop/internal/mihomoconf/noise_test.go
@@ -1,0 +1,82 @@
+package mihomoconf
+
+import "testing"
+
+func wireGuardProxy(name string) Proxy {
+	return Proxy{"name": name, "type": "wireguard", "server": "a.example.com", "port": 51820}
+}
+
+func vlessProxy(name string) Proxy {
+	return Proxy{"name": name, "type": "vless", "server": "b.example.com", "port": 443}
+}
+
+func TestNoisePadsWireGuardOnly(t *testing.T) {
+	proxies := []Proxy{wireGuardProxy("wg"), vlessProxy("vless")}
+
+	out, changed := ApplyAmneziaNoise(proxies, AmneziaNoise{Enabled: true, Count: 5, MinSize: 50, MaxSize: 100})
+	if changed != 1 {
+		t.Fatalf("expected one proxy padded, got %d", changed)
+	}
+
+	options, ok := out[0]["amnezia-wg-option"].(map[string]any)
+	if !ok {
+		t.Fatalf("the WireGuard proxy was not padded: %#v", out[0])
+	}
+	if options["jc"] != 5 || options["jmin"] != 50 || options["jmax"] != 100 {
+		t.Fatalf("unexpected options: %#v", options)
+	}
+	// mihomo has nowhere to put this on a vless proxy, and writing it would be a
+	// key the engine does not know on a type that cannot use it.
+	if _, present := out[1]["amnezia-wg-option"]; present {
+		t.Fatalf("a vless proxy should be untouched: %#v", out[1])
+	}
+}
+
+// A subscription of vless nodes is one where this setting changes nothing, and
+// the count is how the interface can say so instead of leaving someone to wonder.
+func TestNoiseReportsWhenItReachesNothing(t *testing.T) {
+	_, changed := ApplyAmneziaNoise([]Proxy{vlessProxy("a"), vlessProxy("b")},
+		AmneziaNoise{Enabled: true, Count: 5, MinSize: 50, MaxSize: 100})
+	if changed != 0 {
+		t.Fatalf("expected nothing padded, got %d", changed)
+	}
+}
+
+func TestNoiseOffChangesNothing(t *testing.T) {
+	proxies := []Proxy{wireGuardProxy("wg")}
+	out, changed := ApplyAmneziaNoise(proxies, AmneziaNoise{Enabled: false, Count: 5, MinSize: 50, MaxSize: 100})
+	if changed != 0 {
+		t.Fatalf("expected nothing padded, got %d", changed)
+	}
+	if _, present := out[0]["amnezia-wg-option"]; present {
+		t.Fatal("the proxy should be untouched")
+	}
+}
+
+// Numbers that would tell mihomo to add no junk are the same as the switch being
+// off, and writing the option to say nothing only makes the config harder to read.
+func TestNoiseIgnoresNumbersThatSayNothing(t *testing.T) {
+	for _, noise := range []AmneziaNoise{
+		{Enabled: true, Count: 0, MinSize: 50, MaxSize: 100},
+		{Enabled: true, Count: 5, MinSize: 0, MaxSize: 100},
+		// A largest smaller than the smallest is not a range.
+		{Enabled: true, Count: 5, MinSize: 100, MaxSize: 50},
+	} {
+		if _, changed := ApplyAmneziaNoise([]Proxy{wireGuardProxy("wg")}, noise); changed != 0 {
+			t.Errorf("%#v should have been ignored", noise)
+		}
+	}
+}
+
+// The proxies come from the subscription; a setting must not edit what the
+// subscription said.
+func TestNoiseDoesNotAlterTheProxiesItWasGiven(t *testing.T) {
+	original := wireGuardProxy("wg")
+	proxies := []Proxy{original}
+
+	ApplyAmneziaNoise(proxies, AmneziaNoise{Enabled: true, Count: 5, MinSize: 50, MaxSize: 100})
+
+	if _, present := original["amnezia-wg-option"]; present {
+		t.Fatal("the caller's proxy was modified in place")
+	}
+}

--- a/desktop/internal/session/process_other.go
+++ b/desktop/internal/session/process_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package session
+
+import "os/exec"
+
+// Only Windows gives a console program a window to hide.
+func hideConsoleWindow(_ *exec.Cmd) {}

--- a/desktop/internal/session/process_windows.go
+++ b/desktop/internal/session/process_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package session
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// createNoWindow stops a console program putting a window on screen.
+//
+// PowerShell is a console program, so starting one from a GUI app flashes a
+// window over the interface. Reading the tunnel's routes is polled while the
+// adapter comes up, so this was not one flash but a stutter of them across every
+// connect in tunnel mode — reported by a user as, fairly, "very ugly".
+//
+// `internal/firewall` and `internal/appdata` each already had this file. This
+// package ran a command without it.
+const createNoWindow = 0x08000000
+
+func hideConsoleWindow(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= createNoWindow
+}

--- a/desktop/internal/session/session.go
+++ b/desktop/internal/session/session.go
@@ -66,9 +66,18 @@ type Options struct {
 	// that makes Automatic work at all.
 	Exclude []string
 
+	// VerifyTLSIntegrity refuses a node whose certificates do not verify through
+	// the tunnel, which is what interception looks like from here.
+	VerifyTLSIntegrity bool
+
 	// SplitTunnel routes named programs around the tunnel, or only them through
 	// it. Empty means everything goes through it.
 	SplitTunnel mihomoconf.SplitTunnel
+
+	// Noise pads WireGuard proxies so their shape is less recognisable. It
+	// reaches nothing else, because the noise is AmneziaWG's and mihomo has
+	// nowhere to put it on a vless or trojan proxy.
+	Noise mihomoconf.AmneziaNoise
 
 	// FrontingIP reaches every eligible node through this address instead of the
 	// one its name resolves to, while still presenting the name. Empty means the
@@ -267,6 +276,15 @@ func (s *Session) start(ctx context.Context, opts Options) error {
 
 	probe := func(probeCtx context.Context) int { return probeStatus(probeCtx, opts.MixedPort) }
 	acceptHealthy := func(code int) error {
+		// Carrying traffic is not the same as carrying it privately. If whatever
+		// sits between here and the internet is terminating TLS, every request
+		// succeeds and the connection is being read — so a node that answers is
+		// still refused when its certificates do not verify.
+		if opts.VerifyTLSIntegrity {
+			if err := verifyTLSIntegrity(ctx, opts.MixedPort); err != nil {
+				return err
+			}
+		}
 		if opts.Tun.Enabled {
 			switch err := waitForTunnel(ctx, opts.Tun.Device, opts.Tun.IPv6); {
 			case err == nil:
@@ -316,12 +334,21 @@ func (s *Session) start(ctx context.Context, opts Options) error {
 			code, err := waitForHealthy(ctx, probe)
 			if err == nil {
 				if err := acceptHealthy(code); err != nil {
-					return err
+					// Interception is about this node, not about the app: reject
+					// it and let the walk below try another. Anything else — a
+					// tunnel that never came up — is not survivable by changing
+					// node.
+					if !errors.Is(err, ErrTLSIntercepted) {
+						return err
+					}
+					lastErr = err
+				} else {
+					s.selected = s.resolveSelection(ctx)
+					return nil
 				}
-				s.selected = s.resolveSelection(ctx)
-				return nil
+			} else {
+				lastErr = fmt.Errorf("automatic selection: %w", err)
 			}
-			lastErr = fmt.Errorf("automatic selection: %w", err)
 		}
 	}
 
@@ -357,7 +384,12 @@ func (s *Session) start(ctx context.Context, opts Options) error {
 		code, err := waitForHealthy(ctx, probe)
 		if err == nil {
 			if err := acceptHealthy(code); err != nil {
-				return err
+				if !errors.Is(err, ErrTLSIntercepted) {
+					return err
+				}
+				// This node's certificates did not verify. Another may.
+				lastErr = fmt.Errorf("%q: %w", candidate, err)
+				continue
 			}
 			// The group is pinned to this node now, so the engine is no longer the
 			// one choosing and recovery has to do the choosing instead.
@@ -641,6 +673,9 @@ func PrepareConfig(opts Options) (string, []string, error) {
 			}
 			proxies = kept
 		}
+		// Before fronting, which only rewrites addresses: the two are
+		// independent and a WireGuard node can have both.
+		proxies, _ = mihomoconf.ApplyAmneziaNoise(proxies, opts.Noise)
 		if opts.FrontingIP != "" {
 			// Nodes fronting cannot be applied to are left reachable at their own
 			// address rather than dropped: a front that covers most of the list is

--- a/desktop/internal/session/tlsintegrity.go
+++ b/desktop/internal/session/tlsintegrity.go
@@ -1,0 +1,120 @@
+package session
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Checking that nobody is opening the TLS on the way through.
+//
+// A tunnel can carry traffic perfectly and still not be private: if whatever is
+// between this machine and the internet is terminating TLS and re-issuing
+// certificates, every page loads, the health check passes, the dashboard is
+// green, and the connection is being read. The certificate is the only thing
+// that says so.
+//
+// The ordinary health probe cannot tell. It verifies certificates — Go's default
+// transport does — but it treats every error the same and moves to the next URL,
+// so an intercepted connection is indistinguishable from a blocked one. This
+// looks at *why* a request failed.
+//
+// It fails closed on a certificate failure and open on anything else, which is
+// the same line Android draws ("all probes unreachable; allowing connection").
+// The asymmetry is deliberate: a rejected certificate is evidence, while
+// unreachable is the normal condition of the networks this app runs on, and
+// refusing to connect every time three URLs are blocked would make the setting
+// unusable exactly where it matters.
+const (
+	tlsIntegrityProbeTimeout = 2 * time.Second
+	tlsIntegrityBudget       = 7 * time.Second
+)
+
+// ErrTLSIntercepted means a certificate did not verify through the tunnel.
+var ErrTLSIntercepted = errors.New("session: TLS is being intercepted on this connection — certificates do not verify")
+
+// verifyTLSIntegrity returns ErrTLSIntercepted when traffic through the proxy
+// meets a certificate that does not check out.
+func verifyTLSIntegrity(ctx context.Context, proxyPort int) error {
+	proxyURL, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", proxyPort))
+	if err != nil {
+		return nil
+	}
+	deadline, cancel := context.WithTimeout(ctx, tlsIntegrityBudget)
+	defer cancel()
+
+	client := &http.Client{
+		Timeout: tlsIntegrityProbeTimeout,
+		// No TLSClientConfig, so Go verifies the chain and the host name. That
+		// verification is the whole check; skipping it here — as a health probe
+		// might reasonably do — would make this function a no-op that looks like
+		// a security feature.
+		Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)},
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	for _, target := range healthURLs {
+		if deadline.Err() != nil {
+			break
+		}
+		request, err := http.NewRequestWithContext(deadline, http.MethodGet, target, nil)
+		if err != nil {
+			continue
+		}
+		response, err := client.Do(request)
+		if err == nil {
+			_ = response.Body.Close()
+			// One verified handshake is enough. If TLS were being opened, this
+			// is where it would have failed.
+			return nil
+		}
+		if isCertificateFailure(err) {
+			return fmt.Errorf("%w (%s)", ErrTLSIntercepted, hostOf(target))
+		}
+	}
+
+	// Nothing answered. That says nothing about interception, so it must not be
+	// read as evidence of it.
+	return nil
+}
+
+// isCertificateFailure reports whether an error is TLS refusing a certificate,
+// as opposed to the request never getting that far.
+//
+// The distinction is the entire point: connection refused, a timeout and a
+// blocked address are all ordinary here, and treating them as interception would
+// make the setting refuse to connect on any censored network.
+func isCertificateFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	var verification *tls.CertificateVerificationError
+	if errors.As(err, &verification) {
+		return true
+	}
+	var unknownAuthority x509.UnknownAuthorityError
+	if errors.As(err, &unknownAuthority) {
+		return true
+	}
+	var hostname x509.HostnameError
+	if errors.As(err, &hostname) {
+		return true
+	}
+	var invalid x509.CertificateInvalidError
+	return errors.As(err, &invalid)
+}
+
+func hostOf(target string) string {
+	parsed, err := url.Parse(target)
+	if err != nil {
+		return target
+	}
+	return parsed.Host
+}

--- a/desktop/internal/session/tlsintegrity_mitm_test.go
+++ b/desktop/internal/session/tlsintegrity_mitm_test.go
@@ -1,0 +1,146 @@
+package session
+
+import (
+	"bufio"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// The case the setting exists for, stood up for real.
+//
+// A proxy that terminates TLS and re-issues certificates from an authority
+// nobody trusts is exactly what interception looks like from inside the tunnel:
+// every request completes, the health check passes, the dashboard goes green,
+// and the connection is being read. The only thing that says so is the
+// certificate — so this builds one and checks that the connection is refused.
+func TestInterceptedTLSIsRefused(t *testing.T) {
+	intercepting := startInterceptingProxy(t)
+
+	err := verifyTLSIntegrity(t.Context(), intercepting)
+	if err == nil {
+		t.Fatal("an intercepted connection was accepted")
+	}
+	if !errors.Is(err, ErrTLSIntercepted) {
+		t.Fatalf("expected interception to be named, got %v", err)
+	}
+	t.Logf("refused, as it should be: %v", err)
+}
+
+// startInterceptingProxy runs an HTTP proxy that answers CONNECT itself and
+// presents a certificate from an authority the machine does not trust, then
+// returns the port it listens on.
+func startInterceptingProxy(t *testing.T) int {
+	t.Helper()
+
+	authority, authorityKey := selfSignedAuthority(t)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			client, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go interceptOne(client, authority, authorityKey)
+		}
+	}()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func interceptOne(client net.Conn, authority *x509.Certificate, authorityKey *ecdsa.PrivateKey) {
+	defer client.Close()
+
+	request, err := http.ReadRequest(bufio.NewReader(client))
+	if err != nil || request.Method != http.MethodConnect {
+		return
+	}
+	host, _, err := net.SplitHostPort(request.Host)
+	if err != nil {
+		host = request.Host
+	}
+	if _, err := io.WriteString(client, "HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+		return
+	}
+
+	// From here the proxy is the TLS server, which is the interception.
+	leaf, leafKey := issueFor(host, authority, authorityKey)
+	if leaf == nil {
+		return
+	}
+	server := tls.Server(client, &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{leaf.Raw, authority.Raw},
+			PrivateKey:  leafKey,
+		}},
+	})
+	_ = server.SetDeadline(time.Now().Add(5 * time.Second))
+	// The handshake is where the client rejects us; nothing after it matters.
+	_ = server.Handshake()
+	_ = server.Close()
+}
+
+func selfSignedAuthority(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Not A Real Authority"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificate, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return certificate, key
+}
+
+func issueFor(host string, authority *x509.Certificate, authorityKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: host},
+		DNSNames:     []string{host},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, authority, &key.PublicKey, authorityKey)
+	if err != nil {
+		return nil, nil
+	}
+	certificate, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil
+	}
+	return certificate, key
+}

--- a/desktop/internal/session/tlsintegrity_test.go
+++ b/desktop/internal/session/tlsintegrity_test.go
@@ -1,0 +1,75 @@
+package session
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+)
+
+// The whole check turns on this distinction. A rejected certificate is evidence
+// of interception; connection refused is the normal condition of the networks
+// this app runs on, and treating the two alike would either miss the attack or
+// refuse to connect anywhere.
+func TestCertificateFailuresAreToldApartFromUnreachable(t *testing.T) {
+	certificateFailures := []error{
+		&tls.CertificateVerificationError{Err: errors.New("bad chain")},
+		x509.UnknownAuthorityError{},
+		x509.HostnameError{Host: "example.com"},
+		x509.CertificateInvalidError{Reason: x509.Expired},
+		// Wrapped, because that is how they arrive out of net/http.
+		fmt.Errorf("Get %q: %w", "https://example.com",
+			&tls.CertificateVerificationError{Err: errors.New("bad chain")}),
+	}
+	for _, err := range certificateFailures {
+		if !isCertificateFailure(err) {
+			t.Errorf("%T should count as a certificate failure", err)
+		}
+	}
+
+	ordinary := []error{
+		nil,
+		errors.New("connection refused"),
+		&net.OpError{Op: "dial", Err: errors.New("network is unreachable")},
+		context_DeadlineExceeded(),
+		fmt.Errorf("Get %q: %w", "https://example.com", errors.New("EOF")),
+	}
+	for _, err := range ordinary {
+		if isCertificateFailure(err) {
+			t.Errorf("%v should not count as a certificate failure", err)
+		}
+	}
+}
+
+func context_DeadlineExceeded() error {
+	return errors.New("context deadline exceeded")
+}
+
+func TestHostOfNamesTheServerInTheFailure(t *testing.T) {
+	if host := hostOf("https://cloudflare.com/cdn-cgi/trace"); host != "cloudflare.com" {
+		t.Fatalf("got %q", host)
+	}
+	// Something unparseable is reported as-is rather than swallowed.
+	if host := hostOf("::nonsense"); host == "" {
+		t.Fatal("an unparseable target should still be named")
+	}
+}
+
+// Nothing answering says nothing about interception. Reading it as evidence
+// would make the setting refuse to connect on any censored network, which is
+// where it is most needed.
+func TestUnreachableProbesDoNotReportInterception(t *testing.T) {
+	// Nothing is listening on this port, so every probe fails to connect.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	_ = listener.Close()
+
+	if err := verifyTLSIntegrity(t.Context(), port); err != nil {
+		t.Fatalf("an unreachable proxy should not be reported as interception: %v", err)
+	}
+}

--- a/desktop/internal/session/tun.go
+++ b/desktop/internal/session/tun.go
@@ -22,8 +22,12 @@ import (
 // in tunnel mode": the proxy port is up straight away, so the request that
 // proves the connection works passes long before the adapter exists.
 const (
-	tunnelBudget       = 20 * time.Second
-	tunnelPollInterval = 500 * time.Millisecond
+	tunnelBudget = 20 * time.Second
+	// A second rather than half of one. Reading the adapter's routes on Windows
+	// costs a PowerShell process, and forty of them across a connect is a lot of
+	// work to ask for — the adapter is either there within a second or two of
+	// coming up, or it is not coming.
+	tunnelPollInterval = time.Second
 )
 
 // errTunnelUnverifiable means this platform has no way to inspect the adapter,

--- a/desktop/internal/session/tun_windows.go
+++ b/desktop/internal/session/tun_windows.go
@@ -54,6 +54,9 @@ func tunnelRoutes(device string) (string, error) {
 	command := exec.CommandContext(ctx, shell, "-NoProfile", "-NonInteractive", "-Command",
 		`$ErrorActionPreference='SilentlyContinue'; Get-NetRoute -InterfaceAlias $env:WHITEVPN_TUN_DEVICE | ForEach-Object { $_.DestinationPrefix }`)
 	command.Env = append(os.Environ(), "WHITEVPN_TUN_DEVICE="+device)
+	// Or a console window appears and vanishes for every check, and this is
+	// polled while the adapter comes up.
+	hideConsoleWindow(command)
 
 	out, err := command.CombinedOutput()
 	if err != nil {

--- a/desktop/mihomo_connect.go
+++ b/desktop/mihomo_connect.go
@@ -114,13 +114,18 @@ func (a *App) startWhiteDNSVPNWithMihomo() (model.AppState, error) {
 		// would be the worst of both.
 		Exclude:     a.hiddenNodeNames(a.selectedSubscriptionID()),
 		SplitTunnel: splitTunnelFor(settings),
-		FrontingIP:  frontingIP,
-		DNSPrivacy:  dnsPrivacyMode(settings.DNSPrivacy.Mode),
-		DoHURL:      settings.DNSPrivacy.DoHURL,
-		DoTEndpoint: settings.DNSPrivacy.DoTEndpoint,
-		Tun:         tunOptionsFor(settings),
-		CoreStdout:  mihomoLogWriter{app: a},
-		CoreStderr:  mihomoLogWriter{app: a},
+		// The fourth control that was stored and never read. It refuses a node
+		// whose certificates do not verify through the tunnel — a connection
+		// that carries traffic while being read is the failure it exists for.
+		VerifyTLSIntegrity: settings.TLSIntegrityEnabled,
+		Noise:              amneziaNoiseFor(settings),
+		FrontingIP:         frontingIP,
+		DNSPrivacy:         dnsPrivacyMode(settings.DNSPrivacy.Mode),
+		DoHURL:             settings.DNSPrivacy.DoHURL,
+		DoTEndpoint:        settings.DNSPrivacy.DoTEndpoint,
+		Tun:                tunOptionsFor(settings),
+		CoreStdout:         mihomoLogWriter{app: a},
+		CoreStderr:         mihomoLogWriter{app: a},
 	})
 	if err != nil {
 		a.reportConnectFailure(ctx, err.Error())
@@ -556,6 +561,20 @@ func tunOptionsFor(settings model.WhiteVPNSettings) mihomoconf.TunOptions {
 		return mihomoconf.TunOptions{Enabled: false}
 	}
 	return mihomoconf.DefaultTunOptions()
+}
+
+// amneziaNoiseFor turns the saved noise setting into the engine's shape.
+//
+// The third control that was stored and never read. It reaches WireGuard proxies
+// and nothing else, which is the line Android draws too, because the noise is
+// AmneziaWG's and mihomo has nowhere to put it on a vless or trojan node.
+func amneziaNoiseFor(settings model.WhiteVPNSettings) mihomoconf.AmneziaNoise {
+	return mihomoconf.AmneziaNoise{
+		Enabled: settings.AmneziaNoise.Enabled,
+		Count:   settings.AmneziaNoise.Count,
+		MinSize: settings.AmneziaNoise.MinSize,
+		MaxSize: settings.AmneziaNoise.MaxSize,
+	}
 }
 
 // splitTunnelFor turns the saved setting into the engine's shape.


### PR DESCRIPTION
## TLS integrity and Amnezia noise were stored and never read

The same shape as split tunnelling and IP fronting before them: shown in Settings, validated, saved, and connected to nothing outside internal/model. A user could turn either on and nothing whatsoever would change. An audit of every setting found these two; the kill switch is also unwired but its switch is greyed out, which is honest.

**TLS integrity is not what the name suggests.** It is not a check on the server's certificate before connecting — it is a check for interception. After the connection is up it makes an HTTPS request through the proxy and looks at whether the certificate verifies. If something between the machine and the internet is terminating TLS and re-issuing certificates, every request succeeds, the health check passes, the dashboard is green, and the connection is being read. The certificate is the only thing that says so.

The ordinary health probe cannot tell. It verifies certificates — Go's default transport does — but treats every error alike and moves to the next URL, so an intercepted connection is indistinguishable from a blocked one. This looks at why a request failed.

It fails closed on a certificate failure and open on anything else, which is the line Android draws ("all probes unreachable; allowing connection"). The asymmetry is deliberate: a rejected certificate is evidence, while unreachable is the ordinary condition of these networks, and refusing to connect whenever three URLs are blocked would make the setting useless exactly where it is needed. A node that fails is rejected and the walk moves on rather than the connect being abandoned.

TestInterceptedTLSIsRefused stands up a real intercepting proxy with its own authority and checks the connection is refused — it was worth building rather than trusting that the error types were right.

Android's 24-hour quarantine is not ported: it keys on clean-IP scan endpoints and that scan does not exist here.

**Amnezia noise** writes amnezia-wg-option with jc, jmin and jmax. It reaches WireGuard proxies and nothing else, which is not a shortcut — the noise is AmneziaWG's and mihomo has nowhere to put it on a vless or trojan proxy, and Android draws the same line. A catalogue without WireGuard nodes is one where this setting still changes nothing, correctly, so the interface says so.

Both descriptions were rewritten. The TLS one promised a day-long quarantine that describes Android's behaviour around a feature this app does not have.

## A console window flashed on every tunnel connect

Mine, and recent. Reading the tunnel's routes runs Get-NetRoute through PowerShell, which is a console program, so Windows gives it a window. When I fixed the tunnel-verification race I put that call in a loop polling every 500ms for 20 seconds — so it was not one flash but up to forty.

internal/firewall and internal/appdata each already had a process_windows.go doing exactly this. internal/session did not. It does now, following the same pattern, and the interval is a second rather than half of one: forty PowerShell processes is a lot of work to ask for even when nobody can see them.

Two tests still fail on this branch —
TestEnsureAppDataWritableRepairsDarwinWithAdministratorPrompt and TestFindMihomoCoreExplainsItselfWhenAbsent. Both predate it and both are fixed on the branch that adds CI; merging that one first means this arrives to a green main.