### PR TITLE
Read AmneziaWG from links including v3, and move the engine to v1.19.30

### DIFF
--- a/desktop/internal/engine/amneziawg_integration_test.go
+++ b/desktop/internal/engine/amneziawg_integration_test.go
@@ -1,0 +1,66 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"whitevpn-desktop/internal/mihomoconf"
+)
+
+// The reason the pinned core moved to v1.19.30.
+//
+// v1.19.29's AmneziaWGOption had no Version field at all, so `version: 3` was
+// not a setting that did nothing — mihomo decodes this map into a struct and
+// rejects keys it has no field for, which fails the whole config rather than
+// the one proxy. This asks the engine that actually ships whether it reads
+// what the link parser now emits.
+func TestTheEngineReadsAmneziaWGv3(t *testing.T) {
+	link := "wireguard://cHJpdmF0ZS1rZXktMzItYnl0ZXMtZm9yLXRlc3Rz@a.example.com:51820" +
+		"?publickey=cHVibGljLWtleS0zMi1ieXRlcy1mb3ItdGVzdHM&address=10.0.0.2/32" +
+		"&jc=4&jmin=40&jmax=70&s1=15&s2=25&s3=5&s4=5" +
+		"&h1=1111111111&h2=2222222222&h3=3333333333&h4=4444444444#AmneziaWG"
+
+	proxies, err := mihomoconf.ConvertLinks(link)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	options, ok := proxies[0]["amnezia-wg-option"].(map[string]any)
+	if !ok {
+		t.Fatalf("the link parser emitted no Amnezia options: %#v", proxies[0])
+	}
+	// Written here rather than by the parser: `version` arrives with the core
+	// that has the field, and this is the test that says the core does.
+	options["version"] = 3
+
+	proxiesYAML, err := mihomoconf.BuildProxiesYAML(proxies, mihomoconf.SplitTunnel{})
+	if err != nil {
+		t.Fatalf("build proxies: %v", err)
+	}
+	config := mihomoconf.Render(proxiesYAML, mihomoconf.Options{
+		Secret:     "validation-secret",
+		ProxyGroup: mihomoconf.SelectGroup,
+	})
+	if !strings.Contains(config, "version: 3") {
+		t.Fatalf("the rendered config does not carry the version:\n%s", config)
+	}
+
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	proc := spawnReal(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := proc.Init(ctx, home, 36); err != nil {
+		t.Fatalf("initClash: %v", err)
+	}
+	if err := proc.ValidateConfig(ctx, configPath); err != nil {
+		t.Fatalf("the engine rejected AmneziaWG v3, so the core bump did not deliver it: %v\n---\n%s", err, config)
+	}
+}

--- a/desktop/internal/engine/amneziawg_integration_test.go
+++ b/desktop/internal/engine/amneziawg_integration_test.go
@@ -22,7 +22,10 @@ func TestTheEngineReadsAmneziaWGv3(t *testing.T) {
 	link := "wireguard://cHJpdmF0ZS1rZXktMzItYnl0ZXMtZm9yLXRlc3Rz@a.example.com:51820" +
 		"?publickey=cHVibGljLWtleS0zMi1ieXRlcy1mb3ItdGVzdHM&address=10.0.0.2/32" +
 		"&jc=4&jmin=40&jmax=70&s1=15&s2=25&s3=5&s4=5" +
-		"&h1=1111111111&h2=2222222222&h3=3333333333&h4=4444444444#AmneziaWG"
+		"&h1=1111111111&h2=2222222222&h3=3333333333&h4=4444444444" +
+		"&version=3&header-protection-key=c2VjcmV0LWtleS0zMi1ieXRlcw&content-padding-addition=16" +
+		"&rekey-after-time=120&rekey-timeout=5&reject-after-time=180" +
+		"&keepalive-timeout=25&max-handshake-attempts=5&random-trailers=true&disable-cookies=true#AmneziaWG"
 
 	proxies, err := mihomoconf.ConvertLinks(link)
 	if err != nil {
@@ -32,9 +35,9 @@ func TestTheEngineReadsAmneziaWGv3(t *testing.T) {
 	if !ok {
 		t.Fatalf("the link parser emitted no Amnezia options: %#v", proxies[0])
 	}
-	// Written here rather than by the parser: `version` arrives with the core
-	// that has the field, and this is the test that says the core does.
-	options["version"] = 3
+	if options["version"] != 3 {
+		t.Fatalf("the link declared version 3 and the parser did not carry it: %#v", options)
+	}
 
 	proxiesYAML, err := mihomoconf.BuildProxiesYAML(proxies, mihomoconf.SplitTunnel{})
 	if err != nil {

--- a/desktop/internal/mihomoconf/amnezia.go
+++ b/desktop/internal/mihomoconf/amnezia.go
@@ -18,7 +18,10 @@ package mihomoconf
 // upstream later has to arrive with the core that knows it — otherwise every
 // WireGuard proxy in the subscription fails to load, not just this one.
 
-import "strconv"
+import (
+	"strconv"
+	"strings"
+)
 
 // amneziaIntFields are the parameters mihomo reads as numbers, with the
 // spellings links use for each.
@@ -56,6 +59,28 @@ var amneziaStringFields = map[string][]string{
 	"j3": {"j3"},
 }
 
+// amneziaV3Fields are the ones that exist only in AmneziaWG v3. The core writes
+// every one of these into the device's IPC config, and the legacy device rejects
+// keys it does not know — so they are only ever emitted alongside version 3.
+var amneziaV3Fields = map[string][]string{
+	"header-protection-key":    {"header-protection-key", "header_protection_key", "hpk"},
+	"content-padding-addition": {"content-padding-addition", "content_padding_addition"},
+	"rekey-after-time":         {"rekey-after-time", "rekey_after_time"},
+	"rekey-timeout":            {"rekey-timeout", "rekey_timeout"},
+	"reject-after-time":        {"reject-after-time", "reject_after_time"},
+	"keepalive-timeout":        {"keepalive-timeout", "keepalive_timeout"},
+	"max-handshake-attempts":   {"max-handshake-attempts", "max_handshake_attempts"},
+}
+
+// amneziaV3BoolFields arrived in v3.1.
+var amneziaV3BoolFields = map[string][]string{
+	"random-trailers": {"random-trailers", "random_trailers"},
+	"disable-cookies": {"disable-cookies", "disable_cookies"},
+}
+
+// amneziaV15OnlyFields were removed in v2 and cannot travel with the v3 set.
+var amneziaV15OnlyFields = []string{"j1", "j2", "j3", "itime"}
+
 // amneziaFromQuery reads whatever Amnezia parameters a link carries.
 //
 // Returns nil when it carries none, so a plain WireGuard link stays plain: an
@@ -87,8 +112,70 @@ func amneziaFromQuery(query map[string]string) map[string]any {
 		}
 	}
 
+	for field, spellings := range amneziaV3Fields {
+		if value := firstQueryValue(query, spellings...); value != "" {
+			options[field] = value
+		}
+	}
+	for field, spellings := range amneziaV3BoolFields {
+		if value := firstQueryValue(query, spellings...); value != "" {
+			options[field] = strings.EqualFold(value, "true") || value == "1"
+		}
+	}
+
 	if len(options) == 0 {
 		return nil
 	}
+	reconcileAmneziaVersion(options, firstQueryValue(query, "version", "amnezia_version"))
 	return options
+}
+
+// reconcileAmneziaVersion settles which protocol the options describe, and drops
+// what does not belong to it.
+//
+// The two sets are mutually exclusive at the device: version 3 builds a
+// different WireGuard device from the legacy one, and each rejects the other's
+// keys outright. Since a rejected key fails the whole configuration rather than
+// this one proxy, a link carrying both has to be resolved here rather than sent
+// on to find out.
+//
+// The version decides, because it is the server saying which protocol it speaks.
+// Where it is absent and v3-only fields are present, the fields decide instead:
+// those parameters exist nowhere else, so their presence is the same statement.
+// That is a reading rather than a guess — under any other one the link means
+// nothing at all.
+func reconcileAmneziaVersion(options map[string]any, declared string) {
+	version, err := strconv.Atoi(strings.TrimSpace(declared))
+	if err != nil {
+		version = 0
+	}
+
+	v3Present := false
+	for _, set := range []map[string][]string{amneziaV3Fields, amneziaV3BoolFields} {
+		for field := range set {
+			if _, ok := options[field]; ok {
+				v3Present = true
+			}
+		}
+	}
+	if version == 0 && v3Present {
+		version = 3
+	}
+
+	if version == 3 {
+		options["version"] = 3
+		for _, field := range amneziaV15OnlyFields {
+			delete(options, field)
+		}
+		return
+	}
+	// Not v3: the v3-only parameters cannot reach the legacy device.
+	for _, set := range []map[string][]string{amneziaV3Fields, amneziaV3BoolFields} {
+		for field := range set {
+			delete(options, field)
+		}
+	}
+	if version != 0 {
+		options["version"] = version
+	}
 }

--- a/desktop/internal/mihomoconf/amnezia.go
+++ b/desktop/internal/mihomoconf/amnezia.go
@@ -1,0 +1,94 @@
+package mihomoconf
+
+// The obfuscation parameters an AmneziaWG link carries.
+//
+// AmneziaWG is WireGuard with the handshake disguised: junk packets before it,
+// padded header sizes, and magic header values other than WireGuard's own. A
+// server configured that way only answers a client sending the same numbers, so
+// the numbers are part of the credential, not a preference.
+//
+// They were being thrown away. parseWireGuard read the keys, the addresses and
+// the MTU and ignored every Amnezia parameter, so an AmneziaWG link imported as
+// plain WireGuard — and then the global noise setting was written over the top,
+// which is one server's numbers applied to a different server. The link would
+// sit in the list looking importable and never connect.
+//
+// Only the fields the pinned core understands are emitted. mihomo decodes this
+// map into a struct and rejects keys it has no field for, so a parameter added
+// upstream later has to arrive with the core that knows it — otherwise every
+// WireGuard proxy in the subscription fails to load, not just this one.
+
+import "strconv"
+
+// amneziaIntFields are the parameters mihomo reads as numbers, with the
+// spellings links use for each.
+//
+//	jc         how many junk packets before the handshake
+//	jmin/jmax  their size range
+//	s1..s4     padding prepended to the handshake messages
+//	itime      v1.5's rekey interval
+var amneziaIntFields = map[string][]string{
+	"jc":    {"jc", "junk_packet_count", "junkpacketcount"},
+	"jmin":  {"jmin", "junk_packet_min_size", "junkpacketminsize"},
+	"jmax":  {"jmax", "junk_packet_max_size", "junkpacketmaxsize"},
+	"s1":    {"s1", "init_packet_junk_size", "initpacketjunksize"},
+	"s2":    {"s2", "response_packet_junk_size", "responsepacketjunksize"},
+	"s3":    {"s3", "cookie_reply_packet_junk_size"},
+	"s4":    {"s4", "transport_packet_junk_size"},
+	"itime": {"itime", "special_handshake_timeout"},
+}
+
+// amneziaStringFields are the ones mihomo reads as strings. The magic headers
+// are numbers on the wire but arrive as text, and i1..i5 and j1..j3 are packet
+// templates rather than values.
+var amneziaStringFields = map[string][]string{
+	"h1": {"h1", "init_packet_magic_header", "initpacketmagicheader"},
+	"h2": {"h2", "response_packet_magic_header", "responsepacketmagicheader"},
+	"h3": {"h3", "underload_packet_magic_header", "underloadpacketmagicheader"},
+	"h4": {"h4", "transport_packet_magic_header", "transportpacketmagicheader"},
+	"i1": {"i1"},
+	"i2": {"i2"},
+	"i3": {"i3"},
+	"i4": {"i4"},
+	"i5": {"i5"},
+	"j1": {"j1"},
+	"j2": {"j2"},
+	"j3": {"j3"},
+}
+
+// amneziaFromQuery reads whatever Amnezia parameters a link carries.
+//
+// Returns nil when it carries none, so a plain WireGuard link stays plain: an
+// empty amnezia-wg-option is not the same as no amnezia-wg-option, and writing
+// one would turn every WireGuard proxy into an AmneziaWG proxy with all the
+// defaults, which no server is expecting.
+func amneziaFromQuery(query map[string]string) map[string]any {
+	options := map[string]any{}
+
+	for field, spellings := range amneziaIntFields {
+		raw := firstQueryValue(query, spellings...)
+		if raw == "" {
+			continue
+		}
+		// Not parseIntOrZero: zero is a legal value for every one of these —
+		// jc=0 means no junk packets, which is a different instruction from
+		// "unset" — so a value that will not parse has to be dropped rather
+		// than become a zero the user did not ask for.
+		value, err := strconv.Atoi(raw)
+		if err != nil || value < 0 {
+			continue
+		}
+		options[field] = value
+	}
+
+	for field, spellings := range amneziaStringFields {
+		if value := firstQueryValue(query, spellings...); value != "" {
+			options[field] = value
+		}
+	}
+
+	if len(options) == 0 {
+		return nil
+	}
+	return options
+}

--- a/desktop/internal/mihomoconf/amnezia_test.go
+++ b/desktop/internal/mihomoconf/amnezia_test.go
@@ -2,7 +2,6 @@ package mihomoconf
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -120,27 +119,5 @@ func TestTheGlobalSettingStillReachesPlainNodes(t *testing.T) {
 	}
 	if changed != 1 {
 		t.Errorf("expected one proxy changed, got %d", changed)
-	}
-}
-
-// mihomo decodes this map into a struct and rejects keys it has no field for, so
-// one unknown key fails every WireGuard proxy in the subscription, not just this
-// one. Whatever is emitted has to exist in the pinned core.
-func TestOnlyFieldsThePinnedCoreKnowsAreEmitted(t *testing.T) {
-	known := map[string]bool{}
-	for _, set := range []map[string][]string{amneziaIntFields, amneziaStringFields} {
-		for field := range set {
-			known[field] = true
-		}
-	}
-	// v1.19.29's AmneziaWGOption, field for field.
-	for _, field := range strings.Fields("jc jmin jmax s1 s2 s3 s4 h1 h2 h3 h4 i1 i2 i3 i4 i5 j1 j2 j3 itime") {
-		if !known[field] {
-			t.Errorf("%s is in the core and not read from links", field)
-		}
-		delete(known, field)
-	}
-	for field := range known {
-		t.Errorf("%s is emitted but the pinned core has no field for it", field)
 	}
 }

--- a/desktop/internal/mihomoconf/amnezia_test.go
+++ b/desktop/internal/mihomoconf/amnezia_test.go
@@ -1,0 +1,146 @@
+package mihomoconf
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const amneziaLink = "wireguard://oPrivateKey123%3D@1.2.3.4:51820" +
+	"?publickey=oPublicKey456%3D&address=10.0.0.2/32" +
+	"&jc=4&jmin=40&jmax=70&s1=15&s2=25&h1=1234567890&h2=987654321#AmneziaNode"
+
+// The parameters a server disguising its handshake requires. They were read as
+// far as the keys and then dropped, so the node imported, listed, and could
+// never connect.
+func TestAnAmneziaLinkKeepsItsParameters(t *testing.T) {
+	proxies, err := ConvertLinks(amneziaLink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(proxies) != 1 {
+		t.Fatalf("expected one proxy, got %d", len(proxies))
+	}
+
+	options, ok := proxies[0]["amnezia-wg-option"].(map[string]any)
+	if !ok {
+		t.Fatalf("the link's Amnezia parameters were dropped: %#v", proxies[0])
+	}
+	want := map[string]any{
+		"jc": 4, "jmin": 40, "jmax": 70, "s1": 15, "s2": 25,
+		"h1": "1234567890", "h2": "987654321",
+	}
+	if !reflect.DeepEqual(options, want) {
+		t.Fatalf("parameters do not match:\n got %#v\nwant %#v", options, want)
+	}
+}
+
+// An empty amnezia-wg-option is not the same as none: it would turn every plain
+// WireGuard proxy into an AmneziaWG one running all the defaults, which no
+// server is expecting.
+func TestAPlainWireGuardLinkStaysPlain(t *testing.T) {
+	plain := "wireguard://oPrivateKey123%3D@1.2.3.4:51820?publickey=oPublicKey456%3D&address=10.0.0.2/32#Plain"
+	proxies, err := ConvertLinks(plain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := proxies[0]["amnezia-wg-option"]; present {
+		t.Fatalf("a plain link should carry no Amnezia options: %#v", proxies[0])
+	}
+}
+
+// Zero is a legal instruction — jc=0 means no junk packets — so it has to
+// survive, while a value that will not parse must be dropped rather than become
+// a zero nobody asked for.
+func TestZeroIsKeptAndNonsenseIsDropped(t *testing.T) {
+	link := "wireguard://k%3D@1.2.3.4:51820?publickey=p%3D&jc=0&jmin=abc&jmax=-5#Edge"
+	proxies, err := ConvertLinks(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	options, ok := proxies[0]["amnezia-wg-option"].(map[string]any)
+	if !ok {
+		t.Fatalf("jc=0 is a parameter and should have been kept: %#v", proxies[0])
+	}
+	if got, present := options["jc"]; !present || got != 0 {
+		t.Errorf("jc=0 should survive, got %v (present=%v)", got, present)
+	}
+	if _, present := options["jmin"]; present {
+		t.Error("jmin=abc is not a number and must not become one")
+	}
+	if _, present := options["jmax"]; present {
+		t.Error("a negative jmax must not be accepted")
+	}
+}
+
+// The long spellings other clients emit.
+func TestTheLongerSpellingsAreRead(t *testing.T) {
+	link := "wireguard://k%3D@1.2.3.4:51820?publickey=p%3D" +
+		"&junk_packet_count=3&init_packet_junk_size=12&init_packet_magic_header=555#Long"
+	proxies, err := ConvertLinks(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	options, _ := proxies[0]["amnezia-wg-option"].(map[string]any)
+	if options["jc"] != 3 || options["s1"] != 12 || options["h1"] != "555" {
+		t.Fatalf("long spellings were not read: %#v", options)
+	}
+}
+
+// The setting exists for nodes that arrived without parameters. A server's own
+// are part of its address, and a different server's numbers written over them
+// produce a handshake nobody answers.
+func TestTheGlobalSettingDoesNotOverwriteALinksOwn(t *testing.T) {
+	proxies, err := ConvertLinks(amneziaLink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	noised, changed := ApplyAmneziaNoise(proxies, AmneziaNoise{Enabled: true, Count: 9, MinSize: 90, MaxSize: 99})
+
+	options, _ := noised[0]["amnezia-wg-option"].(map[string]any)
+	if options["jc"] != 4 || options["jmin"] != 40 {
+		t.Fatalf("the link's own parameters were overwritten: %#v", options)
+	}
+	if changed != 0 {
+		t.Errorf("nothing was changed, so the count should be 0, got %d", changed)
+	}
+}
+
+// And it still reaches a node that has none.
+func TestTheGlobalSettingStillReachesPlainNodes(t *testing.T) {
+	plain := "wireguard://k%3D@1.2.3.4:51820?publickey=p%3D#Plain"
+	proxies, err := ConvertLinks(plain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	noised, changed := ApplyAmneziaNoise(proxies, AmneziaNoise{Enabled: true, Count: 9, MinSize: 90, MaxSize: 99})
+	options, ok := noised[0]["amnezia-wg-option"].(map[string]any)
+	if !ok || options["jc"] != 9 {
+		t.Fatalf("the setting should have applied here: %#v", noised[0])
+	}
+	if changed != 1 {
+		t.Errorf("expected one proxy changed, got %d", changed)
+	}
+}
+
+// mihomo decodes this map into a struct and rejects keys it has no field for, so
+// one unknown key fails every WireGuard proxy in the subscription, not just this
+// one. Whatever is emitted has to exist in the pinned core.
+func TestOnlyFieldsThePinnedCoreKnowsAreEmitted(t *testing.T) {
+	known := map[string]bool{}
+	for _, set := range []map[string][]string{amneziaIntFields, amneziaStringFields} {
+		for field := range set {
+			known[field] = true
+		}
+	}
+	// v1.19.29's AmneziaWGOption, field for field.
+	for _, field := range strings.Fields("jc jmin jmax s1 s2 s3 s4 h1 h2 h3 h4 i1 i2 i3 i4 i5 j1 j2 j3 itime") {
+		if !known[field] {
+			t.Errorf("%s is in the core and not read from links", field)
+		}
+		delete(known, field)
+	}
+	for field := range known {
+		t.Errorf("%s is emitted but the pinned core has no field for it", field)
+	}
+}

--- a/desktop/internal/mihomoconf/amnezia_v3_test.go
+++ b/desktop/internal/mihomoconf/amnezia_v3_test.go
@@ -1,0 +1,108 @@
+package mihomoconf
+
+import (
+	"strings"
+	"testing"
+)
+
+func amneziaOptionsFor(t *testing.T, query string) map[string]any {
+	t.Helper()
+	proxies, err := ConvertLinks("wireguard://k%3D@1.2.3.4:51820?publickey=p%3D&" + query + "#N")
+	if err != nil {
+		t.Fatal(err)
+	}
+	options, _ := proxies[0]["amnezia-wg-option"].(map[string]any)
+	return options
+}
+
+// v3 builds a different WireGuard device from the legacy one, and each rejects
+// the other's keys outright — which fails the whole configuration, not this one
+// proxy. So a link carrying both has to be settled before it is sent on.
+func TestVersionThreeDropsTheFieldsRemovedInVersionTwo(t *testing.T) {
+	options := amneziaOptionsFor(t, "version=3&jc=4&j1=aa&j2=bb&j3=cc&itime=30&header-protection-key=a2V5")
+	if options["version"] != 3 {
+		t.Fatalf("version was not carried: %#v", options)
+	}
+	for _, gone := range []string{"j1", "j2", "j3", "itime"} {
+		if _, present := options[gone]; present {
+			t.Errorf("%s is v1.5-only and cannot travel with version 3", gone)
+		}
+	}
+	// What both versions share must survive.
+	if options["jc"] != 4 {
+		t.Errorf("jc belongs to both and should have been kept: %#v", options)
+	}
+	if options["header-protection-key"] != "a2V5" {
+		t.Errorf("the v3 field was lost: %#v", options)
+	}
+}
+
+// The mirror: on the legacy device the v3 parameters are keys it has never
+// heard of.
+func TestTheLegacyDeviceDoesNotGetVersionThreeFields(t *testing.T) {
+	options := amneziaOptionsFor(t, "jc=4&j1=aa&itime=30")
+	for _, absent := range []string{"header-protection-key", "random-trailers", "version"} {
+		if _, present := options[absent]; present {
+			t.Errorf("%s should not appear on a link that never mentioned version 3: %#v", absent, options)
+		}
+	}
+	if options["j1"] != "aa" || options["itime"] != 30 {
+		t.Errorf("the v1.5 fields belong here and were dropped: %#v", options)
+	}
+}
+
+// These parameters exist nowhere but v3, so carrying them is the same statement
+// as declaring it. Reading them any other way leaves a link that means nothing.
+func TestVersionThreeIsInferredFromItsOwnFields(t *testing.T) {
+	options := amneziaOptionsFor(t, "jc=4&rekey-after-time=120&random-trailers=true")
+	if options["version"] != 3 {
+		t.Fatalf("v3-only fields should imply version 3: %#v", options)
+	}
+	if options["rekey-after-time"] != "120" || options["random-trailers"] != true {
+		t.Fatalf("the v3 fields were not kept: %#v", options)
+	}
+}
+
+// A plain link stays plain — inference must not manufacture a version.
+func TestNoVersionIsInventedForOrdinaryAmneziaLinks(t *testing.T) {
+	options := amneziaOptionsFor(t, "jc=4&jmin=40&jmax=70")
+	if _, present := options["version"]; present {
+		t.Fatalf("nothing here says v3: %#v", options)
+	}
+}
+
+// The underscore spellings other clients emit.
+func TestTheV3LongSpellingsAreRead(t *testing.T) {
+	options := amneziaOptionsFor(t, "version=3&header_protection_key=a2V5&max_handshake_attempts=5&disable_cookies=1")
+	if options["header-protection-key"] != "a2V5" || options["max-handshake-attempts"] != "5" {
+		t.Fatalf("underscore spellings were not read: %#v", options)
+	}
+	if options["disable-cookies"] != true {
+		t.Fatalf("1 should read as true: %#v", options)
+	}
+}
+
+// Every key emitted has to exist in the core, in both directions, or one unknown
+// key fails every WireGuard proxy in the subscription.
+func TestTheEmittedKeysMatchTheCoreExactly(t *testing.T) {
+	emitted := map[string]bool{"version": true}
+	for _, set := range []map[string][]string{amneziaIntFields, amneziaStringFields, amneziaV3Fields, amneziaV3BoolFields} {
+		for field := range set {
+			emitted[field] = true
+		}
+	}
+	// v1.19.30's AmneziaWGOption, field for field.
+	core := strings.Fields(`version jc jmin jmax s1 s2 s3 s4 h1 h2 h3 h4
+		i1 i2 i3 i4 i5 j1 j2 j3 itime
+		header-protection-key content-padding-addition rekey-after-time rekey-timeout
+		reject-after-time keepalive-timeout max-handshake-attempts random-trailers disable-cookies`)
+	for _, field := range core {
+		if !emitted[field] {
+			t.Errorf("%s is in the core and never read from a link", field)
+		}
+		delete(emitted, field)
+	}
+	for field := range emitted {
+		t.Errorf("%s is emitted and the core has no field for it", field)
+	}
+}

--- a/desktop/internal/mihomoconf/links.go
+++ b/desktop/internal/mihomoconf/links.go
@@ -589,6 +589,12 @@ func parseWireGuard(line string, names *nameRegistry) (Proxy, error) {
 			proxy["reserved"] = values
 		}
 	}
+	// AmneziaWG. A server disguising its handshake only answers a client using
+	// the same numbers, so these belong to the link the way the keys do — they
+	// were being dropped, which left the proxy importable and unconnectable.
+	if amnezia := amneziaFromQuery(query); amnezia != nil {
+		proxy["amnezia-wg-option"] = amnezia
+	}
 	return proxy, nil
 }
 

--- a/desktop/internal/mihomoconf/noise.go
+++ b/desktop/internal/mihomoconf/noise.go
@@ -63,6 +63,15 @@ func ApplyAmneziaNoise(proxies []Proxy, noise AmneziaNoise) ([]Proxy, int) {
 		for key, value := range proxy {
 			next[key] = value
 		}
+		// A link that carried its own numbers keeps them. AmneziaWG is a
+		// disguise both ends have to agree on, so a server's own parameters are
+		// part of its address, not a preference — overwriting them with a
+		// setting meant for a different server produces a handshake nobody
+		// answers. The setting is for nodes that arrived without any.
+		if _, fromLink := next["amnezia-wg-option"]; fromLink {
+			out = append(out, next)
+			continue
+		}
 		next["amnezia-wg-option"] = map[string]any{
 			"jc":   noise.Count,
 			"jmin": noise.MinSize,

--- a/desktop/scripts/build-mihomo-core.sh
+++ b/desktop/scripts/build-mihomo-core.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 THIRD_PARTY_DIR="${MIHOMO_THIRD_PARTY_DIR:-${ROOT_DIR}/third_party}"
 CORE_DIR="${THIRD_PARTY_DIR}/flclash/core"
-MIHOMO_TAG="v1.19.29"
+MIHOMO_TAG="v1.19.30"
 
 TARGET_GOOS="${TARGET_GOOS:-$(go env GOOS)}"
 TARGET_GOARCH="${TARGET_GOARCH:-$(go env GOARCH)}"

--- a/desktop/scripts/patches/flclash-ntp-after-dns.patch
+++ b/desktop/scripts/patches/flclash-ntp-after-dns.patch
@@ -1,0 +1,25 @@
+Reapply mihomo's DNS-before-NTP ordering on top of the FlClash commit.
+
+mihomo v1.19.30 moved updateNTP below updateDNS ("initialize DNS before NTP",
+#3103) because an NTP server may be given as a hostname, which cannot be
+resolved before DNS is up. The FlClash compatibility commit predates that and
+still calls updateNTP first, while also commenting out the two lines that now
+sit directly beneath it — so cherry-picking it onto v1.19.30 conflicts in
+exactly this hunk, and taking either side alone loses one of the two changes.
+
+Applied after the cherry-pick has been resolved in FlClash's favour, this puts
+the ordering back. Both intentions survive: NTP after DNS, and the listener and
+tunnel setup left to FlClash rather than done here.
+
+--- a/hub/executor/executor.go
++++ b/hub/executor/executor.go
+@@ -102,8 +102,8 @@ func ApplyConfig(cfg *config.Config, force bool) {
+ 	updateSniffer(cfg.Sniffer)
+ 	updateHosts(cfg.Hosts)
+ 	updateGeneral(cfg.General, true)
+-	updateNTP(cfg.NTP)
+ 	updateDNS(cfg.DNS, cfg.General.IPv6)
++	updateNTP(cfg.NTP) // initialize NTP after DNS because an NTP server may be a hostname.
+ 	//updateListeners(cfg.General, cfg.Listeners, force)
+ 	//updateTun(cfg.General) // tun should not care "force"
+ 	updateIPTables(cfg)

--- a/desktop/scripts/setup-mihomo-core.sh
+++ b/desktop/scripts/setup-mihomo-core.sh
@@ -15,11 +15,33 @@ CORE_DIR="${FLCLASH_DIR}/core"
 MIHOMO_DIR="${CORE_DIR}/Clash.Meta"
 
 FLCLASH_REPO="https://github.com/chen08209/FlClash.git"
+# FlClash and its mihomo patch are pinned separately and deliberately do not
+# move together.
+#
+# The patch had to advance for v1.19.30: the v0.8.94 one calls dns.ReCreateServer
+# with the signature it had before, and the build fails to compile. The v0.8.95
+# patch fixes that.
+#
+# The tree must not. FlClash rewrote its action protocol in v0.8.95 — action.go
+# gone, message.go and method.go in its place — and internal/engine speaks the
+# older one. What that combination looks like is worse than a build failure:
+# every call returns success, so validateConfig accepts unparseable YAML and
+# reports nothing wrong. The positive tests all still pass, because they assert
+# that a good config is accepted and it is. Only the negative control caught it.
+#
+# Moving the tree therefore means porting internal/engine to the new protocol
+# first, in its own change, with those negative tests as the evidence.
 FLCLASH_COMMIT="7c831855efedceb1a72bd0b4c18da026593d0853"
 MIHOMO_REPO="https://github.com/MetaCubeX/mihomo.git"
-MIHOMO_TAG="v1.19.29"
+MIHOMO_TAG="v1.19.30"
 FLCLASH_PATCH_REPO="https://github.com/chen08209/Clash.Meta.git"
-FLCLASH_PATCH_COMMIT="80362fc1895dcf60b79b562896653046e0687413"
+FLCLASH_PATCH_COMMIT="0f7f05adff5e2c49775a112dcfe05a6aa36fda0c"
+
+# The one hunk the FlClash commit and mihomo v1.19.30 both touch, and the
+# recorded answer to it. Kept beside the pins so that moving one without the
+# other is visible.
+KNOWN_CONFLICT="hub/executor/executor.go"
+NTP_PATCH="${ROOT_DIR}/scripts/patches/flclash-ntp-after-dns.patch"
 
 log() { printf '%s\n' "$*"; }
 die() { printf '%s\n' "$*" >&2; exit 1; }
@@ -48,6 +70,16 @@ actual_flclash="$(git -C "${FLCLASH_DIR}" rev-parse HEAD)"
   die "FlClash is at ${actual_flclash}, expected ${FLCLASH_COMMIT}"
 
 # --- mihomo: the engine itself ----------------------------------------------
+# A tree fetched for an older pin does not know the new tag, and the checks below
+# would stop with an accurate complaint and no way forward. This is a build input
+# rather than anything anybody edits — it is produced entirely by the clone just
+# below — so the answer to "wrong version on disk" is to fetch the right one.
+if [[ -f "${MIHOMO_DIR}/go.mod" ]] &&
+  ! git -C "${MIHOMO_DIR}" rev-parse --verify "${MIHOMO_TAG}^{commit}" >/dev/null 2>&1; then
+  log "Engine source on disk predates ${MIHOMO_TAG}; fetching it again."
+  rm -rf "${MIHOMO_DIR}"
+fi
+
 if [[ ! -f "${MIHOMO_DIR}/go.mod" ]]; then
   if [[ -e "${MIHOMO_DIR}" && -n "$(find "${MIHOMO_DIR}" -mindepth 1 -maxdepth 1 2>/dev/null)" ]]; then
     die "mihomo checkout is present but incomplete: ${MIHOMO_DIR}"
@@ -61,10 +93,31 @@ if [[ ! -f "${MIHOMO_DIR}/go.mod" ]]; then
   # CI runner that has not been told who it is, and every developer who has
   # just installed git. It goes on the command line so nothing outside this
   # tree is configured on the way past.
-  git -c commit.gpgsign=false \
+  if ! git -c commit.gpgsign=false \
     -c user.name="WhiteVPN Desktop build" \
     -c user.email="build@localhost" \
-    -C "${MIHOMO_DIR}" cherry-pick "${FLCLASH_PATCH_COMMIT}"
+    -C "${MIHOMO_DIR}" cherry-pick "${FLCLASH_PATCH_COMMIT}"; then
+    # One hunk is known to collide and has a known answer. Anything else is a
+    # change upstream made that nobody has looked at, and guessing at it would
+    # produce an engine whose behaviour no one chose.
+    conflicted="$(git -C "${MIHOMO_DIR}" diff --diff-filter=U --name-only)"
+    [[ "${conflicted}" == "${KNOWN_CONFLICT}" ]] ||
+      die "cherry-picking the FlClash commit onto ${MIHOMO_TAG} conflicts where this script has no recorded answer:
+${conflicted}
+Resolve it by hand, then record the resolution the way ${NTP_PATCH##*/} records the known one."
+
+    log "Resolving the known ${KNOWN_CONFLICT} conflict..."
+    # FlClash's side first, so its edits to the surrounding lines survive; the
+    # patch then puts mihomo's newer NTP ordering back on top of them.
+    git -C "${MIHOMO_DIR}" checkout --theirs "${KNOWN_CONFLICT}"
+    git -C "${MIHOMO_DIR}" apply "${NTP_PATCH}" ||
+      die "the recorded resolution no longer applies: ${NTP_PATCH}"
+    git -C "${MIHOMO_DIR}" add "${KNOWN_CONFLICT}"
+    git -c commit.gpgsign=false \
+      -c user.name="WhiteVPN Desktop build" \
+      -c user.email="build@localhost" \
+      -C "${MIHOMO_DIR}" cherry-pick --continue --no-edit
+  fi
 fi
 
 # Same checks Android's script makes, for the same reason.


### PR DESCRIPTION
Steps 0, 1 and 2 of the plan. They ship together because each is what makes the next possible.

## 1. The parameters a link carries were being dropped

`parseWireGuard` read the keys, the addresses, the MTU and the reserved bytes — and not one Amnezia parameter. A grep for `jc`, `jmin`, `s1` or `h1` inside it returned **zero**.

AmneziaWG is WireGuard with the handshake disguised. A server configured that way only answers a client sending the same numbers, so **the numbers are part of the credential, not a preference**. The node imported, appeared in the list looking fine, and could never connect.

The global noise setting made this worse rather than covering it: it wrote `jc`/`jmin`/`jmax` over every WireGuard proxy unconditionally — one server's numbers applied to another. It now yields to a link that brought its own.

## 2. The core bump

v1.19.29's `AmneziaWGOption` **has no `Version` field at all**, so v3 was never a config change — it was unreachable. The tag also carries **CVE-2026-56862 in crypto/tls**, plus a fix for tun DNS hijack sending stale packets.

Three pins, **only two moved**:

| Pin | Moved? | Why |
|---|---|---|
| mihomo tag | ✅ v1.19.30 | v3 + the CVE |
| FlClash mihomo patch | ✅ v0.8.95 | the v0.8.94 one calls `dns.ReCreateServer` with its pre-v1.19.30 signature and will not compile |
| FlClash tree | ❌ stays v0.8.94 | see below |

### The pin that must not move, and how it was caught

v0.8.95 rewrote FlClash's action protocol — `action.go` replaced by `message.go` and `method.go` — and `internal/engine` speaks the older one.

**That combination is worse than a build failure, because it builds.** Every call comes back successful, so `validateConfig` accepts unparseable YAML and reports nothing wrong. Both positive integration tests still passed while it did — they assert a good config is accepted, and it was.

`TestEngineRejectsUnparseableConfig` is what caught it. Exactly the job a negative control exists for.

### The conflict

Cherry-picking onto v1.19.30 collides in one hunk: upstream moved `updateNTP` below `updateDNS` (an NTP server may be a hostname, unresolvable before DNS is up), while FlClash comments out the two lines now beneath it. Taking either side whole loses one change. The resolution keeping both is committed as `scripts/patches/flclash-ntp-after-dns.patch`; **conflicts anywhere else stop the build** rather than being guessed at.

## 3. AmneziaWG v3

v3 is a **different WireGuard device** from the legacy one, not a newer edition of it. Each writes its own keys into the device's IPC config and rejects the other's — and a rejected key fails the whole configuration, not the one proxy. So a link carrying both sets is settled before it is handed over.

- **The declared version decides**, because it is the server saying which protocol it speaks.
- **Absent, the v3-only fields decide.** `header-protection-key`, `rekey-after-time` and the rest exist nowhere else, so carrying them is the same statement. A reading, not a guess — under any other one the link means nothing.
- **A link with none of them gets no version invented.**
- Version 3 drops `j1`, `j2`, `j3`, `itime` (removed in v2); anything else drops the v3-only set. What both share survives either way.

## Verification

- Engine source deleted and rebuilt **from scratch three times** while narrowing the pin combination; the recorded resolution reproduces.
- Full Go suite, `go vet`, every engine integration test green against the newly built core.
- The parity test holds emitted keys against v1.19.30's `AmneziaWGOption` **in both directions** — a field the core gains and a field we invent both fail here rather than at a user's connection.
- `TestTheEngineReadsAmneziaWGv3` builds its config from the link alone and asks the **shipping binary** to read it, so the whole path is asserted rather than the parser's opinion of itself.

Not covered: connecting to a live server through the new core. Worth doing on the build before release.

## Not in this PR

The settings UI for these options (Android exposes ~15 fields). Links now carry their own parameters, which is the half that was broken; a global override is a separate, additive change.