### PR TITLE
Keep the tray's message loop on the thread that owns its window

### DIFF
--- a/desktop/tray.go
+++ b/desktop/tray.go
@@ -60,7 +60,26 @@ func (a *App) startTray() {
 		systray.Register(a.onTrayReady, a.onTrayExit)
 		return
 	}
-	go systray.Run(a.onTrayReady, a.onTrayExit)
+	go func() {
+		// The icon's window and the loop that pumps its messages have to stay on
+		// one OS thread. Windows delivers a window's messages only to the thread
+		// that created it, and GetMessage reads the calling thread's queue — so a
+		// goroutine the scheduler moves between threads creates the window on one
+		// and then listens on another, where nothing ever arrives.
+		//
+		// systray locks the thread in its own init(), which covers a Run() on the
+		// main goroutine. Starting one with `go` steps outside that: the icon
+		// still appears, because it is created once, and then every click,
+		// every menu open and Quit itself go into a queue nobody reads. What the
+		// user sees is an icon that does nothing and an app that can only be
+		// ended from Task Manager.
+		//
+		// Not unlocked afterwards: the goroutine only returns once the tray has
+		// quit, and letting the thread die with it is better than handing a
+		// thread that owned a window back for general use.
+		runtime.LockOSThread()
+		systray.Run(a.onTrayReady, a.onTrayExit)
+	}()
 }
 
 func (a *App) onTrayReady() {


### PR DESCRIPTION
The icon appeared and did nothing. No menu on right click, no way to show the window or quit — and since quitting was one of the things that stopped working, **Task Manager was the only way to end the app**.

## Cause

[5ada8f0](https://github.com/WhiteDNS/WhiteVPN-Desktop/commit/5ada8f0) "Keep the tray loop on Windows" moved Windows and Linux from `systray.Register` to `go systray.Run`. The trouble is the `go`.

Windows delivers a window's messages only to the thread that created it, and `GetMessage` reads the *calling* thread's queue. A goroutine the scheduler is free to move between threads creates the window on one and then listens on another, where nothing ever arrives.

systray locks the thread in its own `init()`, which covers a `Run()` on the main goroutine. Starting one with `go` steps outside that.

## Why the symptoms looked like a removed menu

| Symptom | Reason |
|---|---|
| Icon appears | created once, during registration |
| Right click does nothing | `WM_RBUTTONUP` sits in a queue nobody reads, so `showMenu()` is never reached |
| Cannot quit | `Quit` is delivered the same way |

`onTrayReady` still builds every menu item. They were only unreachable — a dead loop, not a missing menu.

## Fix

The goroutine locks its thread before starting the loop. It is not unlocked afterwards: it only returns once the tray has quit, and letting the thread die with it beats handing a thread that owned a window back for general use.

## Testing

None automated — this is Windows message-loop behaviour that only appears on a real desktop. It wants a manual check on the build: right click the icon, open the menu, confirm Quit actually exits.