### PR TITLE
Test every subscription in one run

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -146,6 +146,7 @@ import type {
   ConnectionSelection,
   UpdateStatus,
   WhiteVPNNode,
+  NodeMeasurement,
   WhiteVPNNodeList,
   NodeTestRequest,
   RuntimeType,
@@ -732,6 +733,13 @@ function App() {
     return manualAvailable || (state?.v2raySubscriptions ?? []).some((subscription) => subscription.id === browsing) ? browsing : fallback;
   }, [browsing, state?.selectedSubscriptionId, state?.v2rayProfiles, state?.v2raySubscriptions]);
 
+  // The nodes:test handler is registered once and would otherwise close over
+  // whichever subscription was showing when the page mounted.
+  const browsedSubscriptionRef = useRef(browsedSubscriptionId);
+  useEffect(() => {
+    browsedSubscriptionRef.current = browsedSubscriptionId;
+  }, [browsedSubscriptionId]);
+
   function applyState(next: AppState) {
     setState((current) => normalizeAppState(next, current));
   }
@@ -806,7 +814,12 @@ function App() {
   async function runNodeTest(request: NodeTestRequest) {
     try {
       setNodeTestRunning(true);
-      await backend.startNodeTest({ ...request, subscriptionId: browsedSubscriptionId });
+      // The page's subscription is what a normal run measures. A run covering
+      // everything supplies its own list per subscription, so naming one here
+      // would only invite the question of which wins.
+      await backend.startNodeTest(
+        request.allSubscriptions ? request : { ...request, subscriptionId: browsedSubscriptionId },
+      );
     } catch (err) {
       setNodeTestRunning(false);
       showError(messageFromError(err));
@@ -939,8 +952,17 @@ function App() {
       onRuntimeEvent<unknown>("subscriptions:changed", () => {
         void backend.getAppState().then(applyState);
       }),
-      onRuntimeEvent<WhiteVPNNode>("nodes:test", (node) => {
-        setNodes((current) => current.map((entry) => (entry.name === node.name ? node : entry)));
+      onRuntimeEvent<NodeMeasurement>("nodes:test", (measurement) => {
+        // A run can cover every subscription now, so a result has to say which
+        // list it is for. Node names come from providers and two subscriptions
+        // can both hold a "Germany 01" — applied on the name alone, one list's
+        // measurement would overwrite the other's wherever they collide.
+        if (measurement.subscriptionId !== browsedSubscriptionRef.current) {
+          return;
+        }
+        setNodes((current) =>
+          current.map((entry) => (entry.name === measurement.node.name ? measurement.node : entry)),
+        );
       }),
       onRuntimeEvent<unknown>("nodes:test-done", () => setNodeTestRunning(false)),
       onRuntimeEvent<string>("nodes:test-error", (message) => {
@@ -2634,6 +2656,9 @@ function NodesPage({
   const [hidingBusy, setHidingBusy] = useState(false);
   const unknown = t("vpn.nodes.unknownCountry");
   const manualProfileCount = state.v2rayProfiles.filter((profile) => !profile.subscriptionId).length;
+  // How many lists a run covering everything would walk: the subscriptions, and
+  // the hand-added configs when there are any.
+  const sourceCount = state.v2raySubscriptions.length + (manualProfileCount > 0 ? 1 : 0);
 
   useEffect(() => {
     setSort(subscriptionId === manualServerSourceID ? null : { column: "label", direction: "asc" });
@@ -2770,6 +2795,18 @@ function NodesPage({
     }
     setPending({ nodes: new Set(targets), tests: request });
     onRunTest({ ...request, nodes: targets });
+  }
+
+  // Every subscription in turn. The backend walks them one at a time, so this
+  // takes as long as running the same test on each page in sequence — which is
+  // what it replaces.
+  function runTestsEverywhere() {
+    onError("");
+    // Nothing is marked pending: the rows on screen are one list of several,
+    // and marking them would show a spinner on nodes whose turn may not have
+    // come yet.
+    setPending(null);
+    onRunTest({ ...request, nodes: [], allSubscriptions: true });
   }
 
   // What a bulk export covers: the selection when there is one, everything on
@@ -3008,10 +3045,21 @@ function NodesPage({
               {t("servers.stop")}
             </Button>
           ) : (
-            <Button onClick={runTests} disabled={!visible.length}>
-              <Gauge />
-              {selectedNames.length ? t("servers.testSelected") : t("servers.testAll")}
-            </Button>
+            <>
+              <Button onClick={runTests} disabled={!visible.length}>
+                <Gauge />
+                {selectedNames.length ? t("servers.testSelected") : t("servers.testAll")}
+              </Button>
+              {/* Only when there is more than one list to cover. On a single
+                  subscription this would be the button beside it, worded
+                  differently. */}
+              {sourceCount > 1 && (
+                <Button variant="outline" onClick={runTestsEverywhere} title={t("servers.testEverywhere.hint")}>
+                  <Gauge />
+                  {t("servers.testEverywhere", { count: sourceCount })}
+                </Button>
+              )}
+            </>
           )}
         </>
       }

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -633,6 +633,11 @@ const strings = {
     en: "Point your program at {endpoint} — it accepts both HTTP and SOCKS5. If another program already holds this port, connecting will say so rather than quietly moving to another one, which would leave whatever you configured pointing at nothing.",
     fa: "برنامه‌تان را به {endpoint} وصل کنید — هم HTTP و هم SOCKS5 را می‌پذیرد. اگر برنامهٔ دیگری این پورت را گرفته باشد، هنگام اتصال همین را می‌گوید و بی‌سروصدا پورت دیگری انتخاب نمی‌کند، چون آن‌وقت چیزی که تنظیم کرده‌اید به جای خالی وصل می‌ماند.",
   },
+  "servers.testEverywhere": { en: "Test all {count} lists", fa: "تست همهٔ {count} فهرست" },
+  "servers.testEverywhere.hint": {
+    en: "Runs the chosen tests over every subscription in turn, so the results can be compared across all of them. Each list is measured on its own engine, one after another, so this takes about as long as testing each page separately.",
+    fa: "تست‌های انتخاب‌شده را روی همهٔ اشتراک‌ها به‌ترتیب اجرا می‌کند تا نتیجه‌ها با هم قابل مقایسه باشند. هر فهرست با موتور خودش و یکی پس از دیگری اندازه‌گیری می‌شود، پس تقریباً به‌اندازهٔ تست جداگانهٔ هر صفحه طول می‌کشد.",
+  },
   "servers.export": { en: "Export configs", fa: "خروجی گرفتن از کانفیگ‌ها" },
   "servers.exportSelected": { en: "Export selected ({count})", fa: "خروجی انتخاب‌شده‌ها ({count})" },
   "servers.exportAll": { en: "Export all ({count})", fa: "خروجی همه ({count})" },

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -713,10 +713,21 @@ export type WhiteVPNNode = {
 // One run of the node tests: which nodes, which tests, and the numbers the user
 // is allowed to change. Bounds live in internal/model; anything outside them is
 // replaced with the default rather than clamped.
+// One node's result and the list it belongs to. Node names come from providers,
+// so two subscriptions can both hold a "Germany 01" — a result matched on the
+// name alone would land on whichever list happens to be on screen.
+export interface NodeMeasurement {
+  subscriptionId: string;
+  node: WhiteVPNNode;
+}
+
 export type NodeTestRequest = {
   // Which subscription the names belong to; empty means the selected one.
   subscriptionId?: string;
   nodes: string[];
+  // Test every subscription in turn rather than one. `nodes` is ignored when it
+  // is set — the names on one page do not describe the others.
+  allSubscriptions?: boolean;
   reachability: boolean;
   delay: boolean;
   speed: boolean;

--- a/desktop/internal/model/types.go
+++ b/desktop/internal/model/types.go
@@ -608,12 +608,36 @@ type WhiteVPNNode struct {
 
 // NodeTestRequest is one run of the tests: which nodes, which tests, and the
 // numbers the user is allowed to change.
+// NodeMeasurement is one node's result and the subscription it belongs to.
+//
+// The subscription is a property of the result rather than of the node: the
+// same node measured under two subscriptions is two results, and the interface
+// has to know which list a result is for. Matching on the name alone was enough
+// only while a run could not leave one subscription.
+type NodeMeasurement struct {
+	SubscriptionID string       `json:"subscriptionId"`
+	Node           WhiteVPNNode `json:"node"`
+}
+
 type NodeTestRequest struct {
 	// Which subscription the names belong to. Empty means the selected one,
 	// which is what the dashboard tests; the Servers page names the one it is
 	// looking at, so a test measures the nodes on screen.
 	SubscriptionID string   `json:"subscriptionId"`
 	Nodes          []string `json:"nodes"`
+
+	// AllSubscriptions tests every subscription in turn rather than one.
+	//
+	// Nodes is ignored when it is set, because the names on one page do not
+	// describe the others. Somebody comparing what they have across three
+	// providers was running the same test three times and reading three tables;
+	// this is that, once.
+	//
+	// Sequential rather than parallel, and not a shortcut: each subscription
+	// needs a measuring engine built from its own body, and running several at
+	// once would have them compete for the bandwidth the speed test is trying to
+	// measure.
+	AllSubscriptions bool `json:"allSubscriptions"`
 
 	Reachability bool `json:"reachability"`
 	Delay        bool `json:"delay"`

--- a/desktop/testeverywhere_test.go
+++ b/desktop/testeverywhere_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+
+	"whitevpn-desktop/internal/model"
+)
+
+func appWithSources(subscriptions []string, manual bool) *App {
+	state := model.DefaultAppState()
+	state.V2RaySubscriptions = nil
+	for _, id := range subscriptions {
+		state.V2RaySubscriptions = append(state.V2RaySubscriptions, model.V2RaySubscription{ID: id})
+	}
+	state.V2RayProfiles = nil
+	if manual {
+		state.V2RayProfiles = []model.V2RayProfile{{ID: "p1"}}
+	}
+	return &App{state: state}
+}
+
+// Every list with nodes in it, including the one the user assembled by hand —
+// leaving those out of "test everything" would leave out the nodes they care
+// most about.
+func TestEveryListIsCovered(t *testing.T) {
+	got := appWithSources([]string{"whitedns-vpn", "mine"}, true).subscriptionIDsForTesting()
+	want := []string{"whitedns-vpn", "mine", model.ManualServerSourceID}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+// A profile that belongs to a subscription is already covered by that
+// subscription; only the hand-added ones are their own source.
+func TestManualIsListedOnlyWhenThereAreHandAddedConfigs(t *testing.T) {
+	app := appWithSources([]string{"whitedns-vpn"}, false)
+	app.state.V2RayProfiles = []model.V2RayProfile{{ID: "p1", SubscriptionID: "whitedns-vpn"}}
+	for _, id := range app.subscriptionIDsForTesting() {
+		if id == model.ManualServerSourceID {
+			t.Fatal("nothing was added by hand, so there is no manual list to test")
+		}
+	}
+}
+
+// The names on the page a run was started from do not describe the other lists,
+// so a run covering everything names none — and must not be refused for it.
+func TestARunCoveringEverythingNeedsNoNodeNames(t *testing.T) {
+	app := appWithSources(nil, false)
+	err := app.StartNodeTest(model.NodeTestRequest{AllSubscriptions: true, Reachability: true})
+	if err != nil {
+		t.Fatalf("a full run should be accepted without node names: %v", err)
+	}
+	app.CancelNodeTest()
+
+	// And a single-subscription run with no names is still nothing to do.
+	if err := app.StartNodeTest(model.NodeTestRequest{Reachability: true}); err == nil {
+		t.Fatal("a run naming no nodes and no subscriptions should be refused")
+	}
+}

--- a/desktop/whitevpn_measure.go
+++ b/desktop/whitevpn_measure.go
@@ -58,7 +58,10 @@ type measureState struct {
 // followed by one answer.
 func (a *App) StartNodeTest(request model.NodeTestRequest) error {
 	request = model.NormalizeNodeTestRequest(request)
-	if len(request.Nodes) == 0 {
+	// A run covering every subscription names no nodes on purpose: the names on
+	// the page it was started from say nothing about the other lists, so each
+	// one contributes its own.
+	if len(request.Nodes) == 0 && !request.AllSubscriptions {
 		return fmt.Errorf("no nodes to test")
 	}
 
@@ -96,11 +99,74 @@ func (a *App) CancelNodeTest() {
 }
 
 func (a *App) runNodeTest(ctx context.Context, request model.NodeTestRequest) {
+	if request.AllSubscriptions {
+		a.runNodeTestEverywhere(ctx, request)
+		return
+	}
+
 	subscriptionID := request.SubscriptionID
 	if subscriptionID == "" {
 		subscriptionID = a.selectedSubscriptionID()
 	}
-	nodes := a.nodesByName(subscriptionID, request.Nodes)
+	a.runNodeTestFor(ctx, subscriptionID, a.nodesByName(subscriptionID, request.Nodes), request)
+}
+
+// runNodeTestEverywhere walks the subscriptions in turn.
+//
+// One at a time because each needs a measuring engine built from its own body,
+// and because the speed test measures bandwidth — several running at once would
+// be measuring each other.
+//
+// One subscription failing does not stop the rest. A provider that is down, or
+// an address that cannot be fetched, is a reason to skip that list rather than
+// to abandon the two the user could have had an answer for.
+func (a *App) runNodeTestEverywhere(ctx context.Context, request model.NodeTestRequest) {
+	for _, subscriptionID := range a.subscriptionIDsForTesting() {
+		if ctx.Err() != nil {
+			return
+		}
+		// Every node in each list: the names on the page the user started from
+		// say nothing about the other subscriptions.
+		list, err := a.ListSubscriptionNodes(subscriptionID, false)
+		if err != nil {
+			a.appendRuntimeLog(fmt.Sprintf("skipping %q while testing every subscription: %v", subscriptionID, err))
+			continue
+		}
+		nodes := make([]model.WhiteVPNNode, 0, len(list.Nodes))
+		for _, node := range list.Nodes {
+			// Hidden nodes are out of the way rather than out of reach, but a
+			// node the user took out of the list is not one they are asking to
+			// have measured.
+			if !node.Hidden {
+				nodes = append(nodes, node)
+			}
+		}
+		a.runNodeTestFor(ctx, subscriptionID, nodes, request)
+	}
+}
+
+// subscriptionIDsForTesting is every list that has nodes to measure.
+func (a *App) subscriptionIDsForTesting() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	ids := make([]string, 0, len(a.state.V2RaySubscriptions)+1)
+	for _, subscription := range a.state.V2RaySubscriptions {
+		ids = append(ids, subscription.ID)
+	}
+	// Manually added configs are a source like any other here. They are the one
+	// list a user assembled by hand, so leaving them out of "test everything"
+	// would be leaving out the nodes they care most about.
+	for _, profile := range a.state.V2RayProfiles {
+		if profile.SubscriptionID == "" {
+			ids = append(ids, model.ManualServerSourceID)
+			break
+		}
+	}
+	return ids
+}
+
+func (a *App) runNodeTestFor(ctx context.Context, subscriptionID string, nodes []model.WhiteVPNNode, request model.NodeTestRequest) {
 	if len(nodes) == 0 {
 		return
 	}
@@ -117,6 +183,13 @@ func (a *App) runNodeTest(ctx context.Context, request model.NodeTestRequest) {
 
 	measurer, err := a.startMeasurer(ctx, subscriptionID)
 	if err != nil {
+		if request.AllSubscriptions {
+			// One list of several. The interface reads nodes:test-error as the
+			// run being over, so reporting it that way would stop the spinner
+			// and the error banner on the two subscriptions still to come.
+			a.appendRuntimeLog(fmt.Sprintf("could not measure %q: %v", subscriptionID, err))
+			return
+		}
 		a.emit("nodes:test-error", err.Error())
 		return
 	}
@@ -307,6 +380,10 @@ func (a *App) recordNodeMeasurement(subscriptionID, name string, apply func(*mod
 	}
 	a.nodesMu.Unlock()
 	if found {
-		a.emit("nodes:test", updated)
+		// Which subscription this belongs to travels with it. Node names come
+		// from providers, so two subscriptions can both hold a "Germany 01",
+		// and a result matched on the name alone would land on whichever one
+		// the page happens to be showing.
+		a.emit("nodes:test", model.NodeMeasurement{SubscriptionID: subscriptionID, Node: updated})
 	}
 }


### PR DESCRIPTION
Step 3 of the plan. Independent of [#58](https://github.com/WhiteDNS/WhiteVPN-Desktop/pull/58) — different files, either order.

Someone comparing what three providers give them was running the same test three times, on three pages, and reading three tables. This is that, once.

## The bug that had to be fixed first

Results were emitted as a bare node and applied **by name**:

```ts
setNodes((current) => current.map((entry) => (entry.name === node.name ? node : entry)));
```

That was enough only while a run could not leave one subscription. Node names come from providers, so two subscriptions can easily both hold a `🇩🇪 Germany 01` — and across lists, matching on the name alone writes one subscription's measurement onto another's node. Silently, on whichever page happens to be open.

So the event carries the subscription now, and the interface ignores what is not for the list on screen. The subscription belongs to the **result** rather than to the node: the same node measured under two subscriptions is two results.

## The run

- **Sequential, and not for simplicity.** Each subscription needs a measuring engine built from its own body, and the speed test measures bandwidth — several at once would be measuring each other.
- **One list failing does not end the run.** A provider being down is a reason to skip that list, not to abandon the two the user could have had an answer for.
- **Hand-added configs count as a list.** They are the one set a user assembled themselves; leaving them out of "test everything" would leave out the nodes they care most about. A profile belonging to a subscription is not counted twice.

## Three things that had to give way

A run covering everything names no nodes, which is the whole point — and:

1. `StartNodeTest` refused an empty node list outright.
2. The interface forced the page's subscription onto every request.
3. A subscription that cannot build an engine emitted `nodes:test-error`, which the interface reads as **the whole run being over** — stopping the spinner while the backend carried on with the remaining lists. It logs and moves on instead.

The button appears only where there is more than one list to cover; on a single subscription it would be the button beside it, worded differently.

## Verification

Full Go suite, `go vet`, frontend typecheck and build green. New tests cover the source enumeration (including manual-only-when-present) and that a full run is accepted without node names while a single-subscription run with none is still refused.

Not covered by tests: the timing of a real multi-subscription run. Worth watching once on a build with two or three subscriptions, since a speed test over several lists is long by nature.