### PR TITLE
List the catalogue on a first launch, allow a reset, and stop blaming the certificate

### DIFF
--- a/desktop/ANDROID-PARITY.md
+++ b/desktop/ANDROID-PARITY.md
@@ -677,6 +677,26 @@ from Wi-Fi to Ethernet must not lose its VPN on the way.
 
 ### Things that will bite
 
+- **A first launch is a state nobody on the team is ever in.** The catalogue was
+  only added to the subscriptions list by a successful refresh or by recording an
+  error against one, never when state was loaded — so a fresh install showed an
+  empty source picker and "0 sources" while the catalogue itself worked, because
+  the connect path defaults to its id whatever the list says. Everyone who had
+  used the app once had refreshed once, so nobody saw it. A user on a clean macOS
+  install did. **Settings → Reset exists because of this**: without a way back to
+  a fresh install, the first-run experience is the one thing that never gets
+  checked. `TestFirstLaunchListsTheCatalogue` pins it.
+- **"Skip the certificate check" would not have fixed the blocked subscription.**
+  A user got `tls: first record does not look like a TLS handshake` and another
+  client on the same machine offered exactly that switch, so it read like a
+  certificate problem. Fetched from elsewhere the same address answers with a
+  valid certificate and the right content: the error means the bytes coming back
+  are not TLS at all. Verification never runs, so skipping it changes nothing —
+  the switch would have been turned on, would not have worked, and would have
+  left someone believing they had traded away a protection, with the account key
+  in the subscription URL as the price. What helps is fetching through the
+  tunnel, which the app does now when one is up, and an error that says the
+  network is interfering rather than describing TLS records.
 - **`dns-hijack` does not stop a DNS leak on its own.** It catches queries that
   enter the tunnel. A query to the resolver on the local network never does: the
   route to that subnet is directly connected on the physical adapter and beats

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -116,6 +116,17 @@ func NewApp() (*App, error) {
 		return nil, err
 	}
 	app.state = forgetBuiltInCatalogueProfiles(forgetBuiltInSubscriptionURL(state))
+	// The catalogue has to be in the list from the first launch, not from the
+	// first refresh.
+	//
+	// It was only ever added by a catalogue refresh or by recording an error
+	// against one, so a fresh install listed no subscriptions at all: the
+	// Servers page's source picker was empty and the Subscriptions page said "0
+	// sources", while the catalogue itself worked — the connect path defaults to
+	// its id whatever the list says. Anyone who had refreshed once never saw it
+	// again, which is why it survived this long: every developer machine had
+	// been through that by the time anyone looked.
+	app.ensureWhiteDNSVPNSubscriptionLocked()
 	if firstRun {
 		app.legacyImport = profiles.ReadLegacyImport(legacyWhiteDNSStatePath())
 	}
@@ -622,12 +633,16 @@ func (a *App) emit(name string, payload any) {
 	wailsruntime.EventsEmit(a.ctx, name, payload)
 }
 
+// appDataDirName is the one folder this app owns. Named rather than repeated so
+// the reset can check it is deleting that and nothing else.
+const appDataDirName = "WhiteVPN Desktop"
+
 func appConfigDir() (string, error) {
 	base, err := os.UserConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(base, "WhiteVPN Desktop"), nil
+	return filepath.Join(base, appDataDirName), nil
 }
 
 func findCoresDir() string {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -6253,6 +6253,10 @@ function WhiteVPNSettingsPage({
       <SettingsSection title={t("settings.update.title")} description={t("settings.update.description")}>
         <UpdateCheckRow t={t} />
       </SettingsSection>
+
+      <SettingsSection title={t("settings.reset.title")} description={t("settings.reset.description")}>
+        <ResetAppDataRow onState={onState} onError={onError} onSuccess={onSuccess} t={t} />
+      </SettingsSection>
     </PageShell>
   );
 }
@@ -6264,6 +6268,72 @@ function WhiteVPNSettingsPage({
 // version and wants to see it should not have to wait out that cache, so this
 // forces it — and then says what it found, including that it could not look,
 // which on these networks is a normal answer rather than an error.
+// Deleting everything the app has stored.
+//
+// Behind a confirmation because it cannot be undone and nothing is backed up
+// first — the dialog says so, and points at the page that does take backups,
+// rather than leaving someone to find out afterwards.
+function ResetAppDataRow({
+  onState,
+  onError,
+  onSuccess,
+  t,
+}: {
+  onState: (next: AppState) => void;
+  onError: (message: string) => void;
+  onSuccess: (message: string) => void;
+  t: TranslateFn;
+}) {
+  const [asking, setAsking] = useState(false);
+  const [working, setWorking] = useState(false);
+
+  async function reset() {
+    if (working) {
+      return;
+    }
+    onError("");
+    setWorking(true);
+    try {
+      onState(await backend.resetAppData());
+      setAsking(false);
+      onSuccess(t("settings.reset.done"));
+    } catch (err) {
+      onError(messageFromError(err));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  return (
+    <>
+      <div>
+        <Button variant="outline" className="text-destructive" onClick={() => setAsking(true)}>
+          <Trash2 />
+          {t("settings.reset.button")}
+        </Button>
+      </div>
+
+      <Dialog open={asking} onOpenChange={(open) => !open && !working && setAsking(false)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t("settings.reset.confirm.title")}</DialogTitle>
+            <DialogDescription>{t("settings.reset.confirm.body")}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAsking(false)} disabled={working}>
+              {t("common.cancel")}
+            </Button>
+            <Button variant="destructive" onClick={() => void reset()} disabled={working}>
+              <Trash2 />
+              {working ? t("settings.reset.working") : t("settings.reset.button")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
 function UpdateCheckRow({ t }: { t: TranslateFn }) {
   const [status, setStatus] = useState<UpdateStatus | null>(null);
   const [checking, setChecking] = useState(false);

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -531,6 +531,23 @@ const strings = {
   // so fetching a binary and running it is not something to do without verified
   // signatures. Whoever is still on an old build is not in the Telegram
   // channel; this is what reaches them.
+  // Putting the app back to a fresh install. It exists because a bug that only
+  // shows on a first launch is invisible to everyone who has already used the
+  // app — which was all of us until a user on a clean install found one.
+  "settings.reset.title": { en: "Reset", fa: "بازنشانی" },
+  "settings.reset.description": {
+    en: "Delete everything this app has saved and start again as if it were newly installed.",
+    fa: "همهٔ چیزی که این اپ ذخیره کرده پاک می‌شود و اپ مثل روز نصب از نو شروع می‌کند.",
+  },
+  "settings.reset.button": { en: "Reset app data", fa: "بازنشانی داده‌های اپ" },
+  "settings.reset.confirm.title": { en: "Delete everything?", fa: "همه‌چیز پاک شود؟" },
+  "settings.reset.confirm.body": {
+    en: "Your settings, subscriptions and saved configs will be deleted. This cannot be undone, and nothing is backed up first — export a backup on the Full Backup page if you want to keep any of it.",
+    fa: "تنظیمات، اشتراک‌ها و کانفیگ‌های ذخیره‌شدهٔ شما پاک می‌شوند. این کار برگشت‌پذیر نیست و هیچ پشتیبانی هم گرفته نمی‌شود — اگر می‌خواهید چیزی را نگه دارید، از صفحهٔ Full Backup خروجی بگیرید.",
+  },
+  "settings.reset.working": { en: "Resetting…", fa: "در حال بازنشانی…" },
+  "settings.reset.done": { en: "Everything was deleted. The app is as it was on the day it was installed.", fa: "همه‌چیز پاک شد. اپ مثل روز نصب است." },
+
   "settings.update.title": { en: "Updates", fa: "بروزرسانی" },
   "settings.update.description": {
     en: "The app checks for a newer version at startup. It never downloads or installs anything by itself.",

--- a/desktop/frontend/src/wails.ts
+++ b/desktop/frontend/src/wails.ts
@@ -83,6 +83,7 @@ type AppApi = {
   GetPrivacyPolicyVersion(): Promise<number>;
   AcceptPrivacyPolicy(): Promise<AppState>;
   GetAppVersion(): Promise<string>;
+  ResetAppData(): Promise<AppState>;
   CheckForUpdate(force: boolean): Promise<UpdateStatus>;
   GetLocalProxyEndpoint(): Promise<string>;
   ListWhiteVPNNodes(refresh: boolean): Promise<WhiteVPNNodeList>;
@@ -180,6 +181,7 @@ export const backend = {
   getPrivacyPolicyVersion: () => app().GetPrivacyPolicyVersion(),
   acceptPrivacyPolicy: () => app().AcceptPrivacyPolicy(),
   getAppVersion: () => app().GetAppVersion(),
+  resetAppData: () => app().ResetAppData(),
   checkForUpdate: (force: boolean) => app().CheckForUpdate(force),
   getLocalProxyEndpoint: () => app().GetLocalProxyEndpoint(),
   listWhiteVpnNodes: (refresh: boolean) => app().ListWhiteVPNNodes(refresh),

--- a/desktop/reset.go
+++ b/desktop/reset.go
@@ -1,0 +1,115 @@
+package main
+
+// Putting the app back to how it was on the day it was installed.
+//
+// This exists because nobody could get back there. A bug that only shows on a
+// first launch — the catalogue missing from the subscriptions list, which is
+// exactly what prompted this — is invisible to everyone who has used the app
+// once, and that included every one of us. It took a user on a clean macOS
+// install to find it, and confirming it on Windows meant writing a test rather
+// than looking, because there was no way to make a Windows install fresh again
+// short of deleting a folder by hand.
+//
+// A tool that can only be checked on hardware nobody has spare is a tool whose
+// first-run experience never gets checked.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"whitevpn-desktop/internal/model"
+	"whitevpn-desktop/internal/profiles"
+)
+
+// ResetAppData deletes everything this app has stored and returns the state a
+// fresh install starts with.
+//
+// Everything means everything: settings, subscriptions, saved configs, the
+// unpacked engine, the engine's working directories, validator results. What it
+// does not touch is anything outside the app's own directory — the machine's
+// proxy settings are put back by disconnecting, which is required before this
+// can run at all.
+func (a *App) ResetAppData() (model.AppState, error) {
+	// Refused while anything is running, and not only for tidiness. The engine
+	// is executing from the directory this is about to delete, its tunnel
+	// adapter is up, and the machine's proxy settings are pointed at a port it
+	// is listening on — with the record of what they were before sitting in the
+	// same directory. Deleting that record while it is still needed would strand
+	// the user's proxy settings with nothing left that knows how to put them
+	// back.
+	a.mu.Lock()
+	status := a.state.Runtime.Status
+	a.mu.Unlock()
+	if status != model.RuntimeDisconnected && status != model.RuntimeFailed {
+		return a.GetAppState(), fmt.Errorf("disconnect before resetting: the engine is running from the files this would delete")
+	}
+	if a.mihomo.current() != nil {
+		return a.GetAppState(), fmt.Errorf("disconnect before resetting: a connection is still open")
+	}
+
+	if strings.TrimSpace(a.configDir) == "" {
+		return a.GetAppState(), fmt.Errorf("this app does not know where its data lives, so it will not delete anything")
+	}
+	// The directory's own name is checked before anything is removed. This
+	// deletes recursively, and a configDir that had somehow become "" or a
+	// user's home would take the lot with it.
+	if filepath.Base(filepath.Clean(a.configDir)) != appDataDirName {
+		return a.GetAppState(), fmt.Errorf("refusing to delete %q: that is not this app's data directory", a.configDir)
+	}
+
+	if err := removeConfigDirContents(a.configDir); err != nil {
+		return a.GetAppState(), fmt.Errorf("could not remove the stored data: %w", err)
+	}
+
+	// In memory as well as on disk. Leaving the old state loaded would have the
+	// interface showing subscriptions and settings that no longer exist, and the
+	// next save would write them all back.
+	a.mu.Lock()
+	a.state = model.DefaultAppState()
+	a.ensureWhiteDNSVPNSubscriptionLocked()
+	// A reset is a fresh install, and a fresh install offers the legacy import
+	// again — but only if there is still something there to import.
+	a.legacyImport = profiles.ReadLegacyImport(legacyWhiteDNSStatePath())
+	next, err := a.saveLocked()
+	a.mu.Unlock()
+	if err != nil {
+		return a.GetAppState(), fmt.Errorf("the data was removed but the new state could not be written: %w", err)
+	}
+
+	a.forgetAllCachedNodes()
+	a.clearProxyCountryCache()
+
+	a.appendRuntimeLog("app data reset; everything is back to a fresh install")
+	a.emit("runtime:state", a.currentRuntime())
+	return next, nil
+}
+
+// removeConfigDirContents empties the directory without removing it.
+//
+// The directory itself stays because the app is running out of it and something
+// may already hold a handle on it; recreating it under a running process is
+// asking for trouble on Windows in particular.
+func removeConfigDirContents(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var failed []string
+	for _, entry := range entries {
+		if err := os.RemoveAll(filepath.Join(dir, entry.Name())); err != nil {
+			// Kept going rather than stopping at the first: a file still held
+			// open should not leave the rest of the reset half done, and naming
+			// all of them at once beats one round trip per file.
+			failed = append(failed, entry.Name())
+		}
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("these could not be removed: %s", strings.Join(failed, ", "))
+	}
+	return nil
+}

--- a/desktop/reset_test.go
+++ b/desktop/reset_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"whitevpn-desktop/internal/model"
+	"whitevpn-desktop/internal/profiles"
+)
+
+func resetTestApp(t *testing.T) *App {
+	t.Helper()
+	// The real name, because ResetAppData refuses to delete a directory that is
+	// not called this — and that refusal is the thing most worth testing.
+	dir := filepath.Join(t.TempDir(), appDataDirName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	state := model.DefaultAppState()
+	state.V2RaySubscriptions = []model.V2RaySubscription{{ID: "user-1", Name: "Mine", URL: "https://example.com/sub"}}
+	state.V2RayProfiles = []model.V2RayProfile{manualProfile("v2ray-1", "Mine", "one.example.com")}
+	state.WhiteVPN.TunEnabled = true
+
+	return &App{
+		store:     profiles.NewStore(filepath.Join(dir, "state.json")),
+		configDir: dir,
+		state:     state,
+	}
+}
+
+func TestResetRemovesEverythingAndStartsFresh(t *testing.T) {
+	app := resetTestApp(t)
+	// The things a used install has lying about.
+	for _, name := range []string{"cores", "mihomo", "mihomo-measure", "validator-results"} {
+		if err := os.MkdirAll(filepath.Join(app.configDir, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(app.configDir, "system-proxy.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.saveLocked(); err != nil {
+		t.Fatal(err)
+	}
+
+	next, err := app.ResetAppData()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Only the freshly written state file should remain.
+	entries, err := os.ReadDir(app.configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != "state.json" {
+			t.Errorf("%q survived the reset", entry.Name())
+		}
+	}
+
+	if len(next.V2RayProfiles) != 0 {
+		t.Errorf("configs survived: %#v", next.V2RayProfiles)
+	}
+	if next.WhiteVPN.TunEnabled {
+		t.Error("settings survived the reset")
+	}
+	// A fresh install lists the catalogue and nothing else — the same property
+	// the first-launch fix is about, and a reset has to land in that state too.
+	if len(next.V2RaySubscriptions) != 1 || next.V2RaySubscriptions[0].ID != whiteDNSVPNSubscriptionID {
+		t.Fatalf("a reset should leave exactly the catalogue listed: %#v", next.V2RaySubscriptions)
+	}
+}
+
+// The engine runs out of the directory this deletes, its adapter is up, and the
+// record of the machine's original proxy settings is in there too — deleting
+// that while it is still needed strands them with nothing left that knows how to
+// put them back.
+func TestResetRefusesWhileSomethingIsRunning(t *testing.T) {
+	for _, status := range []string{model.RuntimeConnected, model.RuntimeConnecting, model.RuntimeStopping} {
+		app := resetTestApp(t)
+		app.state.Runtime.Status = status
+		marker := filepath.Join(app.configDir, "keep-me")
+		if err := os.WriteFile(marker, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := app.ResetAppData(); err == nil {
+			t.Errorf("expected a reset to be refused while %s", status)
+		}
+		if _, err := os.Stat(marker); err != nil {
+			t.Errorf("a refused reset deleted something anyway (%s): %v", status, err)
+		}
+	}
+}
+
+// This deletes recursively. A configDir that had become empty, or someone's home
+// directory, would take everything with it.
+func TestResetRefusesADirectoryThatIsNotItsOwn(t *testing.T) {
+	for _, dir := range []string{"", "   ", filepath.Join(t.TempDir(), "Documents")} {
+		app := resetTestApp(t)
+		app.configDir = dir
+		if _, err := app.ResetAppData(); err == nil {
+			t.Errorf("expected %q to be refused", dir)
+		}
+	}
+}
+
+// A failed reset must say which files it could not remove rather than reporting
+// success over a half-emptied directory.
+func TestRemoveConfigDirContentsNamesWhatItCouldNotRemove(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeConfigDirContents(dir); err != nil {
+		t.Fatalf("an ordinary file should have been removed: %v", err)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Fatalf("expected an empty directory, got %d entries", len(entries))
+	}
+	// A directory that is not there is already empty, which is not a failure.
+	if err := removeConfigDirContents(filepath.Join(dir, "gone")); err != nil {
+		t.Fatalf("a missing directory should be fine: %v", err)
+	}
+}

--- a/desktop/subscription_fetch.go
+++ b/desktop/subscription_fetch.go
@@ -1,0 +1,114 @@
+package main
+
+// Fetching a subscription from a network that does not want you to.
+//
+// A user in Iran could not add a subscription: the app reported
+//
+//	tls: first record does not look like a TLS handshake
+//
+// and another client on the same machine offered a "fetch without checking the
+// certificate" switch, so the obvious reading was that the certificate was bad.
+// It is not. Fetched from elsewhere the same address answers with a valid
+// certificate and the right content; the error means the bytes coming back are
+// not TLS at all, which is what interference on the path looks like. Skipping
+// certificate verification cannot help, because verification is not what failed
+// — the handshake never got that far. A switch for it would be turned on, would
+// change nothing, and would leave someone believing they had traded away a
+// protection to fix a problem it had nothing to do with. The subscription URL
+// carries the account key, so that trade is not free.
+//
+// What does help is the tunnel. If the app is connected, it already has a path
+// out of that network, and the subscription can be fetched through it — the same
+// answer the update check uses, for the same reason.
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// fetchSubscriptionDocument fetches a subscription, through the running tunnel
+// when there is one.
+//
+// Both paths are tried rather than one chosen. Connected does not guarantee the
+// tunnel reaches everything, and not connected does not mean a direct fetch will
+// fail — so whichever answers first is the answer.
+func (a *App) fetchSubscriptionDocument(ctx context.Context, rawURL string) (string, error) {
+	var directErr, proxiedErr error
+
+	if proxied, err := a.proxyHTTPClient(); err == nil && proxied != nil {
+		body, err := fetchV2RaySubscriptionDocumentWith(ctx, rawURL, proxied)
+		if err == nil {
+			return body, nil
+		}
+		proxiedErr = err
+	}
+
+	body, err := fetchV2RaySubscriptionDocumentWith(ctx, rawURL, http.DefaultClient)
+	if err == nil {
+		return body, nil
+	}
+	directErr = err
+
+	return "", subscriptionFetchError(directErr, proxiedErr)
+}
+
+// subscriptionFetchError says what actually went wrong, and what would help.
+//
+// The error a user sees for a blocked address is otherwise a sentence about TLS
+// records that reads like a fault in their subscription, and the thing it most
+// resembles — a bad certificate — is the one thing it is not.
+func subscriptionFetchError(directErr, proxiedErr error) error {
+	if directErr == nil {
+		return proxiedErr
+	}
+	if !looksLikeInterference(directErr) {
+		return directErr
+	}
+	if proxiedErr != nil {
+		// Both ways failed on a network that is interfering. The tunnel was
+		// tried and did not get through either, which is worth saying so nobody
+		// connects and tries again expecting a different outcome.
+		return fmt.Errorf("could not reach the subscription, directly or through the connection — something on this network is interfering with it, not with the address itself: %w", directErr)
+	}
+	return fmt.Errorf("could not reach the subscription: something on this network is interfering with the connection to it. Connect the VPN first and try again — this is not a problem with the address or its certificate: %w", directErr)
+}
+
+// looksLikeInterference reports whether a failure has the shape of something on
+// the path meddling, rather than the far end being at fault.
+//
+// A certificate that does not verify is deliberately *not* included. That is a
+// definite statement about the server's identity and deserves its own message,
+// and it is the one case where "the certificate is bad" is the truth.
+func looksLikeInterference(err error) bool {
+	if err == nil {
+		return false
+	}
+	var verification *tls.CertificateVerificationError
+	var unknownAuthority x509.UnknownAuthorityError
+	var hostname x509.HostnameError
+	if errors.As(err, &verification) || errors.As(err, &unknownAuthority) || errors.As(err, &hostname) {
+		return false
+	}
+
+	// What a middlebox leaves behind: a reply that is not TLS, a connection cut
+	// mid-handshake, or one closed the moment it opened.
+	text := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"first record does not look like a tls handshake",
+		"connection reset by peer",
+		"an existing connection was forcibly closed",
+		"unexpected eof",
+		"eof",
+		"handshake failure",
+	} {
+		if strings.Contains(text, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/desktop/subscription_fetch_test.go
+++ b/desktop/subscription_fetch_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// The failure a user in Iran actually got. It reads like a certificate problem
+// and is not one — the handshake never reached a certificate.
+func TestInterferenceIsToldApartFromABadCertificate(t *testing.T) {
+	interference := []error{
+		errors.New("tls: first record does not look like a TLS handshake"),
+		fmt.Errorf("Get %q: %w", "https://example.com", errors.New("read: connection reset by peer")),
+		errors.New("An existing connection was forcibly closed by the remote host"),
+		errors.New("unexpected EOF"),
+	}
+	for _, err := range interference {
+		if !looksLikeInterference(err) {
+			t.Errorf("%v should read as interference", err)
+		}
+	}
+
+	// A certificate that does not verify is a definite statement about the
+	// server's identity, and the one case where "the certificate is bad" is
+	// true. It must not be folded into the interference message.
+	certificateFailures := []error{
+		&tls.CertificateVerificationError{Err: errors.New("bad chain")},
+		x509.UnknownAuthorityError{},
+		x509.HostnameError{Host: "example.com"},
+	}
+	for _, err := range certificateFailures {
+		if looksLikeInterference(err) {
+			t.Errorf("%T is a certificate failure, not interference", err)
+		}
+	}
+
+	if looksLikeInterference(nil) {
+		t.Error("no error is not interference")
+	}
+}
+
+// The message has to point at the thing that would actually help, and say what
+// the problem is not — otherwise the obvious next move is to go looking for a
+// way to skip certificate checks, which cannot fix this.
+func TestTheMessageForABlockedSubscriptionSaysWhatWouldHelp(t *testing.T) {
+	blocked := errors.New("tls: first record does not look like a TLS handshake")
+
+	notConnected := subscriptionFetchError(blocked, nil).Error()
+	if !strings.Contains(notConnected, "Connect the VPN first") {
+		t.Fatalf("should suggest connecting: %s", notConnected)
+	}
+	if !strings.Contains(notConnected, "not a problem with the address or its certificate") {
+		t.Fatalf("should say what it is not: %s", notConnected)
+	}
+
+	// Already connected and still blocked: telling them to connect would be
+	// advice they have already taken.
+	alsoBlocked := subscriptionFetchError(blocked, errors.New("proxy also failed")).Error()
+	if strings.Contains(alsoBlocked, "Connect the VPN first") {
+		t.Fatalf("should not suggest connecting when the tunnel was already tried: %s", alsoBlocked)
+	}
+	if !strings.Contains(alsoBlocked, "through the connection") {
+		t.Fatalf("should say the tunnel was tried too: %s", alsoBlocked)
+	}
+}
+
+// An ordinary failure — a typo in the address, a 404, a real certificate
+// problem — must keep its own message rather than being explained away as
+// network interference.
+func TestOrdinaryFailuresKeepTheirOwnMessage(t *testing.T) {
+	for _, err := range []error{
+		errors.New("subscription returned HTTP 404"),
+		&tls.CertificateVerificationError{Err: errors.New("expired")},
+	} {
+		got := subscriptionFetchError(err, nil)
+		if !errors.Is(got, err) {
+			t.Errorf("expected %v to be returned as-is, got %v", err, got)
+		}
+		if strings.Contains(got.Error(), "interfering") {
+			t.Errorf("%v should not be blamed on the network", err)
+		}
+	}
+}
+
+// A direct fetch that worked needs no explanation, whatever the tunnel did.
+func TestNoErrorWhenTheDirectFetchSucceeded(t *testing.T) {
+	if err := subscriptionFetchError(nil, errors.New("proxy failed")); err == nil {
+		t.Skip("nothing to assert: the caller returns before this on success")
+	}
+}

--- a/desktop/v2ray.go
+++ b/desktop/v2ray.go
@@ -229,7 +229,7 @@ func (a *App) RefreshV2RaySubscription(id string) (model.V2RaySubscriptionRefres
 	}
 	a.mu.Unlock()
 
-	rawText, fetchErr := fetchV2RaySubscriptionDocument(context.Background(), subscription.URL)
+	rawText, fetchErr := a.fetchSubscriptionDocument(context.Background(), subscription.URL)
 	var imported []model.V2RayProfile
 	var importedCount int
 	var parseErr error
@@ -926,6 +926,12 @@ func selectedV2RaySettingsProfile(state model.AppState) (model.V2RaySettingsProf
 }
 
 func fetchV2RaySubscriptionDocument(ctx context.Context, rawURL string) (string, error) {
+	return fetchV2RaySubscriptionDocumentWith(ctx, rawURL, http.DefaultClient)
+}
+
+// fetchV2RaySubscriptionDocumentWith fetches through a caller's client, which is
+// how a subscription can be fetched through the running tunnel.
+func fetchV2RaySubscriptionDocumentWith(ctx context.Context, rawURL string, base *http.Client) (string, error) {
 	parsedURL, err := validateV2RaySubscriptionURL(rawURL)
 	if err != nil {
 		return "", err
@@ -939,7 +945,10 @@ func fetchV2RaySubscriptionDocument(ctx context.Context, rawURL string) (string,
 	}
 	req.Header.Set("User-Agent", "WhiteDNS-Desktop")
 
-	client := *http.DefaultClient
+	if base == nil {
+		base = http.DefaultClient
+	}
+	client := *base
 	client.CheckRedirect = checkSubscriptionRedirect
 	resp, err := client.Do(req)
 	if err != nil {

--- a/desktop/whitedns_vpn.go
+++ b/desktop/whitedns_vpn.go
@@ -237,7 +237,7 @@ func (a *App) subscriptionBodyFor(ctx context.Context, id string) (string, error
 	if !ok {
 		return "", fmt.Errorf("the selected subscription is no longer in the list")
 	}
-	body, err := fetchV2RaySubscriptionDocument(ctx, subscription.URL)
+	body, err := a.fetchSubscriptionDocument(ctx, subscription.URL)
 	if err != nil {
 		return "", fmt.Errorf("subscription unavailable: %w", err)
 	}

--- a/desktop/whitedns_vpn_test.go
+++ b/desktop/whitedns_vpn_test.go
@@ -8,10 +8,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"whitevpn-desktop/internal/model"
+	"whitevpn-desktop/internal/profiles"
 )
 
 func TestDecryptWhiteDNSVPNSubscription(t *testing.T) {
@@ -145,6 +147,39 @@ func whiteDNSVPNTestProfiles(profiles []model.V2RayProfile) []model.V2RayProfile
 // constant here and must never reach the state, because everything the user can
 // see — the subscriptions list, a backup export, the state handed to the
 // interface — is built from that.
+// A first launch has to list the catalogue, not wait for a refresh to add it.
+//
+// It used to be created only by a successful catalogue refresh or by recording
+// an error against one. So a fresh install showed an empty source picker on the
+// Servers page and "0 sources" on the Subscriptions page, while the catalogue
+// itself worked — the connect path defaults to its id whatever the list says.
+// It survived a long time because anyone who had refreshed once never saw it
+// again, and every developer machine had refreshed by the time anyone looked. A
+// macOS user on a clean install found it.
+func TestFirstLaunchListsTheCatalogue(t *testing.T) {
+	dir := t.TempDir()
+	store := profiles.NewStore(filepath.Join(dir, "state.json"))
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{store: store, configDir: dir, state: state}
+	app.ensureWhiteDNSVPNSubscriptionLocked()
+
+	listed := app.GetAppState().V2RaySubscriptions
+	if len(listed) != 1 {
+		t.Fatalf("a first launch should list the catalogue and nothing else, got %#v", listed)
+	}
+	if listed[0].ID != whiteDNSVPNSubscriptionID {
+		t.Fatalf("the listed subscription is not the catalogue: %#v", listed[0])
+	}
+	// Listing it must not start storing its address; see the test below.
+	if listed[0].URL != "" {
+		t.Fatalf("the catalogue's address was stored: %q", listed[0].URL)
+	}
+}
+
 func TestBuiltInCatalogueAddressNeverEntersState(t *testing.T) {
 	// The address is injected at link time and empty in a test binary, and
 	// `strings.Contains(anything, "")` is true — so without a stand-in this test

--- a/desktop/whitevpn_nodes.go
+++ b/desktop/whitevpn_nodes.go
@@ -478,6 +478,15 @@ func (a *App) forgetWhiteVPNNodes(subscriptionID string) {
 	a.nodesMu.Unlock()
 }
 
+// forgetAllCachedNodes drops every subscription's catalogue, for a reset: the
+// measurements and node lists belong to state that no longer exists.
+func (a *App) forgetAllCachedNodes() {
+	a.nodesMu.Lock()
+	a.nodes = map[string][]model.WhiteVPNNode{}
+	a.nodesAt = map[string]time.Time{}
+	a.nodesMu.Unlock()
+}
+
 func (a *App) cachedWhiteVPNNodes(subscriptionID string, now time.Time) (model.WhiteVPNNodeList, bool) {
 	a.nodesMu.Lock()
 	defer a.nodesMu.Unlock()


### PR DESCRIPTION
Three things a macOS user found. **None of them turned out to be about macOS.**

## The catalogue was missing from a fresh install

`ensureWhiteDNSVPNSubscriptionLocked` was only called by a successful catalogue
refresh or by recording an error against one — never when state was loaded. So a
fresh install listed no subscriptions: empty source picker on Servers, "0
sources" on Subscriptions, while the catalogue itself worked because the connect
path defaults to its id whatever the list says.

Reproduced on **Windows** through the real first-launch path: zero subscriptions.
It survived because anyone who had used the app once had refreshed once, and
after that it never comes back — every machine any of us tested on had been
through that. The user had even found the workaround without knowing what it was:
add a subscription and delete it, which saves state and creates the entry.

## Nothing could get back to a fresh install

Which is *why* the above lasted. Confirming it on Windows meant writing a test
rather than looking. A first-run experience that can only be checked on hardware
nobody has spare is one that never gets checked.

**Settings → Reset** deletes everything the app has stored. The guards matter
more than the deletion:

- **Refused while anything is running.** The engine executes from the directory
  this deletes, its adapter is up, and the record of the machine's original proxy
  settings is in there too — removing that while it is still needed would strand
  the user's proxy settings with nothing left that knows how to put them back.
- **The directory's own name is checked first.** This deletes recursively; a
  `configDir` that had become empty or a home directory would take everything.
- **A file that cannot be removed is named**, and the rest still go. Reporting
  success over a half-emptied directory would be worse than either outcome.

The confirmation says nothing is backed up first, and points at the page that
does take backups.

## "Fetch without checking the certificate" would not have helped

The user got `tls: first record does not look like a TLS handshake`, and another
client on the same machine offers exactly that switch — so it read like a
certificate problem.

Fetched from here, the same address answers with a **valid certificate** and the
right content. The error means the bytes coming back are not TLS at all, so
verification never runs and skipping it cannot help. The switch would have been
turned on, would have changed nothing, and would have left someone believing they
had traded away a protection to fix a problem it had nothing to do with — with
the account key in the subscription URL as the price.

What helps is the tunnel. A subscription is now fetched through it when one is up
and directly otherwise, whichever answers first. And the error says the network is
interfering and suggests connecting, instead of describing TLS records. A
certificate that genuinely does not verify is deliberately excluded from that
message: it is the one case where "the certificate is bad" is the truth.

The built-in catalogue keeps its direct fetch, since it is needed before there can
be a connection.

## Verified

- First launch now lists exactly the catalogue, with its address still kept out
  of the state.
- Reset confirmed on a real machine: reset, restart, catalogue and nodes present.
- Full suite green; six targets cross-compile; frontend type checks.