### PR TITLE
Let a subscription be fetched past a certificate that does not verify

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -435,6 +435,7 @@ function normalizeV2RaySubscription(subscription: V2RaySubscription): V2RaySubsc
     lastUpdatedAt: subscription.lastUpdatedAt || "",
     lastError: subscription.lastError || "",
     importedCount: Math.max(0, Number(subscription.importedCount) || 0),
+    allowInsecureTls: Boolean(subscription.allowInsecureTls),
   };
 }
 
@@ -3746,6 +3747,20 @@ function V2RaySubscriptionsPage({
                 <AlertDescription>{draft.lastError}</AlertDescription>
               </Alert>
             )}
+            {/* Offered once a refresh has failed, never before — but always
+                shown while it is on, or it could not be turned back off. */}
+            {(draft.lastError || draft.allowInsecureTls) && (
+              <div className="grid gap-2 rounded-md border px-3 py-2">
+                <label className="flex items-center justify-between gap-3 text-sm">
+                  {t("subs.editor.allowInsecureTls")}
+                  <Switch
+                    checked={draft.allowInsecureTls}
+                    onCheckedChange={(allowInsecureTls) => setDraft({ ...draft, allowInsecureTls })}
+                  />
+                </label>
+                <p className="text-xs text-muted-foreground">{t("subs.editor.allowInsecureTlsHint")}</p>
+              </div>
+            )}
           </FieldGroup>
           <DialogFooter className="sm:justify-between">
             {draft.id ? (
@@ -3904,6 +3919,7 @@ function defaultV2RaySubscriptionDraft(): V2RaySubscription {
     lastUpdatedAt: "",
     lastError: "",
     importedCount: 0,
+    allowInsecureTls: false,
   };
 }
 

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -218,6 +218,14 @@ const strings = {
   },
   "subs.editor.description": { en: "Saved V2Ray subscription URL", fa: "نشانی اشتراک V2Ray ذخیره‌شده" },
   "subs.editor.url": { en: "Subscription URL", fa: "نشانی اشتراک" },
+  "subs.editor.allowInsecureTls": {
+    en: "Fetch without checking the certificate",
+    fa: "دریافت بدون بررسی گواهی",
+  },
+  "subs.editor.allowInsecureTlsHint": {
+    en: "This server's certificate cannot be verified, so there is no proof you are talking to the real address. Your subscription link contains your account key — if something is intercepting this connection, turning this on hands the key to it. Only for a provider and a network you trust.",
+    fa: "گواهی این سرور تأیید نمی‌شود، پس معلوم نیست واقعاً با همان نشانی طرف هستید. نشانی اشتراک شما کلید حسابتان را در خود دارد — اگر چیزی این ارتباط را شنود کند، با روشن کردن این گزینه کلید را به آن می‌دهید. فقط برای ارائه‌دهنده و شبکه‌ای که به آن اطمینان دارید.",
+  },
   "subs.thisSubscription": { en: "this subscription", fa: "این اشتراک" },
   "subs.deleteDialog.title": { en: "Delete V2Ray subscription?", fa: "اشتراک V2Ray حذف شود؟" },
   "subs.deleteDialog.description": {

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -101,6 +101,7 @@ export interface V2RaySubscription {
   lastUpdatedAt: string;
   lastError: string;
   importedCount: number;
+  allowInsecureTls: boolean;
 }
 
 export interface V2RayPingResult {

--- a/desktop/internal/model/types.go
+++ b/desktop/internal/model/types.go
@@ -178,6 +178,13 @@ type V2RaySubscription struct {
 	LastUpdatedAt string `json:"lastUpdatedAt"`
 	LastError     string `json:"lastError"`
 	ImportedCount int    `json:"importedCount"`
+
+	// AllowInsecureTLS fetches this subscription without verifying the server's
+	// certificate.
+	//
+	// Off by default, and per-subscription rather than global: it is a decision
+	// about one address the user chose to trust, not about the app.
+	AllowInsecureTLS bool `json:"allowInsecureTls"`
 }
 
 type V2RayPingResult struct {

--- a/desktop/subscription_fetch.go
+++ b/desktop/subscription_fetch.go
@@ -2,24 +2,26 @@ package main
 
 // Fetching a subscription from a network that does not want you to.
 //
-// A user in Iran could not add a subscription: the app reported
+// Networks that filter do not all fail the same way, and the difference decides
+// what can fix it. Two failures were seen on the same subscription:
 //
 //	tls: first record does not look like a TLS handshake
 //
-// and another client on the same machine offered a "fetch without checking the
-// certificate" switch, so the obvious reading was that the certificate was bad.
-// It is not. Fetched from elsewhere the same address answers with a valid
-// certificate and the right content; the error means the bytes coming back are
-// not TLS at all, which is what interference on the path looks like. Skipping
-// certificate verification cannot help, because verification is not what failed
-// — the handshake never got that far. A switch for it would be turned on, would
-// change nothing, and would leave someone believing they had traded away a
-// protection to fix a problem it had nothing to do with. The subscription URL
-// carries the account key, so that trade is not free.
+// means the bytes coming back are not TLS at all — something answered in place
+// of the server. Verification never runs, so skipping it changes nothing. What
+// helps there is the tunnel: once connected the app already has a path out of
+// that network, and the subscription can be fetched through it.
 //
-// What does help is the tunnel. If the app is connected, it already has a path
-// out of that network, and the subscription can be fetched through it — the same
-// answer the update check uses, for the same reason.
+// A certificate that does not verify is the other failure, and it is the
+// opposite case. Something is terminating TLS and presenting its own
+// certificate. Skipping verification does get the document — the same
+// subscription that failed this way on iOS came through the moment that app's
+// "fetch without checking the certificate" switch was turned on.
+//
+// So both exist here, and neither is offered where it cannot work. The switch is
+// off by default and per-subscription: turning it on hands the account key in
+// the URL to whoever is intercepting, which is a real cost and only the person
+// who knows the provider and the network can weigh it.
 
 import (
 	"context"
@@ -28,7 +30,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+
 	"strings"
+	"whitevpn-desktop/internal/model"
 )
 
 // fetchSubscriptionDocument fetches a subscription, through the running tunnel
@@ -37,24 +41,52 @@ import (
 // Both paths are tried rather than one chosen. Connected does not guarantee the
 // tunnel reaches everything, and not connected does not mean a direct fetch will
 // fail — so whichever answers first is the answer.
-func (a *App) fetchSubscriptionDocument(ctx context.Context, rawURL string) (string, error) {
+func (a *App) fetchSubscriptionDocument(ctx context.Context, subscription model.V2RaySubscription) (string, error) {
 	var directErr, proxiedErr error
+	skipVerify := subscription.AllowInsecureTLS
 
 	if proxied, err := a.proxyHTTPClient(); err == nil && proxied != nil {
-		body, err := fetchV2RaySubscriptionDocumentWith(ctx, rawURL, proxied)
+		body, err := fetchV2RaySubscriptionDocumentWith(ctx, subscription.URL, clientFor(proxied, skipVerify))
 		if err == nil {
 			return body, nil
 		}
 		proxiedErr = err
 	}
 
-	body, err := fetchV2RaySubscriptionDocumentWith(ctx, rawURL, http.DefaultClient)
+	body, err := fetchV2RaySubscriptionDocumentWith(ctx, subscription.URL, clientFor(http.DefaultClient, skipVerify))
 	if err == nil {
 		return body, nil
 	}
 	directErr = err
 
-	return "", subscriptionFetchError(directErr, proxiedErr)
+	return "", subscriptionFetchError(directErr, proxiedErr, skipVerify)
+}
+
+// clientFor returns base, or a copy of it that does not verify certificates.
+//
+// A copy, because base may be the shared default client or the one built for the
+// running tunnel, and neither may be left with verification disabled after this
+// one fetch.
+func clientFor(base *http.Client, skipVerify bool) *http.Client {
+	if !skipVerify {
+		return base
+	}
+	source, ok := base.Transport.(*http.Transport)
+	if !ok || source == nil {
+		source, _ = http.DefaultTransport.(*http.Transport)
+	}
+	if source == nil {
+		return base
+	}
+	transport := source.Clone()
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{}
+	}
+	transport.TLSClientConfig.InsecureSkipVerify = true
+
+	client := *base
+	client.Transport = transport
+	return &client
 }
 
 // subscriptionFetchError says what actually went wrong, and what would help.
@@ -62,20 +94,80 @@ func (a *App) fetchSubscriptionDocument(ctx context.Context, rawURL string) (str
 // The error a user sees for a blocked address is otherwise a sentence about TLS
 // records that reads like a fault in their subscription, and the thing it most
 // resembles — a bad certificate — is the one thing it is not.
-func subscriptionFetchError(directErr, proxiedErr error) error {
+func subscriptionFetchError(directErr, proxiedErr error, skipVerify bool) error {
 	if directErr == nil {
 		return proxiedErr
 	}
+	// A certificate that does not verify is the one failure the switch answers,
+	// so it is the one failure allowed to mention it.
+	if looksLikeCertificateFailure(directErr) && !skipVerify {
+		return explain(directErr, "this server's certificate could not be verified, so there is no proof this is the real address. If you trust this provider and this network, turn on \"Fetch without checking the certificate\" and try again.")
+	}
 	if !looksLikeInterference(directErr) {
 		return directErr
+	}
+	// Turned on and still failing this way: the switch is not the missing piece
+	// and leaving someone to keep it on for nothing is the worst outcome.
+	if skipVerify {
+		return explain(directErr, "something on this network is answering in place of this subscription's server, so nothing is getting through. \"Fetch without checking the certificate\" cannot help with this one — turn it back off. Connect the VPN first and refresh instead.")
 	}
 	if proxiedErr != nil {
 		// Both ways failed on a network that is interfering. The tunnel was
 		// tried and did not get through either, which is worth saying so nobody
 		// connects and tries again expecting a different outcome.
-		return fmt.Errorf("could not reach the subscription, directly or through the connection — something on this network is interfering with it, not with the address itself: %w", directErr)
+		return explain(directErr, "Tried through the connection and it still could not be reached — something on the network is blocking this subscription, not the address itself.")
 	}
-	return fmt.Errorf("could not reach the subscription: something on this network is interfering with the connection to it. Connect the VPN first and try again — this is not a problem with the address or its certificate: %w", directErr)
+	// The instruction leads. What this is not comes after it, because the
+	// obvious next move otherwise is to go hunting for a way to skip the
+	// certificate check, which cannot fix it.
+	return explain(directErr, "Connect the VPN first, then refresh this subscription — something on this network is blocking it. Nothing is wrong with the address or its certificate.")
+}
+
+// explain carries the cause without printing it.
+//
+// fmt.Errorf with %w would put the cause's own text — including the subscription
+// URL, and so the account key in it — into a message that ends up in a
+// screenshot. Keeping the cause reachable by errors.Is and errors.As while the
+// text stays ours means no future message can leak it by accident either.
+type explainedError struct {
+	message string
+	reason  string
+	cause   error
+}
+
+func (e *explainedError) Error() string { return fmt.Sprintf("%s (%s)", e.message, e.reason) }
+func (e *explainedError) Unwrap() error { return e.cause }
+
+func explain(cause error, message string) error {
+	return &explainedError{message: message, reason: withoutURL(cause), cause: cause}
+}
+
+// withoutURL keeps the reason and drops the address it was reaching for.
+//
+// Go writes these as `Get "https://…": reason`, and that address is the
+// subscription URL, which carries the user's account key. This message lands in
+// a dialog people screenshot and send to whoever is helping them — it had
+// already reached me twice that way before I noticed I was the one putting it
+// there, having written a comment two files up about exactly this risk.
+func withoutURL(err error) string {
+	text := err.Error()
+	if _, reason, found := strings.Cut(text, `": `); found {
+		return strings.TrimSpace(reason)
+	}
+	return text
+}
+
+// looksLikeCertificateFailure reports whether the handshake got far enough to be
+// shown a certificate and refused it.
+//
+// This is the failure the switch can get past, and telling it apart from a reply
+// that was never TLS is the whole point — offering the switch for the other one
+// would be offering a trade that buys nothing.
+func looksLikeCertificateFailure(err error) bool {
+	var verification *tls.CertificateVerificationError
+	var unknownAuthority x509.UnknownAuthorityError
+	var hostname x509.HostnameError
+	return errors.As(err, &verification) || errors.As(err, &unknownAuthority) || errors.As(err, &hostname)
 }
 
 // looksLikeInterference reports whether a failure has the shape of something on
@@ -85,13 +177,7 @@ func subscriptionFetchError(directErr, proxiedErr error) error {
 // definite statement about the server's identity and deserves its own message,
 // and it is the one case where "the certificate is bad" is the truth.
 func looksLikeInterference(err error) bool {
-	if err == nil {
-		return false
-	}
-	var verification *tls.CertificateVerificationError
-	var unknownAuthority x509.UnknownAuthorityError
-	var hostname x509.HostnameError
-	if errors.As(err, &verification) || errors.As(err, &unknownAuthority) || errors.As(err, &hostname) {
+	if err == nil || looksLikeCertificateFailure(err) {
 		return false
 	}
 

--- a/desktop/subscription_fetch_test.go
+++ b/desktop/subscription_fetch_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -49,17 +52,17 @@ func TestInterferenceIsToldApartFromABadCertificate(t *testing.T) {
 func TestTheMessageForABlockedSubscriptionSaysWhatWouldHelp(t *testing.T) {
 	blocked := errors.New("tls: first record does not look like a TLS handshake")
 
-	notConnected := subscriptionFetchError(blocked, nil).Error()
+	notConnected := subscriptionFetchError(blocked, nil, false).Error()
 	if !strings.Contains(notConnected, "Connect the VPN first") {
 		t.Fatalf("should suggest connecting: %s", notConnected)
 	}
-	if !strings.Contains(notConnected, "not a problem with the address or its certificate") {
+	if !strings.Contains(notConnected, "Nothing is wrong with the address or its certificate") {
 		t.Fatalf("should say what it is not: %s", notConnected)
 	}
 
 	// Already connected and still blocked: telling them to connect would be
 	// advice they have already taken.
-	alsoBlocked := subscriptionFetchError(blocked, errors.New("proxy also failed")).Error()
+	alsoBlocked := subscriptionFetchError(blocked, errors.New("proxy also failed"), false).Error()
 	if strings.Contains(alsoBlocked, "Connect the VPN first") {
 		t.Fatalf("should not suggest connecting when the tunnel was already tried: %s", alsoBlocked)
 	}
@@ -68,27 +71,136 @@ func TestTheMessageForABlockedSubscriptionSaysWhatWouldHelp(t *testing.T) {
 	}
 }
 
-// An ordinary failure — a typo in the address, a 404, a real certificate
-// problem — must keep its own message rather than being explained away as
-// network interference.
+// An ordinary failure — a typo in the address, a 404 — must keep its own
+// message rather than being explained away as network interference.
 func TestOrdinaryFailuresKeepTheirOwnMessage(t *testing.T) {
 	for _, err := range []error{
 		errors.New("subscription returned HTTP 404"),
 		&tls.CertificateVerificationError{Err: errors.New("expired")},
 	} {
-		got := subscriptionFetchError(err, nil)
+		got := subscriptionFetchError(err, nil, false)
 		if !errors.Is(got, err) {
-			t.Errorf("expected %v to be returned as-is, got %v", err, got)
+			t.Errorf("expected %v to remain reachable, got %v", err, got)
 		}
-		if strings.Contains(got.Error(), "interfering") {
+		if strings.Contains(got.Error(), "blocking") {
 			t.Errorf("%v should not be blamed on the network", err)
 		}
 	}
 }
 
+// The switch is offered for the failure it can get past, and only that one.
+//
+// A certificate that does not verify is something terminating TLS in the middle,
+// which is what turning it off gets past — that is how this same subscription
+// came through on iOS. A reply that was never TLS is not, and offering the
+// switch there would be offering a trade that buys nothing.
+func TestTheSwitchIsOfferedOnlyWhereItCanWork(t *testing.T) {
+	const offer = "Fetch without checking the certificate"
+
+	certificateFailure := subscriptionFetchError(&tls.CertificateVerificationError{Err: errors.New("unknown authority")}, nil, false).Error()
+	if !strings.Contains(certificateFailure, offer) {
+		t.Fatalf("a certificate failure should offer the switch: %s", certificateFailure)
+	}
+
+	neverTLS := subscriptionFetchError(errors.New("tls: first record does not look like a TLS handshake"), nil, false).Error()
+	if strings.Contains(neverTLS, offer) {
+		t.Fatalf("the switch cannot get past this, so it must not be offered: %s", neverTLS)
+	}
+}
+
+// Already on and still failing this way means the switch is not the missing
+// piece. Leaving someone to keep verification off for nothing is the worst of
+// both outcomes, so the message has to say to turn it back off.
+func TestTheSwitchIsWithdrawnWhenItDidNotHelp(t *testing.T) {
+	got := subscriptionFetchError(errors.New("tls: first record does not look like a TLS handshake"), nil, true).Error()
+	if !strings.Contains(got, "turn it back off") {
+		t.Fatalf("should say to turn it back off: %s", got)
+	}
+}
+
+// With the switch on, a certificate failure is no longer something to suggest it
+// for — verification was already skipped, so this is a different problem.
+func TestNoOfferOnceTheSwitchIsAlreadyOn(t *testing.T) {
+	err := &tls.CertificateVerificationError{Err: errors.New("unknown authority")}
+	got := subscriptionFetchError(err, nil, true)
+	if !errors.Is(got, err) {
+		t.Fatalf("expected the cause to survive, got %v", got)
+	}
+	if strings.Contains(got.Error(), "turn on") {
+		t.Fatalf("should not suggest what is already on: %s", got)
+	}
+}
+
+// Verification is skipped for the one subscription that asked for it, and the
+// clients it is skipped on are copies — the shared default client and the
+// tunnel's client must not be left unverified after one fetch.
+func TestSkippingVerificationDoesNotLeakIntoOtherClients(t *testing.T) {
+	if got := clientFor(http.DefaultClient, false); got != http.DefaultClient {
+		t.Fatal("without the switch the client should be used unchanged")
+	}
+
+	insecure := clientFor(http.DefaultClient, true)
+	if insecure == http.DefaultClient {
+		t.Fatal("the shared default client was modified in place")
+	}
+	transport, ok := insecure.Transport.(*http.Transport)
+	if !ok || !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("verification was not actually skipped")
+	}
+	if base, _ := http.DefaultTransport.(*http.Transport); base.TLSClientConfig != nil && base.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("the default transport was left unverified for the whole app")
+	}
+
+	// A client carrying a dialer — the tunnel's — keeps it, or the fetch stops
+	// going through the tunnel the moment the switch is turned on.
+	dialed := false
+	tunnel := &http.Client{Transport: &http.Transport{DialContext: func(context.Context, string, string) (net.Conn, error) {
+		dialed = true
+		return nil, errors.New("no")
+	}}}
+	through, _ := clientFor(tunnel, true).Transport.(*http.Transport)
+	if through.DialContext == nil {
+		t.Fatal("the tunnel's dialer was dropped")
+	}
+	_, _ = through.DialContext(context.Background(), "tcp", "example.com:443")
+	if !dialed {
+		t.Fatal("the copy is not dialing through the original's dialer")
+	}
+}
+
 // A direct fetch that worked needs no explanation, whatever the tunnel did.
 func TestNoErrorWhenTheDirectFetchSucceeded(t *testing.T) {
-	if err := subscriptionFetchError(nil, errors.New("proxy failed")); err == nil {
+	if err := subscriptionFetchError(nil, errors.New("proxy failed"), false); err == nil {
 		t.Skip("nothing to assert: the caller returns before this on success")
+	}
+}
+
+// The subscription URL carries the account key, and this message lands in a
+// dialog people screenshot and send to whoever is helping them.
+func TestTheErrorDoesNotCarryTheSubscriptionURL(t *testing.T) {
+	const url = "https://cf.example.org/sub/whitedns/418674ba14313e5ae8b2a014e97ddeea"
+	blocked := fmt.Errorf("Get %q: %w", url, errors.New("tls: first record does not look like a TLS handshake"))
+
+	for _, message := range []string{
+		subscriptionFetchError(blocked, nil, false).Error(),
+		subscriptionFetchError(blocked, errors.New("proxy failed"), false).Error(),
+	} {
+		if strings.Contains(message, "418674ba") {
+			t.Fatalf("the account key is in the message a user will screenshot: %s", message)
+		}
+		if strings.Contains(message, "cf.example.org") {
+			t.Fatalf("the subscription address is in the message: %s", message)
+		}
+		// The reason still has to survive, or the message says nothing useful.
+		if !strings.Contains(message, "TLS handshake") {
+			t.Fatalf("the reason was lost: %s", message)
+		}
+	}
+}
+
+// An error with no URL in it is passed through unchanged.
+func TestWithoutURLLeavesAPlainReasonAlone(t *testing.T) {
+	if got := withoutURL(errors.New("connection reset by peer")); got != "connection reset by peer" {
+		t.Fatalf("got %q", got)
 	}
 }

--- a/desktop/v2ray.go
+++ b/desktop/v2ray.go
@@ -229,7 +229,7 @@ func (a *App) RefreshV2RaySubscription(id string) (model.V2RaySubscriptionRefres
 	}
 	a.mu.Unlock()
 
-	rawText, fetchErr := a.fetchSubscriptionDocument(context.Background(), subscription.URL)
+	rawText, fetchErr := a.fetchSubscriptionDocument(context.Background(), subscription)
 	var imported []model.V2RayProfile
 	var importedCount int
 	var parseErr error

--- a/desktop/whitedns_vpn.go
+++ b/desktop/whitedns_vpn.go
@@ -237,7 +237,7 @@ func (a *App) subscriptionBodyFor(ctx context.Context, id string) (string, error
 	if !ok {
 		return "", fmt.Errorf("the selected subscription is no longer in the list")
 	}
-	body, err := a.fetchSubscriptionDocument(ctx, subscription.URL)
+	body, err := a.fetchSubscriptionDocument(ctx, subscription)
 	if err != nil {
 		return "", fmt.Errorf("subscription unavailable: %w", err)
 	}


### PR DESCRIPTION
A subscription in Iran failed with `tls: first record does not look like a TLS handshake`. I concluded from that error that skipping certificate verification could never help, wrote it into the file header, and built the rest around it.

That reasoning holds for **that** error — the bytes coming back are not TLS, so verification never runs — but not as the general rule I turned it into. The same subscription failed on iOS with a certificate error, and came through the moment that app's "fetch without checking the certificate" switch was turned on. Both failures are real, on the same address; only one has an answer here, and I had removed it.

## What changed

- A per-subscription **Fetch without checking the certificate** switch, off by default.
- Offered only for the failure it can get past. A reply that was never TLS does not offer it — that would be a trade that buys nothing.
- Once it is on and that failure persists, the message says to turn it back off, rather than leaving verification disabled for no gain.
- Verification is skipped on a **copy** of the client. The shared default client and the tunnel's client both outlive the fetch. The copy keeps the tunnel's dialer, so turning the switch on does not quietly stop going through the tunnel.

## Errors no longer carry the subscription URL

Go writes these as `Get "https://…": reason`, and that address is the subscription URL, which holds the account key. I had written a comment about exactly that risk and then appended the whole URL to a message that lands in a dialog people screenshot — it had already reached me twice that way.

The cause is now held by an error type that keeps it reachable through `errors.Is` / `errors.As` without printing it, so no later message can leak it by accident either.

## Still open

Refresh is only ever manual. A subscription blocked on the local network needs the tunnel, which means connecting first and refreshing second — an order the user can only learn from the error text. Refreshing empty subscriptions automatically after a successful connect would remove that, and is not in this PR.