### PR TITLE
Retry the subscriptions the network was blocking once the tunnel is up

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -915,6 +915,11 @@ function App() {
           runtimeLogFlushTimerRef.current = window.setTimeout(flushRuntimeLogs, 250);
         }
       }),
+      // Connecting retries the subscriptions the network had been blocking, so
+      // the rows showing that failure are stale the moment it succeeds.
+      onRuntimeEvent<unknown>("subscriptions:changed", () => {
+        void backend.getAppState().then(applyState);
+      }),
       onRuntimeEvent<WhiteVPNNode>("nodes:test", (node) => {
         setNodes((current) => current.map((entry) => (entry.name === node.name ? node : entry)));
       }),

--- a/desktop/mihomo_connect.go
+++ b/desktop/mihomo_connect.go
@@ -187,6 +187,7 @@ func (a *App) startWhiteDNSVPNWithMihomo() (model.AppState, error) {
 	a.resolveExitCountry()
 	a.sampleTraffic(connected)
 	a.watchHealth(connected)
+	a.retryBlockedSubscriptions()
 	return a.GetAppState(), nil
 }
 

--- a/desktop/subscription_retry.go
+++ b/desktop/subscription_retry.go
@@ -1,0 +1,89 @@
+package main
+
+// Refreshing what the network was blocking, once there is a way past it.
+//
+// A subscription whose address is blocked locally can only be fetched through
+// the tunnel, which means connecting first and refreshing second. That order is
+// not discoverable: the only place it is written down is the error you get for
+// doing it the other way round, and the same user hit it twice — once before the
+// message said so and once after. An instruction people have to read and then
+// remember to act on is a step the app can take itself.
+//
+// So a successful connection retries the subscriptions that have nothing in
+// them. Only those: a subscription that already imported nodes is not waiting on
+// anything, and refreshing every one on every connect would put a burst of
+// requests on the provider each time somebody reconnects.
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+// retryingBlockedSubscriptions keeps two connects in quick succession — a
+// reconnect, a network change — from running this twice at once.
+var retryingBlockedSubscriptions atomic.Bool
+
+// retryBlockedSubscriptions refreshes empty subscriptions now that the tunnel is
+// up, in the background.
+//
+// In the background because it is a courtesy, not part of connecting: the
+// connection is already usable and must not wait on someone else's server.
+func (a *App) retryBlockedSubscriptions() {
+	if !retryingBlockedSubscriptions.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		defer retryingBlockedSubscriptions.Store(false)
+		a.refreshEmptySubscriptions()
+	}()
+}
+
+func (a *App) refreshEmptySubscriptions() {
+	ids := a.emptySubscriptionIDs()
+	if len(ids) == 0 {
+		return
+	}
+
+	refreshed := false
+	for _, id := range ids {
+		result, err := a.RefreshV2RaySubscription(id)
+		if err != nil {
+			// Worth a line and nothing more. This ran because the connection
+			// came up, not because anyone asked for it, so a failure here must
+			// not surface as though an action of theirs had failed — the row in
+			// the list carries the reason already.
+			a.appendRuntimeLog(fmt.Sprintf("could not refresh %q now that the connection is up: %v", id, err))
+			continue
+		}
+		refreshed = true
+		a.appendRuntimeLog(fmt.Sprintf(
+			"refreshed %q through the connection: %d configs",
+			result.Subscription.Name, result.Subscription.ImportedCount,
+		))
+	}
+	if refreshed {
+		// The list on screen still shows the failure that sent this here.
+		a.emit("subscriptions:changed", nil)
+	}
+}
+
+// emptySubscriptionIDs is the subscriptions a working connection might fill.
+//
+// The built-in catalogue is skipped: connecting is what fetches it, so by the
+// time this runs it has either just succeeded or the connection would not be up.
+func (a *App) emptySubscriptionIDs() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	var ids []string
+	for _, subscription := range a.state.V2RaySubscriptions {
+		if subscription.ID == whiteDNSVPNSubscriptionID {
+			continue
+		}
+		if subscription.ImportedCount > 0 && subscription.LastError == "" {
+			continue
+		}
+		ids = append(ids, subscription.ID)
+	}
+	return ids
+}

--- a/desktop/subscription_retry_test.go
+++ b/desktop/subscription_retry_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"testing"
+
+	"whitevpn-desktop/internal/model"
+)
+
+func retryTestApp(subscriptions ...model.V2RaySubscription) *App {
+	state := model.DefaultAppState()
+	state.V2RaySubscriptions = subscriptions
+	return &App{state: state}
+}
+
+// Only the ones a working connection might fill.
+//
+// Refreshing every subscription on every connect would put a burst of requests
+// on the provider each time anyone reconnects, and would overwrite lists that
+// were already fine.
+func TestOnlyEmptySubscriptionsAreRetried(t *testing.T) {
+	app := retryTestApp(
+		model.V2RaySubscription{ID: "blocked", ImportedCount: 0, LastError: "something on this network is blocking it"},
+		model.V2RaySubscription{ID: "never-tried", ImportedCount: 0},
+		model.V2RaySubscription{ID: "failed-but-has-nodes", ImportedCount: 12, LastError: "the last refresh failed"},
+		model.V2RaySubscription{ID: "working", ImportedCount: 425},
+	)
+
+	got := app.emptySubscriptionIDs()
+	want := map[string]bool{"blocked": true, "never-tried": true, "failed-but-has-nodes": true}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d subscriptions to retry, got %v", len(want), got)
+	}
+	for _, id := range got {
+		if !want[id] {
+			t.Errorf("%q has nodes and no error — nothing is waiting on it", id)
+		}
+	}
+}
+
+// Connecting is what fetches the catalogue. By the time this runs it has either
+// just succeeded or the connection would not be up, so fetching it again would
+// be a second request for a document already in hand.
+func TestTheBuiltInCatalogueIsNotRetried(t *testing.T) {
+	app := retryTestApp(model.V2RaySubscription{ID: whiteDNSVPNSubscriptionID, ImportedCount: 0})
+	if got := app.emptySubscriptionIDs(); len(got) != 0 {
+		t.Fatalf("the catalogue should not be retried: %v", got)
+	}
+}
+
+// A reconnect, or a network change during one, must not start a second pass
+// while the first is still going.
+func TestTwoConnectsDoNotRetryAtOnce(t *testing.T) {
+	if !retryingBlockedSubscriptions.CompareAndSwap(false, true) {
+		t.Fatal("the guard was left set by another test")
+	}
+	defer retryingBlockedSubscriptions.Store(false)
+
+	// With the guard held, a connect must return without starting a pass. There
+	// is nothing to fetch in this state, so reaching a fetch at all would mean
+	// the guard did not hold.
+	app := retryTestApp(model.V2RaySubscription{ID: "blocked", URL: "https://127.0.0.1:1/nope"})
+	app.retryBlockedSubscriptions()
+}


### PR DESCRIPTION
A subscription whose address is blocked locally can only be fetched through the tunnel, so it has to be connect first, refresh second.

That order is not discoverable anywhere except the error you get for doing it the other way round — and the same user hit it twice, once before the message spelled it out and once after. The second time, the rest of their list had refreshed fine seconds earlier; only the blocked one sat at zero.

An instruction someone has to read and then remember to act on is a step the app can take itself.

## What changed

A successful connection retries the subscriptions that have nothing in them, in the background.

- **Only the empty ones.** One that already imported nodes is not waiting on anything, and refreshing every subscription on every connect would put a burst of requests on the provider each time anybody reconnects.
- **In the background**, because it is a courtesy rather than part of connecting — the connection is already usable and must not wait on someone else's server.
- **A failure is logged and goes no further.** Nobody asked for this, so it must not surface as though an action of theirs had failed; the row in the list already carries its own reason.
- **The built-in catalogue is skipped** — connecting is what fetches it, so by the time this runs it is already in hand.
- Two connects in quick succession cannot start two passes.
- The list on screen reloads when a pass finishes, because the rows still show the failure that sent it there.