### PR TITLE
Stop offering tunnel mode where it cannot run

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -6095,6 +6095,17 @@ function WhiteVPNSettingsPage({
 }) {
   const stored = state.whiteVpn;
   const [draft, setDraft] = useState<WhiteVPNSettings>(stored);
+  // Tunnel mode needs the core raised to root, and that is implemented on
+  // Windows only. Asked of the backend rather than guessed from the interface,
+  // so the day another platform gains it this needs no change here.
+  const [tunnelAvailable, setTunnelAvailable] = useState(true);
+  useEffect(() => {
+    void backend
+      .tunnelSupported()
+      .then(setTunnelAvailable)
+      .catch(() => setTunnelAvailable(false));
+  }, []);
+
   const [frontingDraft, setFrontingDraft] = useState("");
   const [processDraft, setProcessDraft] = useState("");
   const [saving, setSaving] = useState(false);
@@ -6194,10 +6205,15 @@ function WhiteVPNSettingsPage({
             <SelectContent position="popper">
               <SelectItem value="systemProxy">{t("settings.routing.systemProxy")}</SelectItem>
               <SelectItem value="proxyOnly">{t("settings.routing.proxyOnly")}</SelectItem>
-              <SelectItem value="tun">{t("settings.routing.tun")}</SelectItem>
+              {/* Offered only where it can run. A mode that always fails is
+                  worse than one that is absent — the missing one does not waste
+                  somebody's evening on an error about an unimplemented
+                  function. */}
+              {tunnelAvailable && <SelectItem value="tun">{t("settings.routing.tun")}</SelectItem>}
             </SelectContent>
           </Select>
           <FieldDescription>{t(`settings.routing.${routingMode(draft)}.description`)}</FieldDescription>
+          {!tunnelAvailable && <FieldDescription>{t("settings.routing.tun.unavailable")}</FieldDescription>}
         </Field>
 
         {/* Only in proxy-only mode. Everywhere else the port is an

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -624,6 +624,10 @@ const strings = {
     en: "A virtual network adapter carries everything, including programs that ignore proxy settings. Needs Administrator on Windows.",
     fa: "یک کارت شبکهٔ مجازی همه چیز را حمل می‌کند، حتی برنامه‌هایی که تنظیمات پراکسی را نادیده می‌گیرند. روی ویندوز نیاز به دسترسی Administrator دارد.",
   },
+  "settings.routing.tun.unavailable": {
+    en: "Tunnel (TUN) mode is available on Windows only for now. It needs to run the engine with administrator rights, and that is not implemented on this platform yet.",
+    fa: "حالت تونل (TUN) فعلاً فقط روی ویندوز در دسترس است. این حالت باید موتور را با دسترسی مدیر اجرا کند و این کار هنوز روی این سیستم‌عامل پیاده‌سازی نشده است.",
+  },
   "settings.routing.port": { en: "Local proxy port", fa: "پورت پراکسی محلی" },
   "settings.routing.port.description": {
     en: "Point your program at {endpoint} — it accepts both HTTP and SOCKS5. If another program already holds this port, connecting will say so rather than quietly moving to another one, which would leave whatever you configured pointing at nothing.",

--- a/desktop/frontend/src/wails.ts
+++ b/desktop/frontend/src/wails.ts
@@ -79,6 +79,7 @@ type AppApi = {
   OpenValidatorResultFile(name: string): Promise<void>;
   DeleteValidatorResultFile(name: string): Promise<ValidatorResultFile[]>;
   GetWhiteVPNSettings(): Promise<WhiteVPNSettings>;
+  TunnelSupported(): Promise<boolean>;
   SaveWhiteVPNSettings(settings: WhiteVPNSettings): Promise<AppState>;
   GetPrivacyPolicyVersion(): Promise<number>;
   AcceptPrivacyPolicy(): Promise<AppState>;
@@ -177,6 +178,7 @@ export const backend = {
   openValidatorResultFile: (name: string) => app().OpenValidatorResultFile(name),
   deleteValidatorResultFile: (name: string) => app().DeleteValidatorResultFile(name),
   getWhiteVpnSettings: () => app().GetWhiteVPNSettings(),
+  tunnelSupported: () => app().TunnelSupported(),
   saveWhiteVpnSettings: (settings: WhiteVPNSettings) => app().SaveWhiteVPNSettings(settings),
   getPrivacyPolicyVersion: () => app().GetPrivacyPolicyVersion(),
   acceptPrivacyPolicy: () => app().AcceptPrivacyPolicy(),

--- a/desktop/mihomo_connect.go
+++ b/desktop/mihomo_connect.go
@@ -74,7 +74,12 @@ func (a *App) startWhiteDNSVPNWithMihomo() (model.AppState, error) {
 	homeDir := filepath.Join(a.configDir, "mihomo")
 
 	a.mu.Lock()
-	settings := model.NormalizeWhiteVPNSettings(a.state.WhiteVPN)
+	// settingsForThisMachine, not just Normalize: a settings file carried over
+	// from Windows, or written before the interface stopped offering the tunnel
+	// here, still says it is on. Connecting on that would ask the engine to raise
+	// a core it has no way to raise, and the user would be told their connection
+	// failed because of an unimplemented function.
+	settings := settingsForThisMachine(model.NormalizeWhiteVPNSettings(a.state.WhiteVPN))
 	a.mu.Unlock()
 
 	// The dashboard's choices are applied here, against the catalogue this

--- a/desktop/tunnel_support.go
+++ b/desktop/tunnel_support.go
@@ -1,0 +1,41 @@
+package main
+
+// Whether this machine can run tunnel mode at all.
+//
+// A tunnel means creating a virtual adapter and rewriting the routing table,
+// which needs privileges the app does not have and must ask for. Asking is the
+// part that is platform-specific: Windows has ShellExecuteExW with the `runas`
+// verb, and engine.startElevatedChild is implemented there and nowhere else.
+// On Linux and macOS it returns
+//
+//	engine: running the core elevated is only implemented on Windows
+//
+// which is where a Linux user landed after turning the switch on: an accurate
+// sentence about an unimplemented function, offered as though their connection
+// had failed.
+//
+// The rest of the tunnel is not the problem. The unix socket the elevated core
+// would connect back on is already built, permissioned and cleaned up on every
+// platform; what is missing is only the launcher that raises the core. Until
+// that exists the control should not be offered, because a switch that can only
+// fail is worse than one that is absent — the missing one does not waste
+// somebody's evening.
+
+import "runtime"
+
+// TunnelSupported reports whether tunnel mode can run here.
+//
+// Named for the question rather than the operating system. The interface has no
+// business knowing which platforms have an elevation path; it needs to know
+// whether to offer the choice, and that answer belongs here next to the reason
+// for it.
+func (a *App) TunnelSupported() bool {
+	return tunnelSupported()
+}
+
+func tunnelSupported() bool {
+	// Kept as one expression rather than a build-tagged pair of files, so that
+	// the day macOS or Linux gains an elevation path this reads as a list with
+	// something added to it rather than a file somebody has to find.
+	return runtime.GOOS == "windows"
+}

--- a/desktop/tunnel_support_test.go
+++ b/desktop/tunnel_support_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"reflect"
+	"runtime"
+	"testing"
+
+	"whitevpn-desktop/internal/model"
+)
+
+// The switch could never have worked where there is no way to raise the core,
+// and left stored as on it is unreachable — the interface no longer offers the
+// mode it belongs to, so every connection would fail with a sentence about an
+// unimplemented function and no way out short of resetting the app.
+func TestTheTunnelIsDroppedWhereItCannotRun(t *testing.T) {
+	got := settingsForThisMachine(model.WhiteVPNSettings{TunEnabled: true})
+	if got.TunEnabled != tunnelSupported() {
+		t.Fatalf("TunEnabled=%v on %s, where tunnelSupported()=%v", got.TunEnabled, runtime.GOOS, tunnelSupported())
+	}
+}
+
+// Only the tunnel is touched. Everything else a settings file says is the user's
+// and must survive.
+func TestNothingElseIsTouched(t *testing.T) {
+	before := model.WhiteVPNSettings{
+		TunEnabled:     false,
+		SetSystemProxy: false,
+		AllowLAN:       true,
+		ListenPort:     7890,
+		Language:       "fa",
+	}
+	after := settingsForThisMachine(before)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("settings were changed:\nbefore %#v\nafter  %#v", before, after)
+	}
+}
+
+// Off stays off wherever it runs — this drops the tunnel, it never enables it.
+func TestItNeverTurnsTheTunnelOn(t *testing.T) {
+	if settingsForThisMachine(model.WhiteVPNSettings{TunEnabled: false}).TunEnabled {
+		t.Fatal("the tunnel was turned on by something meant only to drop it")
+	}
+}

--- a/desktop/whitevpn_settings.go
+++ b/desktop/whitevpn_settings.go
@@ -10,7 +10,26 @@ import (
 func (a *App) GetWhiteVPNSettings() model.WhiteVPNSettings {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return model.NormalizeWhiteVPNSettings(a.state.WhiteVPN)
+	return settingsForThisMachine(model.NormalizeWhiteVPNSettings(a.state.WhiteVPN))
+}
+
+// settingsForThisMachine drops what this build cannot do.
+//
+// Only the tunnel, and only where there is no way to raise the core. A machine
+// that cannot start an elevated child cannot make an adapter, so the switch
+// could never have worked there — and left stored as on it is unreachable, since
+// the interface no longer offers the mode it belongs to. Every connection would
+// fail with a sentence about an unimplemented function and no way to get out of
+// it short of resetting the app.
+//
+// Deliberately not in model.NormalizeWhiteVPNSettings: that repairs what a
+// settings file says, which is the same answer everywhere, and giving it a
+// dependency on the host would make its tests depend on which machine ran them.
+func settingsForThisMachine(settings model.WhiteVPNSettings) model.WhiteVPNSettings {
+	if settings.TunEnabled && !tunnelSupported() {
+		settings.TunEnabled = false
+	}
+	return settings
 }
 
 // SaveWhiteVPNSettings stores them, repaired.
@@ -20,7 +39,7 @@ func (a *App) GetWhiteVPNSettings() model.WhiteVPNSettings {
 // something through - is corrected once, here, instead of reaching the engine
 // and failing there where the cause is much harder to see.
 func (a *App) SaveWhiteVPNSettings(settings model.WhiteVPNSettings) (model.AppState, error) {
-	normalized := model.NormalizeWhiteVPNSettings(settings)
+	normalized := settingsForThisMachine(model.NormalizeWhiteVPNSettings(settings))
 
 	a.mu.Lock()
 	a.state.WhiteVPN = normalized


### PR DESCRIPTION
A Linux user turned the tunnel on and got:

```
engine: running the core elevated is only implemented on Windows
```

Which is true, and is a sentence about an unimplemented function delivered as though their connection had failed.

## Why the tunnel is Windows-only

A tunnel means creating a virtual adapter and rewriting the routing table, which needs privileges the app does not have and must ask for. **Asking is the platform-specific part** — Windows has `ShellExecuteExW` with the `runas` verb, and `engine.startElevatedChild` exists there and nowhere else.

The rest of the tunnel is not the obstacle. The unix socket the elevated core would connect back on is already built, permissioned `0600` and cleaned up on every platform, and the core already accepts a socket path as its argument. Only the launcher is missing. On Linux that would be `pkexec`, `setcap cap_net_admin+ep`, or a systemd helper; on macOS, `SMJobBless` — the same thing a user asked for so it stops prompting for a password on every connect.

## What changed

The mode is not offered where it cannot run. A control that can only fail is worse than one that is absent — the missing one does not waste somebody's evening.

**Not in the interface alone.** A settings file carried over from Windows, or written before this, still says the tunnel is on — and that state is now unreachable through a dropdown that no longer lists the mode. Every connection would fail with no way out short of resetting the app. So the tunnel is dropped where it cannot run wherever settings are read: for the interface, on save, and again at connect.

Dropped rather than refused. It could never have worked on that machine, and refusing to connect over a setting the user cannot even see would be a dead end rather than an explanation.

Two placement notes:

- `settingsForThisMachine` sits in the app, not in `model.NormalizeWhiteVPNSettings`. That one repairs what a settings file says and should give the same answer everywhere; a dependency on the host would make its tests depend on which machine ran them.
- The interface asks the backend `TunnelSupported()` rather than checking the platform itself, so the day another platform gains an elevation path there is nothing to change there.

## Still open

Actually implementing elevation on Linux and macOS. That is real work — a privileged launcher per platform, and on macOS a signed helper — and it is its own project, not a follow-up to this.