### PR TITLE
Add a proxy-only mode, and let the port be relied on there

### DIFF
--- a/desktop/ANDROID-PARITY.md
+++ b/desktop/ANDROID-PARITY.md
@@ -426,6 +426,7 @@ Things the phone has no equivalent for, added because a desktop needs them.
 | Tray icon | Status, connect/disconnect, open, quit — in the app's own language | `[x]` |
 | Runs in the background | Closing the window hides it; the app keeps carrying traffic | `[x]` |
 | Sets the system proxy | In proxy mode, points Windows at the local proxy and puts back what it found | `[x]` |
+| Proxy-only mode | No phone equivalent. The engine listens and nothing on the machine is redirected | `[+]` |
 
 Closing a VPN's window means "get out of my way", not "stop protecting my
 traffic". But hiding is only offered once there is an icon to come back from:
@@ -439,6 +440,27 @@ shipping the half that starts a proxy without the half that sends anything to
 it. Connected, healthy, 0 D/s, and a user quite reasonably reporting that none
 of the ports work. `TunEnabled` defaults to false, so that was the default
 experience.
+
+The correction went too far the other way: setting it became unconditional
+whenever the tunnel was off, so turning the tunnel off silently reconfigured the
+whole desktop and there was no way to ask for anything else. Users wanting one
+browser extension or Telegram routed — and the rest of the machine left alone —
+had nothing to reach for. There is now a third mode, **proxy-only**, where both
+are off: the engine listens on its mixed port, serving HTTP and SOCKS5, and
+nothing on the machine is touched.
+
+The three are one choice in the interface rather than two switches, because they
+are mutually exclusive at connect — with the tunnel up the system proxy is
+deliberately not set — and two independent switches would silently override each
+other.
+
+Proxy-only is also the one mode where the port is a promise rather than an
+implementation detail: it is what somebody typed into another program, and it
+has to still be right tomorrow. So `chooseProxyPort` holds the configured port
+there and reports one it cannot have, while in the other two modes it falls back
+to any free port as before. Silently binding a different one would break their
+Telegram days later, in a different application, with nothing anywhere
+connecting that to this app.
 
 What was there before the change is written to `system-proxy.json` **before**
 the change, and removed only after it has been put back. A crash therefore

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -473,6 +473,19 @@ function normalizeV2RaySettingsProfile(profile: V2RaySettingsProfile): V2RaySett
   };
 }
 
+// The three ways traffic can reach the engine, as one value.
+//
+// The tunnel takes precedence because that is what the connect path does: with
+// it on, the system proxy is deliberately left alone.
+type RoutingMode = "tun" | "systemProxy" | "proxyOnly";
+
+function routingMode(settings: WhiteVPNSettings): RoutingMode {
+  if (settings.tunEnabled) {
+    return "tun";
+  }
+  return settings.setSystemProxy ? "systemProxy" : "proxyOnly";
+}
+
 function normalizeSettingsProfile(profile: SettingsProfile): SettingsProfile {
   const missingStartupLoss =
     !profile.mtuStartupLossVerifyEnabled &&
@@ -2219,9 +2232,23 @@ function WhiteDNSVPNPage({
                         {exitCountry.pending && <RotateCcw className="size-3 animate-spin text-muted-foreground" />}
                       </Badge>
                     )}
-                    <Badge variant="outline" className="h-6 gap-1 px-3">
-                      <Monitor className="size-3" />
-                      <span className="max-w-48 truncate font-mono">{localProxyEndpoint}</span>
+                    {/* Copyable, because in proxy-only mode this address is the
+                        product: it is what gets typed into Telegram or a
+                        browser extension, and retyping it by eye off a badge is
+                        how a digit goes missing. */}
+                    <Badge
+                      asChild
+                      variant="outline"
+                      className="h-6 cursor-pointer gap-1 px-3 hover:bg-accent"
+                    >
+                      <button
+                        type="button"
+                        title={t("vpn.localProxy.copy")}
+                        onClick={() => void navigator.clipboard?.writeText(localProxyEndpoint)}
+                      >
+                        <Monitor className="size-3" />
+                        <span className="max-w-48 truncate font-mono">{localProxyEndpoint}</span>
+                      </button>
                     </Badge>
                     <Badge variant="outline" className="h-6 gap-1 px-3">
                       <Shield className="size-3" />
@@ -6058,20 +6085,60 @@ function WhiteVPNSettingsPage({
       }
     >
       <SettingsSection title={t("settings.connection.title")} description={t("settings.connection.description")}>
-        <div className="grid gap-2 sm:grid-cols-2">
-          <SettingSwitchRow
-            label={t("settings.tunnel")}
-            checked={draft.tunEnabled}
-            onCheckedChange={(checked) => patch({ tunEnabled: checked })}
-          />
-          <SettingSwitchRow
-            label={t("settings.killSwitch")}
-            checked={draft.killSwitch.enabled}
-            disabled
-            onCheckedChange={(checked) => patch({ killSwitch: { enabled: checked } })}
-          />
-        </div>
-        <FieldDescription>{t("settings.tunnel.description")}</FieldDescription>
+        {/* One choice rather than two switches. The tunnel and the system proxy
+            are mutually exclusive at connect — with the tunnel up the system
+            proxy is deliberately not set — so two independent switches would
+            silently override each other. */}
+        <Field>
+          <FieldLabel>{t("settings.routing.mode")}</FieldLabel>
+          <Select
+            value={routingMode(draft)}
+            onValueChange={(value) =>
+              patch(
+                value === "tun"
+                  ? { tunEnabled: true, setSystemProxy: false }
+                  : { tunEnabled: false, setSystemProxy: value === "systemProxy" },
+              )
+            }
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent position="popper">
+              <SelectItem value="systemProxy">{t("settings.routing.systemProxy")}</SelectItem>
+              <SelectItem value="proxyOnly">{t("settings.routing.proxyOnly")}</SelectItem>
+              <SelectItem value="tun">{t("settings.routing.tun")}</SelectItem>
+            </SelectContent>
+          </Select>
+          <FieldDescription>{t(`settings.routing.${routingMode(draft)}.description`)}</FieldDescription>
+        </Field>
+
+        {/* Only in proxy-only mode. Everywhere else the port is an
+            implementation detail and inviting someone to change it would be
+            inviting them to break something for no reason. */}
+        {routingMode(draft) === "proxyOnly" && (
+          <Field>
+            <FieldLabel>{t("settings.routing.port")}</FieldLabel>
+            <Input
+              type="number"
+              min={1024}
+              max={65535}
+              className="max-w-40"
+              value={draft.listenPort || 2080}
+              onChange={(event) => patch({ listenPort: Number(event.target.value) || 0 })}
+            />
+            <FieldDescription>
+              {t("settings.routing.port.description", { endpoint: `127.0.0.1:${draft.listenPort || 2080}` })}
+            </FieldDescription>
+          </Field>
+        )}
+
+        <SettingSwitchRow
+          label={t("settings.killSwitch")}
+          checked={draft.killSwitch.enabled}
+          disabled
+          onCheckedChange={(checked) => patch({ killSwitch: { enabled: checked } })}
+        />
         <FieldDescription>{t("settings.killSwitch.description")}</FieldDescription>
       </SettingsSection>
 

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -82,6 +82,10 @@ const strings = {
     fa: "پیش از راه‌اندازی وایت‌وی‌پی‌ان، موتور فعال را قطع کنید.",
   },
   "vpn.metric.localProxy": { en: "Local proxy", fa: "پراکسی محلی" },
+  "vpn.localProxy.copy": {
+    en: "Copy — point a browser extension or Telegram here (HTTP or SOCKS5)",
+    fa: "کپی — افزونهٔ مرورگر یا تلگرام را به اینجا وصل کنید (HTTP یا SOCKS5)",
+  },
   "vpn.metric.frontingIp": { en: "Fronting IP", fa: "آی‌پی جایگزین" },
   "vpn.metric.download": { en: "Download", fa: "دریافت" },
   "vpn.metric.upload": { en: "Upload", fa: "ارسال" },
@@ -603,6 +607,27 @@ const strings = {
   "settings.connection.description": {
     en: "How traffic reaches your machine.",
     fa: "اینکه ترافیک چطور به دستگاه شما می‌رسد.",
+  },
+  "settings.routing.mode": { en: "How traffic reaches the tunnel", fa: "ترافیک چطور به تونل برسد" },
+  "settings.routing.systemProxy": { en: "System proxy — the whole machine", fa: "پراکسی سیستم — کل دستگاه" },
+  "settings.routing.proxyOnly": { en: "Proxy only — nothing is redirected", fa: "فقط پراکسی — چیزی تغییر نمی‌کند" },
+  "settings.routing.tun": { en: "Tunnel (TUN) — the whole machine", fa: "تونل (TUN) — کل دستگاه" },
+  "settings.routing.systemProxy.description": {
+    en: "This desktop's proxy settings are pointed at the app while it is connected, and put back when it disconnects. Most programs follow them.",
+    fa: "تا وقتی متصل هستید، تنظیمات پراکسی این دستگاه به برنامه اشاره می‌کند و هنگام قطع به حالت قبل برمی‌گردد. بیشتر برنامه‌ها از آن پیروی می‌کنند.",
+  },
+  "settings.routing.proxyOnly.description": {
+    en: "Nothing on this machine is changed. The app just listens, and you point one program at it — a browser extension, or Telegram's proxy settings. Everything else goes out normally.",
+    fa: "هیچ چیزی روی این دستگاه تغییر نمی‌کند. برنامه فقط گوش می‌دهد و شما یک برنامه را به آن وصل می‌کنید — افزونهٔ مرورگر یا تنظیمات پراکسی تلگرام. بقیه مثل همیشه از مسیر عادی می‌روند.",
+  },
+  "settings.routing.tun.description": {
+    en: "A virtual network adapter carries everything, including programs that ignore proxy settings. Needs Administrator on Windows.",
+    fa: "یک کارت شبکهٔ مجازی همه چیز را حمل می‌کند، حتی برنامه‌هایی که تنظیمات پراکسی را نادیده می‌گیرند. روی ویندوز نیاز به دسترسی Administrator دارد.",
+  },
+  "settings.routing.port": { en: "Local proxy port", fa: "پورت پراکسی محلی" },
+  "settings.routing.port.description": {
+    en: "Point your program at {endpoint} — it accepts both HTTP and SOCKS5. If another program already holds this port, connecting will say so rather than quietly moving to another one, which would leave whatever you configured pointing at nothing.",
+    fa: "برنامه‌تان را به {endpoint} وصل کنید — هم HTTP و هم SOCKS5 را می‌پذیرد. اگر برنامهٔ دیگری این پورت را گرفته باشد، هنگام اتصال همین را می‌گوید و بی‌سروصدا پورت دیگری انتخاب نمی‌کند، چون آن‌وقت چیزی که تنظیم کرده‌اید به جای خالی وصل می‌ماند.",
   },
   "settings.tunnel": { en: "Tunnel (TUN)", fa: "تونل (TUN)" },
   "settings.tunnel.description": {

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -747,5 +747,7 @@ export type WhiteVPNSettings = {
   killSwitch: KillSwitchSettings;
   language: string;
   tunEnabled: boolean;
+  setSystemProxy: boolean;
+  listenPort: number;
   acceptedPrivacyPolicyVersion: number;
 };

--- a/desktop/internal/model/proxyonly_test.go
+++ b/desktop/internal/model/proxyonly_test.go
@@ -1,0 +1,76 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The upgrade path. Every settings file written before SetSystemProxy existed
+// has no key for it, and a plain bool would read that as false — proxy-only —
+// so everyone who updated would find their machine quietly no longer proxied.
+func TestSettingsWrittenBeforeThisFieldStillProxyTheMachine(t *testing.T) {
+	var settings WhiteVPNSettings
+	if err := json.Unmarshal([]byte(`{"tunEnabled":false,"language":"fa"}`), &settings); err != nil {
+		t.Fatal(err)
+	}
+	if !settings.SetSystemProxy {
+		t.Fatal("an older settings file must keep proxying the machine")
+	}
+	// And the rest of the block still decodes.
+	if settings.Language != "fa" {
+		t.Fatalf("the alias dropped other fields: %#v", settings)
+	}
+}
+
+// Turning it off has to survive a save and a reload, or the mode cannot be
+// chosen at all.
+func TestTurningTheSystemProxyOffIsRemembered(t *testing.T) {
+	encoded, err := json.Marshal(WhiteVPNSettings{SetSystemProxy: false, ListenPort: 2080})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var settings WhiteVPNSettings
+	if err := json.Unmarshal(encoded, &settings); err != nil {
+		t.Fatal(err)
+	}
+	if settings.SetSystemProxy {
+		t.Fatal("a deliberate off was read back as on")
+	}
+}
+
+func TestTheSystemProxyStaysOnWhenItWasOn(t *testing.T) {
+	var settings WhiteVPNSettings
+	if err := json.Unmarshal([]byte(`{"setSystemProxy":true}`), &settings); err != nil {
+		t.Fatal(err)
+	}
+	if !settings.SetSystemProxy {
+		t.Fatal("an explicit true was lost")
+	}
+}
+
+// A port the engine could never bind must be corrected here rather than
+// reaching it and failing there, where the cause is much harder to see.
+func TestAnUnusablePortBecomesTheDefault(t *testing.T) {
+	for _, port := range []int{0, -1, 80, 1023, 65536, 200000} {
+		settings := NormalizeWhiteVPNSettings(WhiteVPNSettings{ListenPort: port})
+		if settings.ListenPort != DefaultLocalProxyPort {
+			t.Errorf("port %d should have become %d, got %d", port, DefaultLocalProxyPort, settings.ListenPort)
+		}
+	}
+
+	// Zero in particular: that is what a settings block written before this
+	// field existed carries, and it has to read as "the usual port" rather than
+	// "let the system choose", which would be a different port every run.
+	if got := NormalizeWhiteVPNSettings(WhiteVPNSettings{}).ListenPort; got != DefaultLocalProxyPort {
+		t.Fatalf("an unset port should be the default, got %d", got)
+	}
+}
+
+func TestAUsablePortIsKept(t *testing.T) {
+	for _, port := range []int{1024, 2080, 7890, 10888, 65535} {
+		if got := NormalizeWhiteVPNSettings(WhiteVPNSettings{ListenPort: port}).ListenPort; got != port {
+			t.Errorf("port %d should have been kept, got %d", port, got)
+		}
+	}
+}

--- a/desktop/internal/model/whitevpn_settings.go
+++ b/desktop/internal/model/whitevpn_settings.go
@@ -1,6 +1,9 @@
 package model
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // The settings WhiteVPN for Android exposes, so that someone moving from the
 // phone finds the same options here under the same names and with the same
@@ -120,6 +123,28 @@ type WhiteVPNSettings struct {
 	// Administrator.
 	TunEnabled bool `json:"tunEnabled"`
 
+	// SetSystemProxy points the machine's proxy settings at the engine when the
+	// tunnel is off.
+	//
+	// Neither this nor the tunnel leaves a third option: with both off the
+	// engine listens and nothing on the machine is redirected, which is what
+	// somebody wants who is pointing one browser extension or Telegram at it and
+	// leaving everything else alone. Until this existed, turning the tunnel off
+	// silently reconfigured the whole desktop and there was no way to ask for
+	// anything else.
+	//
+	// There is a SetSystemProxy on V2RaySettingsProfile too. That one belongs to
+	// the removed Xray path and nothing reads it.
+	SetSystemProxy bool `json:"setSystemProxy"`
+
+	// ListenPort is where the engine's local proxy listens, serving HTTP and
+	// SOCKS5 on the one port.
+	//
+	// Settable because in proxy-only mode this number is not an implementation
+	// detail — it is what the user typed into another program, and it has to
+	// keep working tomorrow.
+	ListenPort int `json:"listenPort"`
+
 	AcceptedPrivacyPolicyVersion int `json:"acceptedPrivacyPolicyVersion"`
 }
 
@@ -145,7 +170,44 @@ func DefaultWhiteVPNSettings() WhiteVPNSettings {
 		KillSwitch: KillSwitchSettings{Enabled: false},
 		Language:   "",
 		TunEnabled: false,
+		// On by default, because that is what the app did before this was a
+		// choice, and an update that silently stopped proxying a machine would
+		// look exactly like an update that broke the connection.
+		SetSystemProxy: true,
+		ListenPort:     DefaultLocalProxyPort,
 	}
+}
+
+// DefaultLocalProxyPort is the engine's usual mixed port — HTTP and SOCKS5 on
+// one listener.
+const DefaultLocalProxyPort = 2080
+
+// UnmarshalJSON reads settings, treating an absent SetSystemProxy as on.
+//
+// Every settings file written before that field existed has no key for it, and
+// a plain bool reads a missing key as false — which is the new proxy-only mode.
+// Everyone who updated would have found their machine quietly no longer
+// proxied, which looks exactly like an update that broke the connection, and
+// nothing in the app would have said otherwise.
+//
+// The distinction only survives at this boundary. By the time the value is a
+// bool, "absent" and "deliberately off" are the same thing, so no migration
+// running later could tell them apart.
+func (s *WhiteVPNSettings) UnmarshalJSON(data []byte) error {
+	// An alias to borrow the generated decoding without recursing into this
+	// method. The pointer field sits shallower than the embedded struct's, so
+	// encoding/json fills this one and leaves that one alone.
+	type alias WhiteVPNSettings
+	probe := struct {
+		*alias
+		SetSystemProxy *bool `json:"setSystemProxy"`
+	}{alias: (*alias)(s)}
+
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return err
+	}
+	s.SetSystemProxy = probe.SetSystemProxy == nil || *probe.SetSystemProxy
+	return nil
 }
 
 // NormalizeWhiteVPNSettings repairs a settings block read from disk.
@@ -206,6 +268,15 @@ func NormalizeWhiteVPNSettings(settings WhiteVPNSettings) WhiteVPNSettings {
 	settings.Connection.Node = strings.TrimSpace(settings.Connection.Node)
 	settings.Connection.Types = nonEmptyStrings(lowered(settings.Connection.Types))
 	settings.Language = strings.TrimSpace(settings.Language)
+
+	// A port outside the range, or one of the reserved low ones no ordinary
+	// program may bind, becomes the default rather than reaching the engine and
+	// failing there where the cause is much harder to see. Zero included: that
+	// is what a settings block written before this field existed carries, and it
+	// must read as "the usual port", not as "let the system choose".
+	if settings.ListenPort < 1024 || settings.ListenPort > 65535 {
+		settings.ListenPort = defaults.ListenPort
+	}
 	return settings
 }
 

--- a/desktop/mihomo_connect.go
+++ b/desktop/mihomo_connect.go
@@ -103,10 +103,16 @@ func (a *App) startWhiteDNSVPNWithMihomo() (model.AppState, error) {
 
 	a.handleRuntimeState(model.RuntimeConnecting, "Starting engine")
 
+	mixedPort, err := chooseProxyPort(settings)
+	if err != nil {
+		a.reportConnectFailure(ctx, err.Error())
+		return a.GetAppState(), err
+	}
+
 	connected, err := session.Connect(ctx, session.Options{
 		CorePath:     corePath,
 		HomeDir:      homeDir,
-		MixedPort:    chooseProxyPort(),
+		MixedPort:    mixedPort,
 		Subscription: subscription,
 		Prefer:       prefer,
 		// Nodes the user hid never reach the configuration, so the engine cannot
@@ -147,10 +153,24 @@ func (a *App) startWhiteDNSVPNWithMihomo() (model.AppState, error) {
 	a.state.Runtime.LocalProxyIP = "127.0.0.1"
 	a.mu.Unlock()
 	a.recordConnectedNode(connected.Selected())
-	if !settings.TunEnabled {
+	if proxyOnly(settings) {
+		// Nothing on the machine has been redirected, which is the point: the
+		// engine listens and the user points one program at it. Said plainly,
+		// because a connection that changed nothing otherwise looks like one
+		// that did not work.
+		a.appendRuntimeLog(fmt.Sprintf(
+			"proxy-only: nothing on this machine was redirected — point your programs at 127.0.0.1:%d (HTTP or SOCKS5)",
+			connected.MixedPort()))
+	}
+	if !settings.TunEnabled && settings.SetSystemProxy {
 		// Proxy mode: without this the engine listens and nothing on the
 		// machine is talking to it. With the tunnel up the routing is the
 		// tunnel's job and a proxy as well would be one hop too many.
+		//
+		// SetSystemProxy is checked because it had been stored, defaulted and
+		// logged since this path was written, and never once read — so turning
+		// the tunnel off silently reconfigured the whole machine, and there was
+		// no way to ask for the engine to just listen.
 		if err := a.captureSystemProxy(connected.MixedPort()); err != nil {
 			// Not fatal. The connection is up and the proxy is listening; what
 			// failed is pointing the machine at it, and that is something a user
@@ -385,8 +405,31 @@ func (a *App) stopMihomo() bool {
 // listener does not come up, and the health check then talks to whatever *is*
 // on 2080 and reports a healthy connection through someone else's proxy. A port
 // this app cannot bind is not a port it can claim.
-func chooseProxyPort() int {
-	for _, port := range []int{mihomoconf.DefaultMixedPort, 0} {
+// chooseProxyPort picks the port the engine's local proxy listens on.
+//
+// How hard it insists depends on whether anyone outside this app is relying on
+// the number. With the tunnel up, or with the machine's proxy settings pointed
+// here, nothing the user configured depends on it and any free port will do.
+//
+// In proxy-only mode the port *is* the interface: it is what somebody typed into
+// Telegram or a browser extension, and quietly binding a different one means
+// their program stops working days later, in another application, with nothing
+// anywhere connecting that to this app. So there it is held, and a port that
+// cannot be had is reported instead of worked around.
+func chooseProxyPort(settings model.WhiteVPNSettings) (int, error) {
+	wanted := settings.ListenPort
+	if wanted <= 0 {
+		wanted = mihomoconf.DefaultMixedPort
+	}
+
+	if proxyOnly(settings) {
+		if !portIsFree(wanted) {
+			return 0, fmt.Errorf("port %d is already in use by another program — choose a different local proxy port in Settings, or turn the system proxy back on", wanted)
+		}
+		return wanted, nil
+	}
+
+	for _, port := range []int{wanted, 0} {
 		listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 		if err != nil {
 			continue
@@ -396,9 +439,27 @@ func chooseProxyPort() int {
 		// engine binds it a moment later, and losing that race is a connection
 		// that fails loudly rather than one that succeeds through a stranger.
 		_ = listener.Close()
-		return bound
+		return bound, nil
 	}
-	return mihomoconf.DefaultMixedPort
+	return wanted, nil
+}
+
+// proxyOnly is the mode where the engine listens and nothing else on the machine
+// is touched — no virtual adapter, no change to the machine's proxy settings.
+//
+// It is the mode for pointing one program at the tunnel: a browser extension, or
+// Telegram's proxy field, while everything else goes out normally.
+func proxyOnly(settings model.WhiteVPNSettings) bool {
+	return !settings.TunEnabled && !settings.SetSystemProxy
+}
+
+func portIsFree(port int) bool {
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return false
+	}
+	_ = listener.Close()
+	return true
 }
 
 // GetLocalProxyEndpoint is where the engine's local proxy listens, whether or
@@ -409,8 +470,24 @@ func chooseProxyPort() int {
 // that nothing reads: it showed 10888 while the engine listened on 2080. A port
 // the user is invited to configure their browser with has to be the port
 // traffic will actually arrive on.
+// It went on to report the default whatever the engine had actually bound,
+// which is the same fault in a smaller place: a running session may be on
+// another port entirely, and the number offered for someone to configure their
+// browser with has to be the one traffic will arrive on.
 func (a *App) GetLocalProxyEndpoint() string {
-	return fmt.Sprintf("127.0.0.1:%d", mihomoconf.DefaultMixedPort)
+	if current := a.mihomo.current(); current != nil {
+		if port := current.MixedPort(); port > 0 {
+			return fmt.Sprintf("127.0.0.1:%d", port)
+		}
+	}
+
+	a.mu.Lock()
+	port := model.NormalizeWhiteVPNSettings(a.state.WhiteVPN).ListenPort
+	a.mu.Unlock()
+	if port <= 0 {
+		port = mihomoconf.DefaultMixedPort
+	}
+	return fmt.Sprintf("127.0.0.1:%d", port)
 }
 
 // EngineMihomo marks a runtime as belonging to the mihomo session.

--- a/desktop/proxyonly_test.go
+++ b/desktop/proxyonly_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"whitevpn-desktop/internal/model"
+)
+
+// The three modes, and which of them makes the port somebody else's business.
+func TestProxyOnlyIsBothOthersOff(t *testing.T) {
+	cases := []struct {
+		name     string
+		settings model.WhiteVPNSettings
+		want     bool
+	}{
+		{"tunnel", model.WhiteVPNSettings{TunEnabled: true, SetSystemProxy: false}, false},
+		{"system proxy", model.WhiteVPNSettings{TunEnabled: false, SetSystemProxy: true}, false},
+		{"proxy only", model.WhiteVPNSettings{TunEnabled: false, SetSystemProxy: false}, true},
+		// The tunnel wins over the system proxy at connect, so this is not
+		// proxy-only either — something is still redirecting the machine.
+		{"both", model.WhiteVPNSettings{TunEnabled: true, SetSystemProxy: true}, false},
+	}
+	for _, tc := range cases {
+		if got := proxyOnly(tc.settings); got != tc.want {
+			t.Errorf("%s: proxyOnly = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// With the tunnel up or the machine pointed here, nothing the user configured
+// depends on the number, so a taken port is worked around rather than reported.
+func TestATakenPortIsWorkedAroundWhenNobodyIsRelyingOnIt(t *testing.T) {
+	held, port := holdAPort(t)
+	defer held.Close()
+
+	settings := model.WhiteVPNSettings{TunEnabled: false, SetSystemProxy: true, ListenPort: port}
+	got, err := chooseProxyPort(settings)
+	if err != nil {
+		t.Fatalf("this mode should not fail over a port: %v", err)
+	}
+	if got == port {
+		t.Fatal("the held port was handed out anyway")
+	}
+	if got <= 0 {
+		t.Fatalf("expected some usable port, got %d", got)
+	}
+}
+
+// In proxy-only mode the port is what somebody typed into Telegram. Binding a
+// different one silently means their program stops working days later, in
+// another application, with nothing anywhere connecting that to this app.
+func TestATakenPortIsReportedInProxyOnlyMode(t *testing.T) {
+	held, port := holdAPort(t)
+	defer held.Close()
+
+	settings := model.WhiteVPNSettings{TunEnabled: false, SetSystemProxy: false, ListenPort: port}
+	_, err := chooseProxyPort(settings)
+	if err == nil {
+		t.Fatal("a port that cannot be had must be reported, not worked around")
+	}
+	// The message has to name the port and say what to do about it.
+	for _, want := range []string{fmt.Sprint(port), "Settings"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the message should mention %q: %v", want, err)
+		}
+	}
+}
+
+// A free port is used as asked, in every mode.
+func TestAFreePortIsUsedAsAsked(t *testing.T) {
+	held, port := holdAPort(t)
+	held.Close() // now free, and unlikely to be retaken in this instant
+
+	for _, settings := range []model.WhiteVPNSettings{
+		{TunEnabled: false, SetSystemProxy: false, ListenPort: port},
+		{TunEnabled: false, SetSystemProxy: true, ListenPort: port},
+	} {
+		got, err := chooseProxyPort(settings)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != port {
+			t.Errorf("asked for %d, got %d", port, got)
+		}
+	}
+}
+
+// An unset port falls back to the engine's usual one rather than to zero, which
+// the kernel would read as "any port" — a different one every run, and no
+// number a user could configure anything with.
+func TestAnUnsetPortIsNotTreatedAsAny(t *testing.T) {
+	got, err := chooseProxyPort(model.WhiteVPNSettings{TunEnabled: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == 0 {
+		t.Fatal("zero would let the kernel choose")
+	}
+}
+
+func holdAPort(t *testing.T) (net.Listener, int) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return listener, listener.Addr().(*net.TCPAddr).Port
+}


### PR DESCRIPTION
Turning the tunnel off did not mean "leave my machine alone" — it meant "reconfigure the whole desktop's proxy settings instead". Both modes redirect everything; they only differ in how. Users who want one browser extension or Telegram routed, and the rest of the machine untouched, had nothing to reach for.

There *is* a `SetSystemProxy` field — but on `V2RaySettingsProfile`, the removed Xray path, which nothing reads. The engine's own settings never had one, so the connect path branched on `TunEnabled` alone.

## Three modes, one choice

`WhiteVPNSettings` gains `SetSystemProxy`, and both-off becomes a third mode: the engine listens on its mixed port — HTTP and SOCKS5 together — and nothing on the machine is touched.

| Mode | What it does |
|---|---|
| System proxy | The desktop's proxy settings point here while connected |
| **Proxy only** | Nothing is redirected; you point one program at the port |
| Tunnel (TUN) | A virtual adapter carries everything |

Presented as one select rather than two switches, because they are mutually exclusive at connect — with the tunnel up the system proxy is deliberately not set — and two independent switches would silently override each other.

## Absent means on

Every settings file written before this field existed has no key for it, and a plain `bool` reads a missing key as `false` — which is the *new* mode. Everyone who updated would have found their machine quietly no longer proxied, looking exactly like an update that broke the connection.

The distinction only survives at the unmarshal boundary. Once the value is a `bool`, "absent" and "deliberately off" are the same thing, so no migration running later could tell them apart — hence `UnmarshalJSON` rather than a migration.

## The port

Now settable, and how hard it is held depends on whether anyone outside this app relies on it:

- **Tunnel or system proxy** — an implementation detail. A taken port is worked around, exactly as before.
- **Proxy only** — it is what somebody typed into Telegram. It is held, and one that cannot be had is reported with something to do about it.

Silently binding a different one would break their program days later, in another application, with nothing anywhere connecting that to this app.

`GetLocalProxyEndpoint` had the same fault in a smaller place — it returned the default whatever the engine had actually bound. It now reports the running session's port, and the dashboard endpoint is a copy button, because in this mode that address is the product and retyping it by eye is how a digit goes missing.

## Still open

Placing these controls on the Connect page, as discussed. That needs a decision on what happens when they are changed mid-connection — none of them take effect until a reconnect, so I would disable them while connected rather than let a switch appear to do something it has not done.