### PR TITLE
Account for the links a subscription holds that do not become nodes

### DIFF
--- a/desktop/internal/mihomoconf/document.go
+++ b/desktop/internal/mihomoconf/document.go
@@ -32,29 +32,40 @@ import (
 // most subscriptions are. A document has no share links to report, so the
 // sources come back empty for it rather than invented.
 func ParseSubscription(body string) ([]Proxy, []string, error) {
-	proxies, sources, linkErr := ConvertLinksWithSources(body)
+	proxies, sources, _, err := ParseSubscriptionWithReport(body)
+	return proxies, sources, err
+}
+
+// ParseSubscriptionWithReport also reports what the document held and this could
+// not use, which is what makes a node count explainable.
+//
+// Only the links path fills the report in. The others read a list of proxies
+// out of a structured document rather than a line at a time, so there is no
+// per-line discard to count and an empty report is the honest answer.
+func ParseSubscriptionWithReport(body string) ([]Proxy, []string, SkipReport, error) {
+	proxies, sources, report, linkErr := ConvertLinksWithReport(body)
 	if linkErr == nil {
-		return proxies, sources, nil
+		return proxies, sources, report, nil
 	}
 
 	proxies, docErr := ParseDocument(body)
 	if docErr == nil {
-		return proxies, make([]string, len(proxies)), nil
+		return proxies, make([]string, len(proxies)), SkipReport{}, nil
 	}
 
 	if proxies, err := ParseSingBox(body); err == nil {
-		return proxies, make([]string, len(proxies)), nil
+		return proxies, make([]string, len(proxies)), SkipReport{}, nil
 	}
 	if proxies, err := ParseXrayJSON(body); err == nil {
-		return proxies, make([]string, len(proxies)), nil
+		return proxies, make([]string, len(proxies)), SkipReport{}, nil
 	}
 
 	// Base64 is a wrapper, not a format. ConvertLinks already unwraps it to look
 	// for links; a document served the same way deserves the same treatment,
 	// and providers do serve them that way.
 	if decoded, ok := decodeBase64Text(strings.TrimSpace(body)); ok {
-		if proxies, _, err := ParseSubscription(decoded); err == nil {
-			return proxies, make([]string, len(proxies)), nil
+		if proxies, _, report, err := ParseSubscriptionWithReport(decoded); err == nil {
+			return proxies, make([]string, len(proxies)), report, nil
 		}
 	}
 
@@ -63,7 +74,7 @@ func ParseSubscription(body string) ([]Proxy, []string, error) {
 	// and "must contain V2Ray links" describes none of them. What it *is* is
 	// reported, never what it says — a subscription body carries credentials
 	// and this message ends up in screenshots.
-	return nil, nil, fmt.Errorf("this does not look like a subscription: %s", describeBody(body))
+	return nil, nil, SkipReport{}, fmt.Errorf("this does not look like a subscription: %s", describeBody(body))
 }
 
 // ParseDocument reads the `proxies` of a mihomo configuration.

--- a/desktop/internal/mihomoconf/links.go
+++ b/desktop/internal/mihomoconf/links.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -69,12 +70,26 @@ func ConvertLinks(input string) ([]Proxy, error) {
 // from. Sharing a node means handing back the link it arrived as, and only the
 // converter knows which line survived and which was skipped.
 func ConvertLinksWithSources(input string) ([]Proxy, []string, error) {
+	proxies, sources, _, err := ConvertLinksWithReport(input)
+	return proxies, sources, err
+}
+
+// ConvertLinksWithReport also reports what it threw away.
+//
+// A subscription of 800 links that yields 425 nodes is not obviously wrong, and
+// was not obviously right either: everything this cannot read was discarded
+// without a word, so nobody could say whether the number was the catalogue's or
+// this parser's. Counting the discards is what makes the difference answerable —
+// a protocol nobody supports and a link nobody could read are different problems
+// and want different fixes.
+func ConvertLinksWithReport(input string) ([]Proxy, []string, SkipReport, error) {
 	body := input
 	if decoded, ok := decodeBase64Text(input); ok {
 		body = decoded
 	}
 
 	names := newNameRegistry()
+	report := SkipReport{Unsupported: map[string]int{}, Unreadable: map[string]int{}}
 	var proxies []Proxy
 	var sources []string
 	for _, raw := range strings.Split(body, "\n") {
@@ -83,6 +98,7 @@ func ConvertLinksWithSources(input string) ([]Proxy, []string, error) {
 			continue
 		}
 		scheme := strings.ToLower(line[:strings.Index(line, "://")])
+		report.Links++
 
 		var (
 			proxy Proxy
@@ -102,18 +118,77 @@ func ConvertLinksWithSources(input string) ([]Proxy, []string, error) {
 		case "wireguard", "wg":
 			proxy, err = parseWireGuard(line, names)
 		default:
+			// A protocol this app does not speak. Named, because which one it is
+			// decides whether anything should be done about it.
+			report.Unsupported[scheme]++
 			continue
 		}
 		if err != nil {
+			// A protocol it does speak, in a form it could not read.
+			report.Unreadable[scheme]++
 			continue
 		}
 		proxies = append(proxies, proxy)
 		sources = append(sources, strings.TrimSpace(line))
 	}
+	report.Converted = len(proxies)
 	if len(proxies) == 0 {
-		return nil, nil, errors.New("mihomoconf: no usable proxies in this subscription")
+		return nil, nil, report, errors.New("mihomoconf: no usable proxies in this subscription")
 	}
-	return proxies, sources, nil
+	return proxies, sources, report, nil
+}
+
+// SkipReport is what a subscription held that did not become a node.
+type SkipReport struct {
+	// Links is how many lines looked like one, whatever came of them.
+	Links int
+	// Converted is how many became proxies.
+	Converted int
+	// Unsupported counts links by scheme for protocols this app does not read.
+	Unsupported map[string]int
+	// Unreadable counts links by scheme for protocols it does read but could
+	// not parse — a link that should have worked and did not.
+	Unreadable map[string]int
+}
+
+// Skipped is how many links did not become nodes.
+func (r SkipReport) Skipped() int { return r.Links - r.Converted }
+
+// Summary explains a node count, or is empty when nothing needs explaining.
+//
+// Empty when nothing was skipped, because "425 links, 425 usable" is noise. It
+// exists for the case where the two numbers differ and somebody is wondering
+// which of them is the truth.
+func (r SkipReport) Summary() string {
+	if r.Skipped() <= 0 {
+		return ""
+	}
+	var reasons []string
+	for _, group := range []struct {
+		counts map[string]int
+		label  string
+	}{
+		{r.Unsupported, "not supported"},
+		{r.Unreadable, "unreadable"},
+	} {
+		schemes := make([]string, 0, len(group.counts))
+		for scheme := range group.counts {
+			schemes = append(schemes, scheme)
+		}
+		// Sorted so the same subscription reports the same way twice running,
+		// which is what makes two of these worth comparing.
+		sort.Slice(schemes, func(i, j int) bool {
+			if group.counts[schemes[i]] != group.counts[schemes[j]] {
+				return group.counts[schemes[i]] > group.counts[schemes[j]]
+			}
+			return schemes[i] < schemes[j]
+		})
+		for _, scheme := range schemes {
+			reasons = append(reasons, fmt.Sprintf("%d %s (%s)", group.counts[scheme], scheme, group.label))
+		}
+	}
+	return fmt.Sprintf("%d links, %d usable, %d skipped: %s",
+		r.Links, r.Converted, r.Skipped(), strings.Join(reasons, ", "))
 }
 
 // --- vless / vmess-aead ------------------------------------------------------

--- a/desktop/internal/mihomoconf/skipreport_test.go
+++ b/desktop/internal/mihomoconf/skipreport_test.go
@@ -1,0 +1,93 @@
+package mihomoconf
+
+import (
+	"strings"
+	"testing"
+)
+
+// The question this exists to answer: a subscription of many links yields fewer
+// nodes, and until now nothing recorded which of the two numbers was the truth.
+func TestTheReportAccountsForEveryLink(t *testing.T) {
+	body := strings.Join([]string{
+		"vless://eb3bcbfe-3b07-1a32-3128-a14a2f65c313@one.example.com:443?security=tls&type=ws#one",
+		"vless://eb3bcbfe-3b07-1a32-3128-a14a2f65c313@two.example.com:443?security=tls&type=ws#two",
+		"ssr://this-is-a-protocol-nobody-here-reads",
+		"tuic://also-not-read",
+		"tuic://nor-this",
+		"vmess://not-valid-base64-so-it-cannot-be-read",
+		"# a comment, not a link",
+		"",
+	}, "\n")
+
+	proxies, _, report, err := ConvertLinksWithReport(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.Links != 6 {
+		t.Errorf("six lines looked like links, counted %d", report.Links)
+	}
+	if report.Converted != len(proxies) || report.Converted != 2 {
+		t.Errorf("two links convert, got Converted=%d len=%d", report.Converted, len(proxies))
+	}
+	// Every link is either converted or accounted for. That is the property
+	// worth holding: a link that is neither is one that vanished in silence.
+	if report.Skipped() != 4 {
+		t.Errorf("four links should be skipped, got %d", report.Skipped())
+	}
+	if report.Unsupported["ssr"] != 1 || report.Unsupported["tuic"] != 2 {
+		t.Errorf("protocols this app does not read are miscounted: %v", report.Unsupported)
+	}
+	if report.Unreadable["vmess"] != 1 {
+		t.Errorf("a vmess link that would not parse should be unreadable, got %v", report.Unreadable)
+	}
+
+	// A protocol nobody supports and a link nobody could read are different
+	// problems, so the summary keeps them apart.
+	summary := report.Summary()
+	for _, want := range []string{"6 links", "2 usable", "4 skipped", "2 tuic (not supported)", "1 ssr (not supported)", "1 vmess (unreadable)"} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("summary should mention %q: %s", want, summary)
+		}
+	}
+	// Largest first, so the one worth acting on leads.
+	if strings.Index(summary, "2 tuic") > strings.Index(summary, "1 ssr") {
+		t.Errorf("the biggest group should come first: %s", summary)
+	}
+}
+
+// A count that needs no explaining gets none, or this would be in the log on
+// every refresh of every healthy subscription.
+func TestNothingToExplainSaysNothing(t *testing.T) {
+	body := "vless://eb3bcbfe-3b07-1a32-3128-a14a2f65c313@one.example.com:443?security=tls&type=ws#one"
+	_, _, report, err := ConvertLinksWithReport(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := report.Summary(); got != "" {
+		t.Fatalf("nothing was skipped, so there is nothing to say: %q", got)
+	}
+}
+
+// The same subscription has to report the same way twice running, or two of
+// these cannot be compared.
+func TestTheSummaryIsStable(t *testing.T) {
+	body := strings.Join([]string{
+		"vless://eb3bcbfe-3b07-1a32-3128-a14a2f65c313@one.example.com:443?security=tls&type=ws#one",
+		"ssr://a", "tuic://b", "snell://c", "juicity://d",
+	}, "\n")
+
+	_, _, first, err := ConvertLinksWithReport(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 8; i++ {
+		_, _, again, err := ConvertLinksWithReport(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if first.Summary() != again.Summary() {
+			t.Fatalf("map order leaked into the summary:\n%s\n%s", first.Summary(), again.Summary())
+		}
+	}
+}

--- a/desktop/whitevpn_nodes.go
+++ b/desktop/whitevpn_nodes.go
@@ -78,9 +78,14 @@ func (a *App) ListSubscriptionNodes(subscriptionID string, refresh bool) (model.
 	if err != nil {
 		return a.staleWhiteVPNNodes(subscriptionID, err)
 	}
-	nodes, err := whiteVPNNodesFromSubscription(subscription)
+	nodes, summary, err := whiteVPNNodesWithReport(subscription)
 	if err != nil {
 		return a.staleWhiteVPNNodes(subscriptionID, err)
+	}
+	if summary != "" {
+		// Only when the two numbers differ. A count that needs no explaining
+		// gets none, or this line would be in the log on every refresh.
+		a.appendRuntimeLog(fmt.Sprintf("%s: %s", subscriptionID, summary))
 	}
 	if subscriptionID == model.ManualServerSourceID {
 		a.attachManualProfileIDs(nodes)
@@ -310,17 +315,34 @@ func measureNodeDelays(ctx context.Context, client *engine.Process, names []stri
 // whiteVPNNodesFromSubscription turns a decrypted catalogue into nodes, in the
 // order the catalogue gave them — which is the order the connect path tries.
 func whiteVPNNodesFromSubscription(subscription string) ([]model.WhiteVPNNode, error) {
+	nodes, _, err := whiteVPNNodesWithReport(subscription)
+	return nodes, err
+}
+
+// whiteVPNNodesWithReport also explains the count it returns.
+//
+// "425 nodes" from a subscription of 800 links is not a number anybody can check.
+// Everything unreadable was dropped in silence, so the count could as easily have
+// been the catalogue's size as this parser's reach, and there was no way to tell
+// which — the question that prompted this could not be answered from inside the
+// app at all.
+func whiteVPNNodesWithReport(subscription string) ([]model.WhiteVPNNode, string, error) {
 	// ParseSubscription rather than ConvertLinksWithSources: a subscription may
 	// be share links or a whole mihomo configuration, and the Servers page, the
 	// tests and the connection dialog have no business knowing which.
-	proxies, sources, err := mihomoconf.ParseSubscription(subscription)
+	proxies, sources, report, err := mihomoconf.ParseSubscriptionWithReport(subscription)
 	if err != nil {
-		return nil, fmt.Errorf("the catalogue held no usable nodes: %w", err)
+		return nil, "", fmt.Errorf("the catalogue held no usable nodes: %w", err)
 	}
 	nodes := make([]model.WhiteVPNNode, 0, len(proxies))
+	nameless := 0
 	for index, proxy := range proxies {
 		name := proxy.Name()
 		if strings.TrimSpace(name) == "" {
+			// A node with no name cannot be listed, picked or hidden, all of
+			// which are done by name. Counted rather than merely dropped: this
+			// is the third place a node could vanish without one.
+			nameless++
 			continue
 		}
 		proxyType, _ := proxy["type"].(string)
@@ -340,9 +362,19 @@ func whiteVPNNodesFromSubscription(subscription string) ([]model.WhiteVPNNode, e
 		})
 	}
 	if len(nodes) == 0 {
-		return nil, fmt.Errorf("the catalogue held no usable nodes")
+		return nil, "", fmt.Errorf("the catalogue held no usable nodes")
 	}
-	return nodes, nil
+
+	summary := report.Summary()
+	if nameless > 0 {
+		unnamed := fmt.Sprintf("%d with no name", nameless)
+		if summary == "" {
+			summary = fmt.Sprintf("%d links, %d usable, %d skipped: %s", len(proxies), len(nodes), nameless, unnamed)
+		} else {
+			summary += ", " + unnamed
+		}
+	}
+	return nodes, summary, nil
 }
 
 // proxyPort reads the port whichever way the converter wrote it: YAML numbers


### PR DESCRIPTION
"Why does the catalogue show 425?" could not be answered from inside the app.

Three places dropped a node without recording it:

1. a protocol the converter does not read (`default: continue`)
2. a link of a protocol it *does* read that would not parse (`if err != nil { continue }`)
3. a proxy with no name

So 425 could have been the size of the catalogue or the reach of this parser, and nothing distinguished them.

## What changed

Each of the three is counted, by scheme, and reported wherever a subscription is listed:

```
812 links, 425 usable, 387 skipped: 350 ssr (not supported), 37 vmess (unreadable)
```

The two kinds are kept apart because they are different problems: a protocol nobody here speaks is a **decision**, and a link that should have parsed and did not is a **bug**.

- **Only when the numbers differ.** A subscription whose links all convert says nothing, or this would be in the log on every refresh of every healthy subscription.
- **Ordered largest-first and stable**, so two reports of the same subscription can be compared.

## What did not change

The skipping itself. Dropping socks and tuic is deliberate parity with the phone app and is written down at the top of `links.go` — what was missing was any way to see that it had happened.