### PR TITLE
Only hide the window when something will actually draw the tray icon

### DIFF
--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -22,7 +22,7 @@ require (
 	git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/godbus/dbus/v5 v5.1.0
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/jchv/go-winloader v0.0.0-20210711035445-715c2860da7e // indirect

--- a/desktop/tray.go
+++ b/desktop/tray.go
@@ -203,9 +203,15 @@ func (a *App) quitFromTray() {
 
 // hideInsteadOfClosing is Wails' OnBeforeClose. Returning true keeps the window.
 func (a *App) hideInsteadOfClosing(ctx context.Context) bool {
-	if !a.tray.running() {
-		// No icon to come back from: closing the window has to mean quitting,
-		// or the app becomes something only Task Manager can end.
+	// No icon to come back from: closing the window has to mean quitting, or the
+	// app becomes something only a process manager can end.
+	//
+	// Both halves are needed. running() says the library started; it does not say
+	// anything is drawing the result, and on Linux it always says yes — systray
+	// fires its ready callback before it has so much as opened the session bus.
+	// A GNOME user without an AppIndicator extension closed the window, watched
+	// the app vanish with no icon anywhere, and had to kill it from htop.
+	if !a.tray.running() || !trayIconIsDisplayed() {
 		return false
 	}
 	wailsruntime.WindowHide(ctx)

--- a/desktop/tray_linux.go
+++ b/desktop/tray_linux.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+package main
+
+// Whether this desktop will actually show a tray icon.
+//
+// Closing the window hides the app rather than quitting it, on the reasoning
+// that closing a VPN's window means "get out of my way", not "stop protecting
+// my traffic". That trade only holds while there is an icon to come back from,
+// so hideInsteadOfClosing asks the tray whether it is running first.
+//
+// On Linux that answer was always yes, and it was worthless. systray's
+// nativeStart calls the ready callback before it connects to D-Bus at all, and
+// a failure to register with the watcher afterwards only writes a line to the
+// log — so onTrayReady runs, markReady(true) happens, and the app believes it
+// has an icon whether or not anything is displaying one.
+//
+// GNOME ships no StatusNotifierHost without an extension, which is the common
+// case rather than the exotic one. A user there closed the window, the app
+// hid itself, no icon appeared, and there was nothing left to click: exactly
+// the state the guard exists to prevent, reached through the guard.
+//
+// So the question is asked of the session bus instead of the library: is anyone
+// claiming to host status icons? A name with no owner means no host, which means
+// closing the window has to mean quitting.
+
+import (
+	"github.com/godbus/dbus/v5"
+)
+
+// statusNotifierWatcher is the bus name a tray host claims. KDE's name, used by
+// every implementation including GNOME's AppIndicator extensions.
+const statusNotifierWatcher = "org.kde.StatusNotifierWatcher"
+
+// trayIconIsDisplayed reports whether some host on this desktop will draw the
+// icon.
+//
+// Failing closed: anything unclear here is answered "no", because being wrong
+// that way costs a window that quits when closed, and being wrong the other way
+// costs an app the user cannot reach at all.
+func trayIconIsDisplayed() bool {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return false
+	}
+
+	var owner string
+	err = conn.BusObject().Call(
+		"org.freedesktop.DBus.GetNameOwner", 0, statusNotifierWatcher,
+	).Store(&owner)
+	if err != nil {
+		// NameHasNoOwner, or no bus to ask. Either way nothing is hosting icons.
+		return false
+	}
+	return owner != ""
+}

--- a/desktop/tray_other.go
+++ b/desktop/tray_other.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package main
+
+// trayIconIsDisplayed reports whether some host on this desktop will draw the
+// icon.
+//
+// Windows and macOS both have one notification area, always present, owned by
+// the shell. An icon registered there is an icon shown, so the library having
+// started is the whole answer and there is nothing further to ask.
+//
+// Only Linux can register an icon that nothing displays, which is why the real
+// check lives in tray_linux.go.
+func trayIconIsDisplayed() bool { return true }


### PR DESCRIPTION
A Linux user closed the window and the app disappeared with no icon anywhere. It kept running, kept carrying traffic, and the only way to end it was `htop`.

## Cause

Closing the window hides rather than quits — closing a VPN's window means "get out of my way", not "stop protecting my traffic". That trade only holds while there is an icon to come back from, so `hideInsteadOfClosing` asks `tray.running()` first.

On Linux that answer was always yes, and it was worth nothing:

```go
func nativeStart() {
	systrayReady()                    // fires unconditionally
	conn, err := dbus.SessionBus()
	if err != nil { ...; return }     // too late
```

`systrayReady()` is called before systray connects to D-Bus at all, and a later failure to register with the watcher only logs. So `onTrayReady` runs, `markReady(true)` happens, and the app believes it has an icon whether or not anything is showing one.

GNOME ships no StatusNotifierHost without an extension — the common case, not the exotic one. **The guard against "an app only a process manager can end" was reached through the guard itself.**

## Fix

Ask the session bus rather than the library: does anyone own `org.kde.StatusNotifierWatcher`? A name with no owner means no host, which means closing the window has to mean quitting.

It fails closed. Anything unclear is answered no — being wrong that way costs a window that quits when closed; being wrong the other way costs an app the user cannot reach at all.

Windows and macOS keep the old answer (`tray_other.go`): both have one notification area, owned by the shell and always present, so an icon registered there is an icon shown.

## Verification — please note

My local disk filled up mid-check, so I could **not** run the full test suite or the macOS type-check. What did pass before it ran out:

- `go build ./...` on Windows
- `GOOS=linux go vet ./...` — type-checks the new `tray_linux.go`

CI covers the rest. Do not merge on a red build on my say-so.

Manual check this needs, since no test can cover it: on a GNOME desktop **without** an AppIndicator extension, closing the window should now quit the app. With an extension installed, it should still hide to the icon.