### PR TITLE
Share the connection on the local network, and export configs in bulk

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2565,6 +2565,11 @@ function NodesPage({
   const [request, setRequest] = useState<NodeTestRequest>(defaultNodeTest);
   const [optionsOpen, setOptionsOpen] = useState(false);
   const [shareNode, setShareNode] = useState<WhiteVPNNode | null>(null);
+  const [exportOpen, setExportOpen] = useState(false);
+  // Base64 of the whole list is what a subscription URL serves, and several
+  // clients take it pasted straight in. Plain links are what everything takes,
+  // so that is the default and this is the option.
+  const [exportBase64, setExportBase64] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
   const [importText, setImportText] = useState("");
   const [importing, setImporting] = useState(false);
@@ -2716,6 +2721,38 @@ function NodesPage({
     }
     setPending({ nodes: new Set(targets), tests: request });
     onRunTest({ ...request, nodes: targets });
+  }
+
+  // What a bulk export covers: the selection when there is one, everything on
+  // screen when there is not — the same rule the test buttons follow, so the
+  // filters someone narrowed the list with carry over to this too.
+  const exportNodes = useMemo(
+    () => (selectedNames.length ? visible.filter((node) => selected.has(node.name)) : visible),
+    [visible, selected, selectedNames],
+  );
+  const exportLinks = useMemo(() => exportNodes.map((node) => node.link).filter(Boolean), [exportNodes]);
+  // A subscription served as a mihomo document has no share link per node, so
+  // some rows cannot be exported. Counted and said, rather than a shorter list
+  // than the one that was selected appearing with no explanation.
+  const exportSkipped = exportNodes.length - exportLinks.length;
+  const exportText = useMemo(() => {
+    const plain = exportLinks.join("\n");
+    if (!exportBase64 || !plain) {
+      return plain;
+    }
+    // btoa is Latin-1; a node name can carry a flag emoji or Persian, both of
+    // which are outside it. Encode the bytes, not the code points.
+    return btoa(String.fromCharCode(...new TextEncoder().encode(plain)));
+  }, [exportLinks, exportBase64]);
+  const exportFilename = `whitevpn-${exportLinks.length}-configs${exportBase64 ? "-base64" : ""}.txt`;
+
+  async function copyExport() {
+    try {
+      await navigator.clipboard?.writeText(exportText);
+      onSuccess(t("servers.export.copied", { count: exportLinks.length }));
+    } catch (err) {
+      onError(messageFromError(err));
+    }
   }
 
   async function copyLink(node: WhiteVPNNode) {
@@ -2896,6 +2933,14 @@ function NodesPage({
             <Button variant="outline" onClick={() => void setHidden(selectedHideable, true)} disabled={hidingBusy}>
               <EyeOff />
               {t("servers.hideSelected", { count: selectedHideable.length })}
+            </Button>
+          )}
+          {exportLinks.length > 0 && (
+            <Button variant="outline" onClick={() => setExportOpen(true)}>
+              <Download />
+              {selectedNames.length
+                ? t("servers.exportSelected", { count: exportLinks.length })
+                : t("servers.exportAll", { count: exportLinks.length })}
             </Button>
           )}
           {hiddenCount > 0 && (
@@ -3384,6 +3429,48 @@ function NodesPage({
         </DialogContent>
       </Dialog>
 
+      {/* Exporting what a test run selected. The reason this exists is to carry
+          the survivors of a test to another device — a phone, a television —
+          and doing that one share dialog at a time is why it was asked for. */}
+      <Dialog open={exportOpen} onOpenChange={setExportOpen}>
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{t("servers.export")}</DialogTitle>
+            <DialogDescription>
+              {t("servers.export.description", { count: exportLinks.length })}
+              {exportSkipped > 0 && ` ${t("servers.export.skipped", { count: exportSkipped })}`}
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            readOnly
+            value={exportText}
+            className="h-64 min-h-0 resize-none overflow-auto font-mono text-xs leading-relaxed [field-sizing:fixed]"
+          />
+          <DialogFooter className="sm:justify-between">
+            <label className="flex items-center gap-2 text-sm sm:me-auto">
+              <Switch checked={exportBase64} onCheckedChange={setExportBase64} />
+              {t("servers.export.base64")}
+            </label>
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <Button variant="outline" onClick={() => setExportOpen(false)}>
+                {t("common.close")}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => downloadTextFile(exportFilename, exportText)}
+                disabled={!exportText}
+              >
+                <Download />
+                {t("servers.export.download")}
+              </Button>
+              <Button onClick={() => void copyExport()} disabled={!exportText}>
+                <Copy />
+                {t("servers.copy")}
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <Dialog open={Boolean(shareNode)} onOpenChange={(open) => !open && setShareNode(null)}>
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -6134,6 +6134,19 @@ function WhiteVPNSettingsPage({
         )}
 
         <SettingSwitchRow
+          label={t("settings.allowLan")}
+          checked={draft.allowLan}
+          onCheckedChange={(allowLan) => patch({ allowLan })}
+        />
+        <FieldDescription>{t("settings.allowLan.description")}</FieldDescription>
+        {draft.allowLan && (
+          <Alert>
+            <AlertCircle />
+            <AlertDescription>{t("settings.allowLan.warning")}</AlertDescription>
+          </Alert>
+        )}
+
+        <SettingSwitchRow
           label={t("settings.killSwitch")}
           checked={draft.killSwitch.enabled}
           disabled

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -629,6 +629,20 @@ const strings = {
     en: "Point your program at {endpoint} — it accepts both HTTP and SOCKS5. If another program already holds this port, connecting will say so rather than quietly moving to another one, which would leave whatever you configured pointing at nothing.",
     fa: "برنامه‌تان را به {endpoint} وصل کنید — هم HTTP و هم SOCKS5 را می‌پذیرد. اگر برنامهٔ دیگری این پورت را گرفته باشد، هنگام اتصال همین را می‌گوید و بی‌سروصدا پورت دیگری انتخاب نمی‌کند، چون آن‌وقت چیزی که تنظیم کرده‌اید به جای خالی وصل می‌ماند.",
   },
+  "servers.export": { en: "Export configs", fa: "خروجی گرفتن از کانفیگ‌ها" },
+  "servers.exportSelected": { en: "Export selected ({count})", fa: "خروجی انتخاب‌شده‌ها ({count})" },
+  "servers.exportAll": { en: "Export all ({count})", fa: "خروجی همه ({count})" },
+  "servers.export.description": {
+    en: "{count} configs, one link per line. Paste or import these into another device.",
+    fa: "{count} کانفیگ، هر خط یک لینک. این‌ها را در دستگاه دیگری وارد یا الصاق کنید.",
+  },
+  "servers.export.skipped": {
+    en: "{count} were left out — this subscription does not give them share links.",
+    fa: "{count} مورد کنار گذاشته شد — این اشتراک برای آن‌ها لینک اشتراک‌گذاری نمی‌دهد.",
+  },
+  "servers.export.base64": { en: "Base64", fa: "Base64" },
+  "servers.export.download": { en: "Save to file", fa: "ذخیره در فایل" },
+  "servers.export.copied": { en: "{count} configs copied", fa: "{count} کانفیگ کپی شد" },
   "settings.allowLan": { en: "Share on the local network", fa: "اشتراک روی شبکهٔ محلی" },
   "settings.allowLan.description": {
     en: "Let other devices on this network use this connection — a phone or a television on the same wifi or hotspot. Point them at the address shown on the dashboard once connected.",

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -629,6 +629,15 @@ const strings = {
     en: "Point your program at {endpoint} — it accepts both HTTP and SOCKS5. If another program already holds this port, connecting will say so rather than quietly moving to another one, which would leave whatever you configured pointing at nothing.",
     fa: "برنامه‌تان را به {endpoint} وصل کنید — هم HTTP و هم SOCKS5 را می‌پذیرد. اگر برنامهٔ دیگری این پورت را گرفته باشد، هنگام اتصال همین را می‌گوید و بی‌سروصدا پورت دیگری انتخاب نمی‌کند، چون آن‌وقت چیزی که تنظیم کرده‌اید به جای خالی وصل می‌ماند.",
   },
+  "settings.allowLan": { en: "Share on the local network", fa: "اشتراک روی شبکهٔ محلی" },
+  "settings.allowLan.description": {
+    en: "Let other devices on this network use this connection — a phone or a television on the same wifi or hotspot. Point them at the address shown on the dashboard once connected.",
+    fa: "بگذارید دستگاه‌های دیگر روی این شبکه از این اتصال استفاده کنند — گوشی یا تلویزیون روی همان وای‌فای یا هات‌اسپات. بعد از اتصال، آن‌ها را به آدرسی که در صفحهٔ اصلی نشان داده می‌شود وصل کنید.",
+  },
+  "settings.allowLan.warning": {
+    en: "Anyone else on this network can use it too — nothing asks them for a password. Turn this on for a hotspot or a home network you trust, not for wifi you are a guest on.",
+    fa: "هر کس دیگری هم که روی این شبکه باشد می‌تواند از آن استفاده کند — از کسی رمز پرسیده نمی‌شود. این را برای هات‌اسپات خودتان یا شبکهٔ خانگی مورد اعتماد روشن کنید، نه روی وای‌فایی که مهمان آن هستید.",
+  },
   "settings.tunnel": { en: "Tunnel (TUN)", fa: "تونل (TUN)" },
   "settings.tunnel.description": {
     en: "The tunnel carries every program on the machine. Turning it on asks for Administrator when connecting, because creating the network adapter needs it. Left off, only programs pointed at the local proxy are carried.",

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -748,6 +748,7 @@ export type WhiteVPNSettings = {
   language: string;
   tunEnabled: boolean;
   setSystemProxy: boolean;
+  allowLan: boolean;
   listenPort: number;
   acceptedPrivacyPolicyVersion: number;
 };

--- a/desktop/internal/mihomoconf/allowlan_test.go
+++ b/desktop/internal/mihomoconf/allowlan_test.go
@@ -1,0 +1,39 @@
+package mihomoconf
+
+import (
+	"strings"
+	"testing"
+)
+
+// Off unless asked for. This opens the proxy to everyone on the network with
+// nothing authenticating them, so the default has to be the closed one and a
+// mistake here would be an exposure rather than a missing feature.
+func TestTheProxyIsNotSharedUnlessAsked(t *testing.T) {
+	document := Render("proxies: []\n", Options{MixedPort: 2080, ControlPort: 9090})
+	if !strings.Contains(document, "allow-lan: false") {
+		t.Fatalf("sharing must be off by default:\n%s", firstLines(document, 12))
+	}
+	if strings.Contains(document, "bind-address") {
+		t.Fatal("nothing should be bound beyond this machine when sharing is off")
+	}
+}
+
+func TestSharingBindsBeyondThisMachine(t *testing.T) {
+	document := Render("proxies: []\n", Options{MixedPort: 2080, ControlPort: 9090, AllowLAN: true})
+	if !strings.Contains(document, "allow-lan: true") {
+		t.Fatalf("sharing was asked for and not turned on:\n%s", firstLines(document, 12))
+	}
+	// Said explicitly rather than left to the engine's default, so what the
+	// listener binds is decided here and stays decided.
+	if !strings.Contains(document, `bind-address: "*"`) {
+		t.Fatalf("the listener was not opened to the network:\n%s", firstLines(document, 12))
+	}
+}
+
+func firstLines(text string, n int) string {
+	lines := strings.SplitN(text, "\n", n+1)
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/desktop/internal/mihomoconf/config.go
+++ b/desktop/internal/mihomoconf/config.go
@@ -158,6 +158,15 @@ type Options struct {
 	ControlPort int
 	Secret      string
 
+	// AllowLAN opens the local proxy to the rest of the network rather than to
+	// this machine alone.
+	//
+	// It is what lets a phone on the same hotspot use this desktop's connection,
+	// and it is also what lets anyone else on that network use it. Nothing
+	// authenticates a client, so the only thing standing between the two is
+	// whether the network is one the user trusts.
+	AllowLAN bool
+
 	DNSPrivacy  DNSPrivacyMode
 	DoHURL      string
 	DoTEndpoint string
@@ -310,7 +319,12 @@ func Render(subscriptionYAML string, opts Options) string {
 	fmt.Fprintf(&out, "mixed-port: %d\n", opts.MixedPort)
 	fmt.Fprintf(&out, "external-controller: %s:%d\n", controllerHost, opts.ControlPort)
 	fmt.Fprintf(&out, "secret: %s\n", quoteYAML(opts.Secret))
-	out.WriteString("allow-lan: false\n")
+	fmt.Fprintf(&out, "allow-lan: %t\n", opts.AllowLAN)
+	if opts.AllowLAN {
+		// Said explicitly rather than left to the engine's default for it, so
+		// that what the listener binds is decided here and stays decided.
+		out.WriteString("bind-address: \"*\"\n")
+	}
 	out.WriteString("mode: rule\n")
 	out.WriteString("log-level: warning\n")
 	fmt.Fprintf(&out, "ipv6: %t\n", opts.Tun.IPv6)

--- a/desktop/internal/model/whitevpn_settings.go
+++ b/desktop/internal/model/whitevpn_settings.go
@@ -137,6 +137,16 @@ type WhiteVPNSettings struct {
 	// the removed Xray path and nothing reads it.
 	SetSystemProxy bool `json:"setSystemProxy"`
 
+	// AllowLAN opens the local proxy to the rest of the network rather than to
+	// this machine alone, so another device — a phone on the same hotspot, a
+	// television — can use this desktop's connection.
+	//
+	// Off by default and deliberately not remembered as a general preference the
+	// way the others are: nothing authenticates a client, so whoever else is on
+	// that network can use the tunnel too. On a hotspot the user owns that is the
+	// point; on a café's wifi it is a stranger's free VPN.
+	AllowLAN bool `json:"allowLan"`
+
 	// ListenPort is where the engine's local proxy listens, serving HTTP and
 	// SOCKS5 on the one port.
 	//

--- a/desktop/internal/session/session.go
+++ b/desktop/internal/session/session.go
@@ -32,6 +32,10 @@ type Options struct {
 	MixedPort   int
 	ControlPort int
 
+	// AllowLAN opens the local proxy to the rest of the network, which is how a
+	// phone on the same hotspot reaches this desktop's connection.
+	AllowLAN bool
+
 	DNSPrivacy  mihomoconf.DNSPrivacyMode
 	DoHURL      string
 	DoTEndpoint string
@@ -721,6 +725,7 @@ func PrepareConfig(opts Options) (string, []string, error) {
 	document := mihomoconf.Render(proxiesYAML, mihomoconf.Options{
 		MixedPort:   opts.MixedPort,
 		ControlPort: opts.ControlPort,
+		AllowLAN:    opts.AllowLAN,
 		Secret:      secret,
 		DNSPrivacy:  opts.DNSPrivacy,
 		DoHURL:      opts.DoHURL,

--- a/desktop/lanaddress.go
+++ b/desktop/lanaddress.go
@@ -1,0 +1,49 @@
+package main
+
+// Which address another device should be pointed at.
+//
+// Sharing the connection over a hotspot only works if the person can be told
+// where to point the phone, and "127.0.0.1" is the one answer that is useless
+// for it — that address means "this machine" on the phone too, so a user copying
+// it off the dashboard would be sending the phone to itself.
+
+import "net"
+
+// lanAddress is this machine's address on the local network, or empty when it
+// has none worth offering.
+//
+// Empty rather than a guess. A wrong address here is worse than none: it sends
+// somebody to configure a device with a number that cannot work, and the failure
+// looks like the VPN's rather than the address's.
+func lanAddress() string {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+
+	for _, iface := range interfaces {
+		// Down, or loopback — neither reaches another device.
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addresses, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addresses {
+			network, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			ip := network.IP.To4()
+			// IPv4 only. A phone being set up by hand takes four numbers and a
+			// port; handing someone a v6 address with a zone suffix to type into
+			// Telegram is not an improvement.
+			if ip == nil || !ip.IsPrivate() {
+				continue
+			}
+			return ip.String()
+		}
+	}
+	return ""
+}

--- a/desktop/lanaddress_test.go
+++ b/desktop/lanaddress_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"net"
+	"testing"
+)
+
+// A wrong address here is worse than none: it sends somebody to configure a
+// device with a number that cannot work, and the failure looks like the VPN's.
+func TestTheSharedAddressIsOneAnotherDeviceCouldReach(t *testing.T) {
+	got := lanAddress()
+	if got == "" {
+		t.Skip("this machine has no private IPv4 address to share on")
+	}
+
+	ip := net.ParseIP(got)
+	if ip == nil {
+		t.Fatalf("%q is not an address at all", got)
+	}
+	if ip.To4() == nil {
+		t.Fatalf("%q is not IPv4 — a phone being set up by hand takes four numbers", got)
+	}
+	if ip.IsLoopback() {
+		t.Fatal("loopback means \"this machine\" on the phone too, so it would send the phone to itself")
+	}
+	if !ip.IsPrivate() {
+		t.Fatalf("%q is not a local network address", got)
+	}
+}

--- a/desktop/mihomo_connect.go
+++ b/desktop/mihomo_connect.go
@@ -113,6 +113,7 @@ func (a *App) startWhiteDNSVPNWithMihomo() (model.AppState, error) {
 		CorePath:     corePath,
 		HomeDir:      homeDir,
 		MixedPort:    mixedPort,
+		AllowLAN:     settings.AllowLAN,
 		Subscription: subscription,
 		Prefer:       prefer,
 		// Nodes the user hid never reach the configuration, so the engine cannot
@@ -146,11 +147,28 @@ func (a *App) startWhiteDNSVPNWithMihomo() (model.AppState, error) {
 		return a.GetAppState(), nil
 	}
 
+	// Shared over the network, the address another device needs is this machine's
+	// on the LAN. PublicProxyIP is the field for it — documented as exactly that
+	// and never filled in until now — and the dashboard already prefers it, so
+	// what gets copied off the screen is what a phone can actually be pointed at.
+	sharedAddress := ""
+	if settings.AllowLAN {
+		if sharedAddress = lanAddress(); sharedAddress != "" {
+			a.appendRuntimeLog(fmt.Sprintf(
+				"shared on the network: other devices can use %s:%d", sharedAddress, connected.MixedPort()))
+		} else {
+			// Listening on every interface and not one of them reachable. Said
+			// plainly rather than leaving a switch that appears to have worked.
+			a.appendRuntimeLog("sharing is on, but this machine has no local network address to share on")
+		}
+	}
+
 	a.mu.Lock()
 	a.state.Runtime.ListenIP = "127.0.0.1"
 	a.state.Runtime.ListenPort = connected.MixedPort()
 	a.state.Runtime.ProxyProtocol = "mixed"
 	a.state.Runtime.LocalProxyIP = "127.0.0.1"
+	a.state.Runtime.PublicProxyIP = sharedAddress
 	a.mu.Unlock()
 	a.recordConnectedNode(connected.Selected())
 	if proxyOnly(settings) {


### PR DESCRIPTION
Two requests from user feedback. They ship together.

## Share on the local network

Asked for so a phone or a television on the same hotspot could go through the desktop's tunnel. `allow-lan: false` was written into every generated config as a constant, so the engine only ever listened to this machine.

There is an `AllowLAN` on `V2RaySettingsProfile`, from the removed Xray path, which nothing reads — the same shape as `SetSystemProxy` last week. `WhiteVPNSettings` gains its own, threaded through to the engine, with `bind-address: "*"` stated explicitly rather than left to the engine's default.

**Off by default, and warned about where it is turned on.** Nothing authenticates a client: whoever else is on that network can use the tunnel too. On a hotspot the user owns that is the point; on a café's wifi it is a stranger's free VPN, and only the person at the machine knows which they are on.

The address to point the other device at is now reported. Sharing is useless without it, and `127.0.0.1` is the one answer that cannot work — it means "this machine" on the phone as well, so anyone copying it off the dashboard would send the phone to itself. `PublicProxyIP` was already documented as *"where this machine's proxy can be reached on the LAN"* and had never been filled in; the dashboard already prefers it. When there is no such address, the field stays empty and the log says so, rather than a switch that appears to have worked.

## Export configs in bulk

Asked for by a user who brings their own panel's configs in, tests them, and carries the ones that pass to a phone or a television. The page could already select, test, delete and hide in bulk — and then offered share one row at a time, which for the survivors of a test run over hundreds of nodes is not an export.

- Selection follows the rule the test buttons already use: ticked rows when there are any, everything on screen when there are not. So `test these → export what passed` is two clicks.
- Copy, or save to a file. One link per line, which every client takes.
- Base64 of the whole list is offered too, since that is what a subscription URL serves. Encoded from UTF-8 bytes rather than through `btoa` directly — node names carry flag emoji and Persian, both outside Latin-1, and `btoa` throws on them.
- Rows from a mihomo-document subscription have no share link. They are counted and the count shown, because a list shorter than the selection with no explanation reads as a bug.

## Verification

Full Go suite, `go vet`, frontend typecheck and build all green. New tests cover the config generation (sharing off by default, and what `bind-address` becomes when on) and that the shared address is one another device could actually reach.

Not covered by tests, worth a manual check: connect with sharing on, and confirm a phone on the same hotspot can use the address shown.