### PR TITLE
Connection chaining: send traffic through two nodes

### DIFF
--- a/desktop/ANDROID-PARITY.md
+++ b/desktop/ANDROID-PARITY.md
@@ -427,6 +427,7 @@ Things the phone has no equivalent for, added because a desktop needs them.
 | Runs in the background | Closing the window hides it; the app keeps carrying traffic | `[x]` |
 | Sets the system proxy | In proxy mode, points Windows at the local proxy and puts back what it found | `[x]` |
 | Proxy-only mode | No phone equivalent. The engine listens and nothing on the machine is redirected | `[+]` |
+| Connection chaining | Two hops, as v1.6.0 added on the phone — built differently, see below | `[~]` |
 
 Closing a VPN's window means "get out of my way", not "stop protecting my
 traffic". But hiding is only offered once there is an icon to come back from:
@@ -448,6 +449,31 @@ browser extension or Telegram routed — and the rest of the machine left alone 
 had nothing to reach for. There is now a third mode, **proxy-only**, where both
 are off: the engine listens on its mixed port, serving HTTP and SOCKS5, and
 nothing on the machine is touched.
+
+### Connection chaining
+
+The phone resolves the first hop to a fixed node before rendering, and writes
+only the chosen chain into the config. The desktop does not have to: mihomo
+keeps proxy groups in the same map it looks proxies up in —
+`proxies[groupName] = adapter.NewProxy(group)` — so `dialer-proxy` may name a
+group, and the first hop stays the ordinary selection group. Automatic goes on
+working without being resolved to a node beforehand, and a first hop that fails
+is replaced by the group rather than by a reconnect.
+
+The exit is a copy of the chosen node under a fixed name, because the original
+stays where the first hop draws from and one proxy cannot be both ends of a
+chain. The original is then removed from the group, or it could be picked as the
+first hop and both ends would be one machine.
+
+Where the exit needs a dialer that carries UDP — WireGuard, Hysteria2, TUIC,
+anything over QUIC — the group is narrowed to nodes that can. The phone
+validates the same thing and reports it as an error on a fixed pair; here the
+choice is a group, so narrowing it is what the same rule looks like. A TCP-only
+first hop under a datagram exit builds, connects and carries nothing.
+
+Only the link-based path honours it. A subscription arriving as a whole mihomo
+document brings its own groups and rules, and rewriting somebody else's routing
+to insert a hop is a larger promise than this makes.
 
 The three are one choice in the interface rather than two switches, because they
 are mutually exclusive at connect — with the tunnel up the system proxy is

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -6172,6 +6172,19 @@ function WhiteVPNSettingsPage({
       .catch(() => setTunnelAvailable(false));
   }, []);
 
+  // The nodes a second hop can be chosen from: the selected subscription's, the
+  // list the connection itself is built from. Loaded here rather than passed in,
+  // because this is the only page that needs them and a settings page that
+  // waits on the Servers page having been opened would be a settings page that
+  // sometimes offers nothing.
+  const [chainNodes, setChainNodes] = useState<WhiteVPNNode[]>([]);
+  useEffect(() => {
+    void backend
+      .listWhiteVpnNodes(false)
+      .then((list) => setChainNodes((list.nodes || []).filter((node) => !node.hidden)))
+      .catch(() => setChainNodes([]));
+  }, [state.selectedSubscriptionId]);
+
   const [frontingDraft, setFrontingDraft] = useState("");
   const [processDraft, setProcessDraft] = useState("");
   const [saving, setSaving] = useState(false);
@@ -6248,6 +6261,40 @@ function WhiteVPNSettingsPage({
         </>
       }
     >
+      <SettingsSection title={t("settings.chain.title")} description={t("settings.chain.description")}>
+        <Field>
+          <FieldLabel>{t("settings.chain.exit")}</FieldLabel>
+          <Select
+            value={draft.chainExitNode || "off"}
+            onValueChange={(value) => patch({ chainExitNode: value === "off" ? "" : value })}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent position="popper">
+              <SelectItem value="off">{t("settings.chain.off")}</SelectItem>
+              {chainNodes.map((node) => (
+                <SelectItem key={node.name} value={node.name}>
+                  {node.label || node.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <FieldDescription>
+            {draft.chainExitNode ? t("settings.chain.on.description") : t("settings.chain.off.description")}
+          </FieldDescription>
+        </Field>
+        {/* The chosen node may have left the subscription since it was picked,
+            which the connect path refuses rather than works around — so it is
+            said here, where it can still be changed. */}
+        {draft.chainExitNode && !chainNodes.some((node) => node.name === draft.chainExitNode) && (
+          <Alert variant="destructive">
+            <AlertCircle />
+            <AlertDescription>{t("settings.chain.missing", { name: draft.chainExitNode })}</AlertDescription>
+          </Alert>
+        )}
+      </SettingsSection>
+
       <SettingsSection title={t("settings.connection.title")} description={t("settings.connection.description")}>
         {/* One choice rather than two switches. The tunnel and the system proxy
             are mutually exclusive at connect — with the tunnel up the system

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -608,6 +608,25 @@ const strings = {
     en: "How traffic reaches your machine.",
     fa: "اینکه ترافیک چطور به دستگاه شما می‌رسد.",
   },
+  "settings.chain.title": { en: "Connection chaining", fa: "زنجیره کردن اتصال" },
+  "settings.chain.description": {
+    en: "Send traffic through a second node before it reaches the internet. The connection chosen on the VPN page becomes the first hop; the node chosen here becomes the one traffic leaves from.",
+    fa: "ترافیک را قبل از رسیدن به اینترنت از یک سرور دوم رد کنید. اتصالی که در صفحهٔ وی‌پی‌ان انتخاب کرده‌اید هاپ اول می‌شود و سروری که اینجا انتخاب می‌کنید جایی است که ترافیک از آن خارج می‌شود.",
+  },
+  "settings.chain.exit": { en: "Second hop", fa: "هاپ دوم" },
+  "settings.chain.off": { en: "Off — one hop", fa: "خاموش — یک هاپ" },
+  "settings.chain.off.description": {
+    en: "Traffic leaves from the connection chosen on the VPN page, as usual.",
+    fa: "ترافیک مثل همیشه از اتصالی که در صفحهٔ وی‌پی‌ان انتخاب شده خارج می‌شود.",
+  },
+  "settings.chain.on.description": {
+    en: "Two hops are slower than one, and every node has to carry the traffic of the one after it. If the second hop uses WireGuard or Hysteria2, only nodes that can carry UDP are offered as the first — the rest could not carry it at all.",
+    fa: "دو هاپ کندتر از یکی است و هر سرور باید ترافیک سرور بعدی را هم حمل کند. اگر هاپ دوم WireGuard یا Hysteria2 باشد، فقط سرورهایی به‌عنوان هاپ اول پیشنهاد می‌شوند که بتوانند UDP را حمل کنند — بقیه اصلاً نمی‌توانند.",
+  },
+  "settings.chain.missing": {
+    en: "\"{name}\" is not in this subscription any more. Choose another second hop, or turn chaining off — connecting will refuse until then.",
+    fa: "«{name}» دیگر در این اشتراک نیست. هاپ دوم دیگری انتخاب کنید یا زنجیره را خاموش کنید — تا آن موقع اتصال برقرار نمی‌شود.",
+  },
   "settings.routing.mode": { en: "How traffic reaches the tunnel", fa: "ترافیک چطور به تونل برسد" },
   "settings.routing.systemProxy": { en: "System proxy — the whole machine", fa: "پراکسی سیستم — کل دستگاه" },
   "settings.routing.proxyOnly": { en: "Proxy only — nothing is redirected", fa: "فقط پراکسی — چیزی تغییر نمی‌کند" },

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -746,6 +746,8 @@ export type WhiteVPNSettings = {
   dnsPrivacy: DNSPrivacySettings;
   killSwitch: KillSwitchSettings;
   language: string;
+  // The node traffic leaves from when chaining. Empty means one hop.
+  chainExitNode: string;
   tunEnabled: boolean;
   setSystemProxy: boolean;
   allowLan: boolean;

--- a/desktop/internal/engine/chain_integration_test.go
+++ b/desktop/internal/engine/chain_integration_test.go
@@ -26,7 +26,7 @@ func TestTheEngineReadsAChainedConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("convert: %v", err)
 	}
-	proxiesYAML, err := mihomoconf.BuildProxiesYAMLWithChain(proxies, mihomoconf.SplitTunnel{}, mihomoconf.Chain{ExitNode: "Second Hop"})
+	proxiesYAML, _, err := mihomoconf.BuildProxiesYAMLWithChain(proxies, mihomoconf.SplitTunnel{}, mihomoconf.Chain{ExitNode: "Second Hop"})
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}

--- a/desktop/internal/engine/chain_integration_test.go
+++ b/desktop/internal/engine/chain_integration_test.go
@@ -1,0 +1,61 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"whitevpn-desktop/internal/mihomoconf"
+)
+
+// A chain is only real if the engine reads it. The generated shape leans on two
+// things being true of mihomo — that dialer-proxy may name a proxy group, and
+// that a group and a proxy share one namespace — and neither is worth assuming
+// from reading the source alone.
+func TestTheEngineReadsAChainedConfig(t *testing.T) {
+	links := strings.Join([]string{
+		"vless://11111111-2222-3333-4444-555555555555@a.example.com:443?security=tls&type=ws&path=%2Fws#First%20Hop",
+		"trojan://password@b.example.com:443?sni=b.example.com#Second%20Hop",
+		"vless://11111111-2222-3333-4444-555555555555@c.example.com:443?security=tls&type=grpc&serviceName=svc#Another",
+	}, "\n")
+
+	proxies, err := mihomoconf.ConvertLinks(links)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	proxiesYAML, err := mihomoconf.BuildProxiesYAMLWithChain(proxies, mihomoconf.SplitTunnel{}, mihomoconf.Chain{ExitNode: "Second Hop"})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	for _, want := range []string{
+		"dialer-proxy: " + mihomoconf.SelectGroup,
+		"MATCH," + mihomoconf.ChainExitName,
+	} {
+		if !strings.Contains(proxiesYAML, want) {
+			t.Fatalf("the chain is not in the config (%q missing):\n%s", want, proxiesYAML)
+		}
+	}
+
+	config := mihomoconf.Render(proxiesYAML, mihomoconf.Options{
+		Secret:     "validation-secret",
+		ProxyGroup: mihomoconf.SelectGroup,
+	})
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	proc := spawnReal(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := proc.Init(ctx, home, 36); err != nil {
+		t.Fatalf("initClash: %v", err)
+	}
+	if err := proc.ValidateConfig(ctx, configPath); err != nil {
+		t.Fatalf("the engine rejected the chained config: %v\n---\n%s", err, config)
+	}
+}

--- a/desktop/internal/mihomoconf/chain.go
+++ b/desktop/internal/mihomoconf/chain.go
@@ -1,0 +1,154 @@
+package mihomoconf
+
+// Sending traffic through two nodes instead of one.
+//
+// mihomo's dialer-proxy is what makes this possible: a proxy carrying it is
+// reached *through* the proxy it names, so naming the first hop on the second
+// produces local → first → second → internet. The name may be a group as well
+// as a node, because the engine keeps groups in the same map it looks proxies up
+// in — which means the first hop can stay the ordinary selection group, and
+// Automatic keeps working without being resolved to a fixed node first.
+//
+// The exit is rendered as a copy of the chosen node under a name of its own.
+// A copy, because the original stays in the selection group where the first hop
+// draws from, and one proxy cannot be both ends of the same chain.
+//
+// Two things are then not left to chance:
+//
+//   - The original is taken out of the first hop's choices. Otherwise the group
+//     could pick the very server the exit is, and the user would pay for two
+//     hops through one machine.
+//   - When the exit needs its dialer to carry UDP — WireGuard, Hysteria2, TUIC,
+//     anything over QUIC — the first hop's choices are narrowed to nodes that
+//     can. A chain assembled from a TCP-only first hop and a UDP exit builds,
+//     connects, and carries nothing.
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ChainExitName is what the second hop is called in the generated config.
+//
+// Fixed rather than derived from the node, so nothing downstream has to guess
+// it, and visible enough that somebody reading a config knows why a proxy has a
+// dialer-proxy on it.
+const ChainExitName = "WhiteVPN Exit"
+
+// Chain says whether traffic leaves through a second node, and which.
+type Chain struct {
+	// ExitNode is the name of the node traffic leaves from. Empty means no
+	// chaining, which is the ordinary single-hop configuration.
+	ExitNode string
+}
+
+// Active reports whether this chain does anything.
+func (c Chain) Active() bool { return strings.TrimSpace(c.ExitNode) != "" }
+
+// ChainError explains why a chain could not be built.
+//
+// Its own type because every one of these is something a person chose and can
+// choose differently, so the interface has to be able to say which.
+type ChainError struct {
+	Reason string
+}
+
+func (e *ChainError) Error() string { return e.Reason }
+
+// buildChain returns the exit proxy and the names the first hop may choose
+// from, or an error naming what the user has to change.
+func buildChain(proxies []Proxy, names []string, chain Chain) (Proxy, []string, error) {
+	exitName := strings.TrimSpace(chain.ExitNode)
+
+	var exit Proxy
+	for _, proxy := range proxies {
+		if proxy.Name() == exitName {
+			exit = proxy
+			break
+		}
+	}
+	if exit == nil {
+		return nil, nil, &ChainError{Reason: fmt.Sprintf(
+			"the node chosen as the second hop is not in this subscription any more: %q", exitName)}
+	}
+
+	// The first hop draws from everything else. Taking the exit out is what
+	// stops the group choosing the same server for both ends.
+	first := make([]string, 0, len(names))
+	for _, name := range names {
+		if name != exitName {
+			first = append(first, name)
+		}
+	}
+	if len(first) == 0 {
+		return nil, nil, &ChainError{Reason: "a chain needs a node for the first hop, and this subscription has only the one chosen as the second"}
+	}
+
+	if requiresUDPDialer(exit) {
+		capable := make([]string, 0, len(first))
+		byName := make(map[string]Proxy, len(proxies))
+		for _, proxy := range proxies {
+			byName[proxy.Name()] = proxy
+		}
+		for _, name := range first {
+			if supportsUDPDialing(byName[name]) {
+				capable = append(capable, name)
+			}
+		}
+		if len(capable) == 0 {
+			return nil, nil, &ChainError{Reason: fmt.Sprintf(
+				"%q carries its traffic over UDP, and no other node in this subscription can carry UDP for it — choose a different second hop", exitName)}
+		}
+		first = capable
+	}
+
+	// A copy: the original stays where the first hop draws from.
+	copied := make(Proxy, len(exit)+2)
+	for key, value := range exit {
+		copied[key] = value
+	}
+	copied["name"] = ChainExitName
+	copied["dialer-proxy"] = SelectGroup
+	return copied, first, nil
+}
+
+// requiresUDPDialer reports whether this proxy needs its dialer to carry UDP.
+//
+// The classification is the phone app's, which took it from what mihomo can
+// actually do: these protocols move their payload in datagrams, so a first hop
+// that only carries streams has nothing to hand them to.
+func requiresUDPDialer(proxy Proxy) bool {
+	switch proxyType(proxy) {
+	case "wireguard", "hysteria", "hysteria2", "hy2", "tuic", "juicity", "shadowquic":
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(stringField(proxy, "network"))) {
+	case "quic", "h3", "kcp", "mkcp":
+		return true
+	}
+	return false
+}
+
+// supportsUDPDialing reports whether this proxy can carry UDP for another.
+func supportsUDPDialing(proxy Proxy) bool {
+	if proxy == nil {
+		return false
+	}
+	if enabled, ok := proxy["udp"].(bool); ok && enabled {
+		return true
+	}
+	switch proxyType(proxy) {
+	case "hysteria", "hysteria2", "hy2", "tuic", "shadowquic", "openvpn":
+		return true
+	}
+	return false
+}
+
+func proxyType(proxy Proxy) string {
+	return strings.ToLower(strings.TrimSpace(stringField(proxy, "type")))
+}
+
+func stringField(proxy Proxy, key string) string {
+	value, _ := proxy[key].(string)
+	return value
+}

--- a/desktop/internal/mihomoconf/chain_candidates_test.go
+++ b/desktop/internal/mihomoconf/chain_candidates_test.go
@@ -1,0 +1,49 @@
+package mihomoconf
+
+import "testing"
+
+// What comes back is what the first hop may be, and a caller selecting a proxy
+// has to select from it. Naming the exit's own node, or a TCP node under a
+// datagram exit, would name one the group does not contain — and the failure
+// would arrive at connect time as the engine refusing a selection nobody could
+// see was invalid.
+func TestTheCandidatesReturnedAreWhatTheGroupActuallyHolds(t *testing.T) {
+	document, candidates, err := BuildProxiesYAMLWithChain(chainProxies(), SplitTunnel{}, Chain{ExitNode: "TCP Two"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = document
+
+	for _, name := range candidates {
+		if name == "TCP Two" {
+			t.Fatal("the exit's own node is not a first hop")
+		}
+	}
+	if len(candidates) != 3 {
+		t.Fatalf("expected the other three nodes, got %v", candidates)
+	}
+}
+
+// The datagram case: candidates and group membership have to agree, or the
+// session selects something the engine has never heard of.
+func TestTheCandidatesNarrowWithTheGroupForAUDPExit(t *testing.T) {
+	_, candidates, err := BuildProxiesYAMLWithChain(chainProxies(), SplitTunnel{}, Chain{ExitNode: "Wire One"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only the Hysteria2 node can carry UDP for it.
+	if len(candidates) != 1 || candidates[0] != "UDP One" {
+		t.Fatalf("expected only the UDP-capable node, got %v", candidates)
+	}
+}
+
+// Without a chain the candidates are simply everything, as they always were.
+func TestWithoutAChainEveryNodeIsACandidate(t *testing.T) {
+	_, candidates, err := BuildProxiesYAMLWithChain(chainProxies(), SplitTunnel{}, Chain{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 4 {
+		t.Fatalf("expected every node, got %v", candidates)
+	}
+}

--- a/desktop/internal/mihomoconf/chain_test.go
+++ b/desktop/internal/mihomoconf/chain_test.go
@@ -1,0 +1,205 @@
+package mihomoconf
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func chainProxies() []Proxy {
+	return []Proxy{
+		{"name": "TCP One", "type": "vless", "server": "a.example.com", "port": 443},
+		{"name": "TCP Two", "type": "trojan", "server": "b.example.com", "port": 443},
+		{"name": "UDP One", "type": "hysteria2", "server": "c.example.com", "port": 443},
+		// udp: true as parseWireGuard sets it. A WireGuard proxy relays UDP, so
+		// it can carry a datagram protocol for the hop above it.
+		{"name": "Wire One", "type": "wireguard", "server": "d.example.com", "port": 51820, "udp": true},
+	}
+}
+
+func renderChain(t *testing.T, chain Chain) map[string]any {
+	t.Helper()
+	out, err := BuildProxiesYAMLWithChain(chainProxies(), SplitTunnel{}, chain)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	var document map[string]any
+	if err := yaml.Unmarshal([]byte(out), &document); err != nil {
+		t.Fatalf("the generated config is not YAML: %v", err)
+	}
+	return document
+}
+
+func groupNamed(t *testing.T, document map[string]any, name string) map[string]any {
+	t.Helper()
+	groups, _ := document["proxy-groups"].([]any)
+	for _, entry := range groups {
+		group, _ := entry.(map[string]any)
+		if group["name"] == name {
+			return group
+		}
+	}
+	t.Fatalf("no group named %q", name)
+	return nil
+}
+
+func groupMembers(t *testing.T, document map[string]any, name string) []string {
+	t.Helper()
+	raw, _ := groupNamed(t, document, name)["proxies"].([]any)
+	out := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		out = append(out, entry.(string))
+	}
+	return out
+}
+
+// Without a chain nothing about the config changes.
+func TestNoChainLeavesTheConfigAsItWas(t *testing.T) {
+	document := renderChain(t, Chain{})
+	rules, _ := document["rules"].([]any)
+	if len(rules) == 0 || rules[len(rules)-1] != "MATCH,"+SelectGroup {
+		t.Fatalf("traffic should still leave through the selection group: %v", rules)
+	}
+	proxies, _ := document["proxies"].([]any)
+	if len(proxies) != 4 {
+		t.Fatalf("nothing should have been added: %d proxies", len(proxies))
+	}
+}
+
+// The exit reaches its own server through the selection group, so the group
+// stays the first hop and Automatic keeps working without being resolved to a
+// fixed node first.
+func TestTheExitDialsThroughTheSelectionGroup(t *testing.T) {
+	document := renderChain(t, Chain{ExitNode: "TCP Two"})
+
+	proxies, _ := document["proxies"].([]any)
+	var exit map[string]any
+	for _, entry := range proxies {
+		proxy, _ := entry.(map[string]any)
+		if proxy["name"] == ChainExitName {
+			exit = proxy
+		}
+	}
+	if exit == nil {
+		t.Fatalf("no exit proxy was rendered: %v", proxies)
+	}
+	if exit["dialer-proxy"] != SelectGroup {
+		t.Fatalf("the exit does not dial through the first hop: %v", exit)
+	}
+	// It is a copy of the chosen node, so it must still describe that server.
+	if exit["server"] != "b.example.com" || exit["type"] != "trojan" {
+		t.Fatalf("the exit is not the node that was chosen: %v", exit)
+	}
+
+	rules, _ := document["rules"].([]any)
+	if rules[len(rules)-1] != "MATCH,"+ChainExitName {
+		t.Fatalf("traffic should leave through the exit: %v", rules)
+	}
+}
+
+// The original stays in the config — the exit is a copy — but the first hop must
+// not be able to choose it, or both ends of the chain would be one machine.
+func TestTheFirstHopCannotChooseTheExitsServer(t *testing.T) {
+	document := renderChain(t, Chain{ExitNode: "TCP Two"})
+	for _, group := range []string{SelectGroup, AutoGroup} {
+		for _, member := range groupMembers(t, document, group) {
+			if member == "TCP Two" {
+				t.Errorf("%s can still choose the exit's own node", group)
+			}
+		}
+	}
+	// And the others are still available to it.
+	members := groupMembers(t, document, AutoGroup)
+	if len(members) != 3 {
+		t.Fatalf("the remaining nodes should all be first-hop candidates: %v", members)
+	}
+}
+
+// A chain of a TCP-only first hop and a UDP exit builds, connects, and carries
+// nothing. WireGuard and Hysteria2 move their payload in datagrams, so the hop
+// beneath them has to be able to carry those.
+func TestAUDPExitOnlyGetsFirstHopsThatCanCarryUDP(t *testing.T) {
+	for _, exitNode := range []string{"Wire One", "UDP One"} {
+		out, err := BuildProxiesYAMLWithChain(chainProxies(), SplitTunnel{}, Chain{ExitNode: exitNode})
+		if err != nil {
+			t.Fatalf("%s: %v", exitNode, err)
+		}
+		var document map[string]any
+		if err := yaml.Unmarshal([]byte(out), &document); err != nil {
+			t.Fatal(err)
+		}
+		for _, member := range groupMembers(t, document, AutoGroup) {
+			if strings.HasPrefix(member, "TCP") {
+				t.Errorf("%s needs UDP and %s cannot carry it", exitNode, member)
+			}
+		}
+	}
+}
+
+// And when nothing can carry it, that is said rather than built.
+func TestAUDPExitWithNoUDPCapableHopIsRefused(t *testing.T) {
+	tcpOnly := []Proxy{
+		{"name": "TCP One", "type": "vless", "server": "a.example.com", "port": 443},
+		{"name": "Wire One", "type": "wireguard", "server": "d.example.com", "port": 51820, "udp": true},
+	}
+	_, err := BuildProxiesYAMLWithChain(tcpOnly, SplitTunnel{}, Chain{ExitNode: "Wire One"})
+	if err == nil {
+		t.Fatal("a chain that cannot carry its own traffic should be refused")
+	}
+	var chainErr *ChainError
+	if !asChainError(err, &chainErr) {
+		t.Fatalf("the interface has to be able to tell this from a build failure: %T", err)
+	}
+	if !strings.Contains(err.Error(), "UDP") {
+		t.Fatalf("the message should say what is wrong: %v", err)
+	}
+}
+
+// A node chosen as the exit and then removed from the subscription.
+func TestAnExitThatIsGoneIsReported(t *testing.T) {
+	_, err := BuildProxiesYAMLWithChain(chainProxies(), SplitTunnel{}, Chain{ExitNode: "Not Here"})
+	if err == nil {
+		t.Fatal("choosing a node that no longer exists should be refused")
+	}
+	if !strings.Contains(err.Error(), "not in this subscription") {
+		t.Fatalf("the message should say why: %v", err)
+	}
+}
+
+// One node cannot be both ends of its own chain.
+func TestASubscriptionOfOneCannotBeChained(t *testing.T) {
+	one := []Proxy{{"name": "Only", "type": "vless", "server": "a.example.com", "port": 443}}
+	_, err := BuildProxiesYAMLWithChain(one, SplitTunnel{}, Chain{ExitNode: "Only"})
+	if err == nil {
+		t.Fatal("a chain needs two nodes")
+	}
+}
+
+func asChainError(err error, target **ChainError) bool {
+	for err != nil {
+		if chainErr, ok := err.(*ChainError); ok {
+			*target = chainErr
+			return true
+		}
+		unwrapper, ok := err.(interface{ Unwrap() error })
+		if !ok {
+			return false
+		}
+		err = unwrapper.Unwrap()
+	}
+	return false
+}
+
+// A proxy that says it does not relay UDP cannot carry a datagram protocol,
+// whatever its type. The claim is the proxy's own.
+func TestAProxyThatDoesNotRelayUDPIsNotOfferedAsAUDPHop(t *testing.T) {
+	proxies := []Proxy{
+		{"name": "No UDP", "type": "wireguard", "server": "a.example.com", "port": 51820, "udp": false},
+		{"name": "Wire One", "type": "wireguard", "server": "d.example.com", "port": 51820, "udp": true},
+	}
+	out, err := BuildProxiesYAMLWithChain(proxies, SplitTunnel{}, Chain{ExitNode: "Wire One"})
+	if err == nil {
+		t.Fatalf("the only other node cannot carry UDP, so this chain has no first hop:\n%s", out)
+	}
+}

--- a/desktop/internal/mihomoconf/chain_test.go
+++ b/desktop/internal/mihomoconf/chain_test.go
@@ -20,7 +20,7 @@ func chainProxies() []Proxy {
 
 func renderChain(t *testing.T, chain Chain) map[string]any {
 	t.Helper()
-	out, err := BuildProxiesYAMLWithChain(chainProxies(), SplitTunnel{}, chain)
+	out, _, err := BuildProxiesYAMLWithChain(chainProxies(), SplitTunnel{}, chain)
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestTheFirstHopCannotChooseTheExitsServer(t *testing.T) {
 // beneath them has to be able to carry those.
 func TestAUDPExitOnlyGetsFirstHopsThatCanCarryUDP(t *testing.T) {
 	for _, exitNode := range []string{"Wire One", "UDP One"} {
-		out, err := BuildProxiesYAMLWithChain(chainProxies(), SplitTunnel{}, Chain{ExitNode: exitNode})
+		out, _, err := BuildProxiesYAMLWithChain(chainProxies(), SplitTunnel{}, Chain{ExitNode: exitNode})
 		if err != nil {
 			t.Fatalf("%s: %v", exitNode, err)
 		}
@@ -143,7 +143,7 @@ func TestAUDPExitWithNoUDPCapableHopIsRefused(t *testing.T) {
 		{"name": "TCP One", "type": "vless", "server": "a.example.com", "port": 443},
 		{"name": "Wire One", "type": "wireguard", "server": "d.example.com", "port": 51820, "udp": true},
 	}
-	_, err := BuildProxiesYAMLWithChain(tcpOnly, SplitTunnel{}, Chain{ExitNode: "Wire One"})
+	_, _, err := BuildProxiesYAMLWithChain(tcpOnly, SplitTunnel{}, Chain{ExitNode: "Wire One"})
 	if err == nil {
 		t.Fatal("a chain that cannot carry its own traffic should be refused")
 	}
@@ -158,7 +158,7 @@ func TestAUDPExitWithNoUDPCapableHopIsRefused(t *testing.T) {
 
 // A node chosen as the exit and then removed from the subscription.
 func TestAnExitThatIsGoneIsReported(t *testing.T) {
-	_, err := BuildProxiesYAMLWithChain(chainProxies(), SplitTunnel{}, Chain{ExitNode: "Not Here"})
+	_, _, err := BuildProxiesYAMLWithChain(chainProxies(), SplitTunnel{}, Chain{ExitNode: "Not Here"})
 	if err == nil {
 		t.Fatal("choosing a node that no longer exists should be refused")
 	}
@@ -170,7 +170,7 @@ func TestAnExitThatIsGoneIsReported(t *testing.T) {
 // One node cannot be both ends of its own chain.
 func TestASubscriptionOfOneCannotBeChained(t *testing.T) {
 	one := []Proxy{{"name": "Only", "type": "vless", "server": "a.example.com", "port": 443}}
-	_, err := BuildProxiesYAMLWithChain(one, SplitTunnel{}, Chain{ExitNode: "Only"})
+	_, _, err := BuildProxiesYAMLWithChain(one, SplitTunnel{}, Chain{ExitNode: "Only"})
 	if err == nil {
 		t.Fatal("a chain needs two nodes")
 	}
@@ -198,7 +198,7 @@ func TestAProxyThatDoesNotRelayUDPIsNotOfferedAsAUDPHop(t *testing.T) {
 		{"name": "No UDP", "type": "wireguard", "server": "a.example.com", "port": 51820, "udp": false},
 		{"name": "Wire One", "type": "wireguard", "server": "d.example.com", "port": 51820, "udp": true},
 	}
-	out, err := BuildProxiesYAMLWithChain(proxies, SplitTunnel{}, Chain{ExitNode: "Wire One"})
+	out, _, err := BuildProxiesYAMLWithChain(proxies, SplitTunnel{}, Chain{ExitNode: "Wire One"})
 	if err == nil {
 		t.Fatalf("the only other node cannot carry UDP, so this chain has no first hop:\n%s", out)
 	}

--- a/desktop/internal/mihomoconf/config.go
+++ b/desktop/internal/mihomoconf/config.go
@@ -189,13 +189,20 @@ type Options struct {
 // rule, which is what a link-based subscription needs: links carry nodes and
 // nothing else, so without this there is nothing for traffic to match.
 func BuildProxiesYAML(proxies []Proxy, split SplitTunnel) (string, error) {
-	return BuildProxiesYAMLWithChain(proxies, split, Chain{})
+	document, _, err := BuildProxiesYAMLWithChain(proxies, split, Chain{})
+	return document, err
 }
 
 // BuildProxiesYAMLWithChain is BuildProxiesYAML, and optionally a second hop.
-func BuildProxiesYAMLWithChain(proxies []Proxy, split SplitTunnel, chain Chain) (string, error) {
+//
+// It also returns the names the first hop may be chosen from, which is not the
+// full list once a chain is in play: the exit's own node is taken out, and a
+// datagram exit narrows it further to nodes that can carry UDP. A caller
+// selecting a proxy has to select from these, or it would name one the group
+// does not contain.
+func BuildProxiesYAMLWithChain(proxies []Proxy, split SplitTunnel, chain Chain) (string, []string, error) {
 	if len(proxies) == 0 {
-		return "", fmt.Errorf("mihomoconf: no proxies to build a config from")
+		return "", nil, fmt.Errorf("mihomoconf: no proxies to build a config from")
 	}
 
 	// Names are the engine's key for a proxy, so a duplicate silently replaces
@@ -214,7 +221,7 @@ func BuildProxiesYAMLWithChain(proxies []Proxy, split SplitTunnel, chain Chain) 
 		names = append(names, name)
 	}
 	if len(unique) == 0 {
-		return "", fmt.Errorf("mihomoconf: no proxies with usable names")
+		return "", nil, fmt.Errorf("mihomoconf: no proxies with usable names")
 	}
 
 	// Where traffic leaves. Without a chain that is the selection group itself;
@@ -225,7 +232,7 @@ func BuildProxiesYAMLWithChain(proxies []Proxy, split SplitTunnel, chain Chain) 
 	if chain.Active() {
 		exit, allowed, err := buildChain(unique, names, chain)
 		if err != nil {
-			return "", err
+			return "", nil, err
 		}
 		unique = append(unique, exit)
 		firstHopNames = allowed
@@ -256,9 +263,9 @@ func BuildProxiesYAMLWithChain(proxies []Proxy, split SplitTunnel, chain Chain) 
 
 	encoded, err := yaml.Marshal(document)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-	return string(encoded), nil
+	return string(encoded), firstHopNames, nil
 }
 
 // catchAllRules is what everything not matched already does.

--- a/desktop/internal/mihomoconf/config.go
+++ b/desktop/internal/mihomoconf/config.go
@@ -189,6 +189,11 @@ type Options struct {
 // rule, which is what a link-based subscription needs: links carry nodes and
 // nothing else, so without this there is nothing for traffic to match.
 func BuildProxiesYAML(proxies []Proxy, split SplitTunnel) (string, error) {
+	return BuildProxiesYAMLWithChain(proxies, split, Chain{})
+}
+
+// BuildProxiesYAMLWithChain is BuildProxiesYAML, and optionally a second hop.
+func BuildProxiesYAMLWithChain(proxies []Proxy, split SplitTunnel, chain Chain) (string, error) {
 	if len(proxies) == 0 {
 		return "", fmt.Errorf("mihomoconf: no proxies to build a config from")
 	}
@@ -212,13 +217,28 @@ func BuildProxiesYAML(proxies []Proxy, split SplitTunnel) (string, error) {
 		return "", fmt.Errorf("mihomoconf: no proxies with usable names")
 	}
 
+	// Where traffic leaves. Without a chain that is the selection group itself;
+	// with one it is the exit proxy, which reaches its own server through that
+	// group — so the group stays the first hop and Automatic keeps working.
+	exitTarget := SelectGroup
+	firstHopNames := names
+	if chain.Active() {
+		exit, allowed, err := buildChain(unique, names, chain)
+		if err != nil {
+			return "", err
+		}
+		unique = append(unique, exit)
+		firstHopNames = allowed
+		exitTarget = ChainExitName
+	}
+
 	document := map[string]any{
 		"proxies": toNodes(unique),
 		"proxy-groups": []any{
 			map[string]any{
 				"name":    SelectGroup,
 				"type":    "select",
-				"proxies": append([]string{AutoGroup}, names...),
+				"proxies": append([]string{AutoGroup}, firstHopNames...),
 			},
 			map[string]any{
 				"name":      AutoGroup,
@@ -226,12 +246,12 @@ func BuildProxiesYAML(proxies []Proxy, split SplitTunnel) (string, error) {
 				"url":       DelayTestURL,
 				"interval":  autoInterval,
 				"tolerance": autoTolerance,
-				"proxies":   names,
+				"proxies":   firstHopNames,
 			},
 		},
 		// Split-tunnel rules first, because mihomo takes the first rule that
 		// fits: a catch-all above them means nothing below is ever reached.
-		"rules": append(split.Rules(SelectGroup), catchAllRules(split)...),
+		"rules": append(split.Rules(exitTarget), catchAllRules(split, exitTarget)...),
 	}
 
 	encoded, err := yaml.Marshal(document)
@@ -247,11 +267,11 @@ func BuildProxiesYAML(proxies []Proxy, split SplitTunnel) (string, error) {
 // mean the second is dead — and the dead one would be the one saying everything
 // goes through the tunnel, which is exactly the line someone reading the config
 // to answer "why is this not tunnelled" would stop at.
-func catchAllRules(split SplitTunnel) []string {
+func catchAllRules(split SplitTunnel, target string) []string {
 	if split.Catches() {
 		return nil
 	}
-	return []string{"MATCH," + SelectGroup}
+	return []string{"MATCH," + target}
 }
 
 // toNodes puts the identifying fields first so a config is readable when someone

--- a/desktop/internal/model/whitevpn_settings.go
+++ b/desktop/internal/model/whitevpn_settings.go
@@ -118,6 +118,16 @@ type WhiteVPNSettings struct {
 	// shown Persian will assume the app is broken.
 	Language string `json:"language"`
 
+	// ChainExitNode sends traffic through a second node before it leaves.
+	//
+	// The node named here becomes the exit; the connection chosen on the VPN
+	// page becomes the hop beneath it, Automatic included. Empty means one hop,
+	// which is what everybody gets until they ask for otherwise.
+	//
+	// A name rather than an index, because a subscription refresh reorders the
+	// list and an index would quietly come to mean a different server.
+	ChainExitNode string `json:"chainExitNode"`
+
 	// Tunnel. Not a phone setting: there, VpnService always provides the tunnel.
 	// Here it can be turned off, and off is the only mode that works without
 	// Administrator.
@@ -278,6 +288,7 @@ func NormalizeWhiteVPNSettings(settings WhiteVPNSettings) WhiteVPNSettings {
 	settings.Connection.Node = strings.TrimSpace(settings.Connection.Node)
 	settings.Connection.Types = nonEmptyStrings(lowered(settings.Connection.Types))
 	settings.Language = strings.TrimSpace(settings.Language)
+	settings.ChainExitNode = strings.TrimSpace(settings.ChainExitNode)
 
 	// A port outside the range, or one of the reserved low ones no ordinary
 	// program may bind, becomes the default rather than reaching the engine and

--- a/desktop/internal/session/session.go
+++ b/desktop/internal/session/session.go
@@ -36,6 +36,15 @@ type Options struct {
 	// phone on the same hotspot reaches this desktop's connection.
 	AllowLAN bool
 
+	// Chain sends traffic through a second node before the internet. Empty means
+	// one hop, which is the ordinary case.
+	//
+	// Only the link-based path honours it. A subscription that arrives as a whole
+	// mihomo document brings its own groups and rules, and rewriting somebody
+	// else's routing to insert a hop is a different and much larger promise than
+	// the one this makes.
+	Chain mihomoconf.Chain
+
 	DNSPrivacy  mihomoconf.DNSPrivacyMode
 	DoHURL      string
 	DoTEndpoint string
@@ -688,15 +697,16 @@ func PrepareConfig(opts Options) (string, []string, error) {
 		}
 		// Share links, which is what the WhiteDNS catalogue is. They carry nodes
 		// only, so the groups and rule have to be generated around them.
-		document, buildErr := mihomoconf.BuildProxiesYAML(proxies, opts.SplitTunnel)
+		document, firstHop, buildErr := mihomoconf.BuildProxiesYAMLWithChain(proxies, opts.SplitTunnel, opts.Chain)
 		if buildErr != nil {
 			return "", nil, buildErr
 		}
 		proxiesYAML = document
-		candidates = make([]string, 0, len(proxies))
-		for _, proxy := range proxies {
-			candidates = append(candidates, proxy.Name())
-		}
+		// What the first hop may be, which is not every node once a chain is in
+		// play: the exit's own is taken out so both ends cannot be one machine,
+		// and a datagram exit narrows it to nodes that can carry UDP. Selecting
+		// outside this would name a proxy the group does not contain.
+		candidates = append([]string(nil), firstHop...)
 		if len(opts.Prefer) > 0 {
 			preferred := intersect(candidates, opts.Prefer)
 			if len(preferred) == 0 {

--- a/desktop/mihomo_connect.go
+++ b/desktop/mihomo_connect.go
@@ -119,6 +119,7 @@ func (a *App) startWhiteDNSVPNWithMihomo() (model.AppState, error) {
 		HomeDir:      homeDir,
 		MixedPort:    mixedPort,
 		AllowLAN:     settings.AllowLAN,
+		Chain:        mihomoconf.Chain{ExitNode: settings.ChainExitNode},
 		Subscription: subscription,
 		Prefer:       prefer,
 		// Nodes the user hid never reach the configuration, so the engine cannot


### PR DESCRIPTION
Step 4 of the plan, and the largest. Independent of [#58](https://github.com/WhiteDNS/WhiteVPN-Desktop/pull/58) and [#59](https://github.com/WhiteDNS/WhiteVPN-Desktop/pull/59).

## How it is built, and why not the way the phone builds it

mihomo's `dialer-proxy` makes chaining possible: a proxy carrying it is reached *through* the proxy it names.

The phone resolves the first hop to a fixed node before rendering and writes only the chosen chain into the config. **The desktop does not have to**, because mihomo keeps groups in the same map it looks proxies up in:

```go
proxies[groupName] = adapter.NewProxy(group)
```

So `dialer-proxy` may name a **group**, and the first hop stays the ordinary selection group. Automatic goes on working without being resolved to a node beforehand, and a first hop that fails is replaced by the group rather than by a reconnect.

The exit is a copy of the chosen node under a fixed name — the original stays where the first hop draws from, and one proxy cannot be both ends of a chain.

## Two things not left to chance

**The original is removed from the first hop's choices.** Otherwise the group could pick the very server the exit is, and the user pays for two hops through one machine.

**A datagram exit narrows the first hop to nodes that can carry UDP.** WireGuard, Hysteria2, TUIC, anything over QUIC. A TCP-only first hop under a datagram exit **builds, connects, and carries nothing** — the worst way to find out. Where no node can carry it, that is said rather than built, as an error type the interface can tell from a build failure: every one of these is something a person chose and can choose differently.

The phone validates the same rule and reports it on a fixed pair; here the choice is a group, so narrowing it is what that rule looks like.

## The bug this surfaced

The builder now returns **which names the first hop may be**, and the session takes its candidates from that. It was deriving them from the full node list — so a user whose chosen node was also the exit would have had a proxy selected that the group no longer contained, and found out at connect, from the engine, about a selection nothing in the interface showed as invalid.

## Scope

- **Link-based subscriptions only.** One arriving as a whole mihomo document brings its own groups and rules; rewriting somebody else's routing to insert a hop is a larger promise than this makes.
- Stored as a **name, not an index** — a refresh reorders the list and an index would come to mean a different server without anybody touching it.
- A node chosen and later gone is reported in Settings, where it can still be changed, as well as refused at connect.

## Verification

Full Go suite, `go vet`, frontend typecheck and build green. Tests cover the rendered shape, both refusals, the UDP narrowing in both directions, and that the returned candidates match what the group actually holds.

`TestTheEngineReadsAChainedConfig` asks the shipping binary to read the result, because the shape rests on two claims about mihomo not worth assuming from its source.

**It proves the config parses.** `dialer-proxy` is resolved at dial time, so whether the chain actually carries traffic needs a live server — no test here reaches that. Worth testing on a build before release, and worth knowing that the phone shipped this without validating it against live servers either (their PR says so).