### PR TITLE
Give CI the embedded frontend it cannot build without

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,24 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
 
+      # main.go embeds frontend/dist, which is a build artifact and is not in the
+      # repository — so `go build` fails on a fresh checkout for want of a
+      # directory that only exists after the frontend has been built. It passed
+      # on the machine this was written on because that machine had one left
+      # over, which is the exact class of thing CI is for, and this was the first
+      # thing it caught.
+      #
+      # A placeholder rather than a real frontend build: this job compiles Go and
+      # runs Go tests, and what is inside the bundle makes no difference to
+      # either. The frontend job below builds it properly, and the release
+      # workflow ships what that produces.
+      - name: Placeholder for the embedded frontend
+        working-directory: desktop
+        shell: bash
+        run: |
+          mkdir -p frontend/dist
+          echo '<!doctype html><title>ci placeholder</title>' > frontend/dist/index.html
+
       - name: Build
         working-directory: desktop
         run: go build ./...


### PR DESCRIPTION
The first CI run failed on all three operating systems, and the bug was mine.

`main.go` embeds `frontend/dist`. That directory is a build artifact and is not
in the repository, so `go build ./...` on a fresh checkout fails:

```
main.go:11:12: pattern all:frontend/dist: no matching files found
```

It passed when I ran the same commands locally because this machine had a `dist`
left over from an earlier `wails build`. A check that only passes on a machine
carrying state the repository does not have is exactly what CI is for — and this
was the first thing it caught, about half an hour after being added.

A placeholder rather than a real frontend build: that job compiles Go and runs Go
tests, and what is inside the bundle makes no difference to either. The frontend
job builds it properly and the release workflow ships that. The cross-compile job
needs nothing, since `./internal/...` embeds nothing.

**Verified** the way it should have been the first time: moved `dist` aside,
reproduced the failure, applied the step, then ran build, vet and the full suite
against the placeholder.