### PR TITLE
Put the machine's proxy back, or say that it was not

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -232,6 +232,7 @@ function normalizeRuntime(runtime: RuntimeStatus): RuntimeStatus {
     publicProxyIp: runtime.publicProxyIp || "",
     frontingIp: runtime.frontingIp || "",
     systemProxy: Boolean(runtime.systemProxy),
+    systemProxyStranded: Boolean(runtime.systemProxyStranded),
     exitIp: runtime.exitIp || "",
     nodeName: runtime.nodeName || "",
     nodeCountryCode: runtime.nodeCountryCode || "",
@@ -2430,6 +2431,18 @@ function WhiteDNSVPNPage({
         onMeasure={(names) => void measureDelays(names)}
         onReload={() => void loadNodes(true)}
       />
+
+      {/* Shown whatever the connection is doing, because this is not about the
+          connection: the engine has stopped and the machine is still pointed at
+          it, so nothing on this desktop can reach the internet. A user who is
+          told only "Disconnected" has no reason to look for that. */}
+      {runtime.systemProxyStranded && (
+        <Alert variant="destructive">
+          <AlertCircle />
+          <AlertTitle>{t("vpn.systemProxy.stranded")}</AlertTitle>
+          <AlertDescription>{t("vpn.systemProxy.stranded.description")}</AlertDescription>
+        </Alert>
+      )}
 
       {otherRuntimeActive && (
         <Alert>

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -608,6 +608,14 @@ const strings = {
     en: "How traffic reaches your machine.",
     fa: "اینکه ترافیک چطور به دستگاه شما می‌رسد.",
   },
+  "vpn.systemProxy.stranded": {
+    en: "This machine's proxy settings were not put back",
+    fa: "تنظیمات پراکسی این دستگاه به حالت قبل برنگشت",
+  },
+  "vpn.systemProxy.stranded.description": {
+    en: "The connection has stopped, but this desktop is still pointed at it, so nothing here can reach the internet. Connecting again will fix it, and so will restarting the app — on macOS both ask for your administrator password, which is what has to be approved for the settings to go back.",
+    fa: "اتصال قطع شده، ولی این دستگاه هنوز به آن اشاره می‌کند و برای همین هیچ برنامه‌ای به اینترنت نمی‌رسد. اتصال دوباره این را درست می‌کند، راه‌اندازی مجدد برنامه هم همین‌طور — روی مک هر دو رمز مدیر را می‌پرسند، و همان چیزی است که باید تأیید شود تا تنظیمات برگردد.",
+  },
   "settings.chain.title": { en: "Connection chaining", fa: "زنجیره کردن اتصال" },
   "settings.chain.description": {
     en: "Send traffic through a second node before it reaches the internet. The connection chosen on the VPN page becomes the first hop; the node chosen here becomes the one traffic leaves from.",

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -304,6 +304,10 @@ export interface RuntimeStatus {
   frontingIp: string;
   // Whether the machine has been pointed at the local proxy.
   systemProxy: boolean;
+  // The machine is still pointed at this app's proxy after the engine carrying
+  // it has stopped. Separate from systemProxy because the connection being down
+  // and the machine being given back are different facts.
+  systemProxyStranded: boolean;
   // The node carrying traffic, and where its own name says it is.
   nodeName: string;
   nodeCountryCode: string;

--- a/desktop/internal/model/types.go
+++ b/desktop/internal/model/types.go
@@ -307,6 +307,16 @@ type RuntimeStatus struct {
 	// traffic and one that is merely running is not otherwise visible.
 	SystemProxy bool `json:"systemProxy"`
 
+	// SystemProxyStranded says the machine is still pointed at this app's proxy
+	// after the engine carrying it has stopped.
+	//
+	// Its own fact rather than a status, because the two are independent and
+	// were being reported as one: the connection is genuinely down, and the
+	// machine genuinely cannot reach the internet, and a user told only the first
+	// has no reason to look for the second. It stays true until a restore is
+	// read back and confirmed.
+	SystemProxyStranded bool `json:"systemProxyStranded"`
+
 	// The node carrying traffic, and where it says it is: the name the catalogue
 	// gave it, and the country from the flag in that name.
 	NodeName        string `json:"nodeName"`

--- a/desktop/internal/sysproxy/sysproxy.go
+++ b/desktop/internal/sysproxy/sysproxy.go
@@ -45,3 +45,24 @@ func (s State) SameAs(other State) bool {
 		strings.EqualFold(s.Server, other.Server) &&
 		strings.EqualFold(s.Override, other.Override)
 }
+
+// Satisfies reports whether a state read back from the machine is the state
+// that was asked for.
+//
+// Not SameAs, because turning a proxy off is not the same question as turning
+// one on. Both platforms keep the address behind when they disable a proxy —
+// networksetup holds on to the host and port it was last given, WinINET to its
+// server string — so a machine that was correctly put back reads as
+// {Enabled:false, Server:"127.0.0.1:2080"} when what was asked for was
+// {Enabled:false}. Comparing the address there would call a restore that worked
+// a failure, and tell a user their settings are stranded while they are looking
+// at a working network.
+//
+// When the proxy is meant to be off, that it is off is the whole of it. The
+// address left behind is inert.
+func (s State) Satisfies(want State) bool {
+	if !want.Enabled {
+		return !s.Enabled
+	}
+	return s.SameAs(want)
+}

--- a/desktop/internal/sysproxy/sysproxy_darwin.go
+++ b/desktop/internal/sysproxy/sysproxy_darwin.go
@@ -94,7 +94,7 @@ func verifyServices(services []string, want State, read func(string) (State, err
 		if err != nil {
 			return fmt.Errorf("sysproxy: verify %s: %w", service, err)
 		}
-		if got.Enabled != want.Enabled || !strings.EqualFold(got.Server, want.Server) {
+		if !got.Satisfies(want) {
 			return fmt.Errorf("sysproxy: %s did not stick — asked for %q (enabled=%t), found %q (enabled=%t)",
 				service, want.Server, want.Enabled, got.Server, got.Enabled)
 		}

--- a/desktop/internal/sysproxy/sysproxy_test.go
+++ b/desktop/internal/sysproxy/sysproxy_test.go
@@ -47,3 +47,41 @@ func indexOf(haystack, needle string) int {
 	}
 	return -1
 }
+
+// Turning a proxy off and turning one on are not the same question.
+//
+// Both platforms keep the address behind when they disable a proxy, so a machine
+// that was correctly put back reads as disabled-but-still-addressed. Comparing
+// the address there reported every successful restore as a failure — which,
+// once restore started trusting the answer, would have stranded every user whose
+// settings were "no proxy" to begin with.
+func TestSatisfiesIgnoresTheAddressLeftBehindByTurningItOff(t *testing.T) {
+	want := State{Enabled: false}
+	leftBehind := State{Enabled: false, Server: "127.0.0.1:2080", Override: DefaultBypass}
+
+	if !leftBehind.Satisfies(want) {
+		t.Fatal("a machine with the proxy off satisfies being asked to turn it off")
+	}
+	if leftBehind.SameAs(want) {
+		t.Fatal("SameAs is the stricter question and should still see a difference")
+	}
+	if (State{Enabled: true, Server: "127.0.0.1:2080"}).Satisfies(want) {
+		t.Fatal("a proxy that is still on does not satisfy being asked to turn it off")
+	}
+}
+
+// Being asked to turn one on stays as strict as it was: the address is the
+// whole point of the request.
+func TestSatisfiesStaysStrictWhenAProxyWasAskedFor(t *testing.T) {
+	want := State{Enabled: true, Server: "127.0.0.1:2080", Override: DefaultBypass}
+
+	if !want.Satisfies(want) {
+		t.Fatal("the state that was asked for satisfies the request")
+	}
+	if (State{Enabled: true, Server: "127.0.0.1:9999", Override: DefaultBypass}).Satisfies(want) {
+		t.Fatal("a different address must not pass as the one that was asked for")
+	}
+	if (State{Enabled: false, Server: "127.0.0.1:2080", Override: DefaultBypass}).Satisfies(want) {
+		t.Fatal("a proxy that was written but not switched on must not pass")
+	}
+}

--- a/desktop/internal/sysproxy/sysproxy_windows.go
+++ b/desktop/internal/sysproxy/sysproxy_windows.go
@@ -123,7 +123,7 @@ func Verify(want State) error {
 	if err != nil {
 		return err
 	}
-	if !got.SameAs(want) {
+	if !got.Satisfies(want) {
 		return fmt.Errorf("sysproxy: the settings did not stick — asked for %q (enabled=%t), found %q (enabled=%t)",
 			want.Server, want.Enabled, got.Server, got.Enabled)
 	}

--- a/desktop/system_proxy.go
+++ b/desktop/system_proxy.go
@@ -9,6 +9,16 @@ import (
 	"whitevpn-desktop/internal/sysproxy"
 )
 
+// The machine-facing calls, as variables so the paths that go wrong can be
+// tested. Restoring badly is the failure that matters here, and reproducing it
+// against the real ones would mean a test that reconfigures the developer's own
+// network.
+var (
+	systemProxyCurrent = sysproxy.Current
+	systemProxyApply   = sysproxy.Apply
+	systemProxyVerify  = sysproxy.Verify
+)
+
 // The machine's proxy settings, as they were before this app changed them.
 //
 // On disk, because a crash is exactly when they matter: the process that would
@@ -36,29 +46,42 @@ func (a *App) captureSystemProxy(port int) error {
 	if err != nil {
 		return err
 	}
-	previous, err := sysproxy.Current()
-	if err != nil {
-		return err
-	}
 
-	// The record of what was there goes down before anything is changed. A
-	// failure after this point leaves a machine that can be put back; a failure
-	// before it changes nothing.
-	if err := a.writeSystemProxyBackup(previous); err != nil {
-		return fmt.Errorf("could not record the current settings first: %w", err)
+	// A backup already on disk is the last run's, and it is left alone.
+	//
+	// Its presence means the machine was never given back: a restore that
+	// failed, a dismissed administrator prompt, a process that died. What the
+	// machine holds now is this app's own proxy, so reading it and filing it as
+	// "what was there before" would overwrite the only record of the user's real
+	// settings with a local port. Every restore after that would put the machine
+	// back to 127.0.0.1, delete the record, and report success — which is how a
+	// disconnect came to leave macOS pointed at a proxy nothing was listening on.
+	previous, held := a.readSystemProxyBackup()
+	if !held {
+		// The record of what was there goes down before anything is changed. A
+		// failure after this point leaves a machine that can be put back; a
+		// failure before it changes nothing.
+		previous, err = systemProxyCurrent()
+		if err != nil {
+			return err
+		}
+		if err := a.writeSystemProxyBackup(previous); err != nil {
+			return fmt.Errorf("could not record the current settings first: %w", err)
+		}
 	}
-	if err := sysproxy.Apply(next); err != nil {
+	if err := systemProxyApply(next); err != nil {
 		return err
 	}
 	// Read back rather than assume. Another program can be writing the same
 	// key, and a badge claiming the machine uses this proxy when it does not is
 	// worse than no badge.
-	if err := sysproxy.Verify(next); err != nil {
+	if err := systemProxyVerify(next); err != nil {
 		return err
 	}
 
 	a.mu.Lock()
 	a.state.Runtime.SystemProxy = true
+	a.state.Runtime.SystemProxyStranded = false
 	a.mu.Unlock()
 	a.appendRuntimeLog(fmt.Sprintf(
 		"system proxy set to %s, replacing %q (enabled=%t)", endpoint, previous.Server, previous.Enabled))
@@ -72,17 +95,49 @@ func (a *App) restoreSystemProxy() {
 	if !ok {
 		return
 	}
-	if err := sysproxy.Apply(previous); err != nil {
+	if err := systemProxyApply(previous); err != nil {
 		// The backup stays: a restore that failed is one that still has to
 		// happen, and the next start will try again.
-		a.appendRuntimeLog(fmt.Sprintf("could not restore the system proxy: %v", err))
+		a.strandedSystemProxy(fmt.Sprintf("could not restore the system proxy: %v", err))
+		return
+	}
+	// Read back, the same way capturing does, and for a sharper reason. On macOS
+	// this runs through an administrator prompt: osascript reports whether it
+	// managed to ask, not whether the answer changed anything, so a dismissed
+	// prompt can return an error the caller never sees as one. Deleting the
+	// backup on an unverified restore is what turns a recoverable state into a
+	// permanent one.
+	if err := systemProxyVerify(previous); err != nil {
+		a.strandedSystemProxy(fmt.Sprintf("the system proxy did not go back: %v", err))
 		return
 	}
 	_ = os.Remove(a.systemProxyBackupPath())
 	a.mu.Lock()
 	a.state.Runtime.SystemProxy = false
+	a.state.Runtime.SystemProxyStranded = false
 	a.mu.Unlock()
 	a.appendRuntimeLog("system proxy restored")
+}
+
+// strandedSystemProxy records that the machine is still pointed at a proxy this
+// app is no longer running.
+//
+// The engine really has stopped, so the connection is disconnected and says so.
+// What has not happened is the machine being given back, and those are different
+// facts: reporting only the first leaves somebody with no working network and
+// nothing on screen that explains it. The backup is deliberately left where it
+// is — startup tries again, and until it succeeds this is the only record of
+// what the settings were.
+func (a *App) strandedSystemProxy(reason string) {
+	a.appendRuntimeLog(reason)
+	a.mu.Lock()
+	a.state.Runtime.SystemProxy = true
+	a.state.Runtime.SystemProxyStranded = true
+	a.mu.Unlock()
+	a.appendRuntimeLog(
+		"this machine is still pointed at a proxy that has stopped — reconnect, or restart the app to try again")
+	a.emit("runtime:notice",
+		"Disconnected, but this desktop's proxy settings could not be put back. Its network will not work until they are. Reconnect, or restart the app to try again.")
 }
 
 func (a *App) writeSystemProxyBackup(state sysproxy.State) error {

--- a/desktop/system_proxy_test.go
+++ b/desktop/system_proxy_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -50,5 +51,147 @@ func TestRestoringWithNoBackupChangesNothing(t *testing.T) {
 	app.restoreSystemProxy()
 	if !app.state.Runtime.SystemProxy {
 		t.Fatal("with no backup there is nothing to restore, and nothing to report")
+	}
+}
+
+// The failure this file exists for.
+//
+// A restore that did not happen leaves the machine pointed at this app and the
+// backup on disk. Connecting again must not read that back and file it as "what
+// was there before": the only record of the user's real settings would become a
+// local port, and every restore after it would put the machine back to a proxy
+// nothing is listening on and then delete the evidence.
+func TestConnectingAgainDoesNotOverwriteAnUnusedBackup(t *testing.T) {
+	app := &App{state: model.DefaultAppState(), configDir: t.TempDir()}
+
+	original := sysproxy.State{Enabled: true, Server: "proxy.corp.example:8080", Override: "<local>"}
+	if err := app.writeSystemProxyBackup(original); err != nil {
+		t.Fatal(err)
+	}
+
+	// What the machine holds now is this app's own proxy, left behind by a
+	// restore that failed.
+	defer swapSystemProxyCalls(t,
+		func() (sysproxy.State, error) {
+			return sysproxy.State{Enabled: true, Server: "127.0.0.1:2080"}, nil
+		},
+		func(sysproxy.State) error { return nil },
+		func(sysproxy.State) error { return nil },
+	)()
+
+	if err := app.captureSystemProxy(2080); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := app.readSystemProxyBackup()
+	if !ok {
+		t.Fatal("the backup was removed by a capture that should not have touched it")
+	}
+	if !got.SameAs(original) {
+		t.Fatalf("the user's settings were overwritten with this app's own proxy: got %#v, want %#v", got, original)
+	}
+}
+
+// A restore the machine refused is not a restore. The backup is what makes
+// another attempt possible, so it stays, and the state says the machine is
+// still pointed somewhere that has stopped answering.
+func TestRefusedRestoreKeepsTheBackupAndSaysSo(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		apply  func(sysproxy.State) error
+		verify func(sysproxy.State) error
+	}{
+		{
+			// macOS asks for an administrator password here. Dismissing it is
+			// the ordinary way this fails.
+			name:   "the machine refused the change",
+			apply:  func(sysproxy.State) error { return errors.New("administrator approval failed") },
+			verify: func(sysproxy.State) error { return nil },
+		},
+		{
+			// osascript reports whether it managed to ask, not whether anything
+			// changed, so success has to be read back rather than believed.
+			name:   "the change was accepted but did not stick",
+			apply:  func(sysproxy.State) error { return nil },
+			verify: func(sysproxy.State) error { return errors.New("Wi-Fi did not stick") },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &App{state: model.DefaultAppState(), configDir: t.TempDir()}
+			var notices []string
+			app.emitHook = func(name string, payload any) {
+				if name == "runtime:notice" {
+					notices = append(notices, payload.(string))
+				}
+			}
+			original := sysproxy.State{Enabled: false}
+			if err := app.writeSystemProxyBackup(original); err != nil {
+				t.Fatal(err)
+			}
+			defer swapSystemProxyCalls(t, nil, tc.apply, tc.verify)()
+
+			app.restoreSystemProxy()
+
+			if _, ok := app.readSystemProxyBackup(); !ok {
+				t.Fatal("the backup was deleted, so nothing can ever put these settings back")
+			}
+			if !app.state.Runtime.SystemProxyStranded {
+				t.Fatal("the machine is still pointed at a stopped proxy and the state does not say so")
+			}
+			if !app.state.Runtime.SystemProxy {
+				t.Fatal("the proxy is still set on the machine, so the state must not claim otherwise")
+			}
+			if len(notices) == 0 {
+				t.Fatal("a user whose network has stopped working was told nothing")
+			}
+		})
+	}
+}
+
+// The ordinary case, which has to keep working: the settings go back, they read
+// back as gone, and the record of them is no longer needed.
+func TestConfirmedRestoreClearsTheBackupAndTheWarning(t *testing.T) {
+	app := &App{state: model.DefaultAppState(), configDir: t.TempDir()}
+	app.state.Runtime.SystemProxy = true
+	app.state.Runtime.SystemProxyStranded = true
+	if err := app.writeSystemProxyBackup(sysproxy.State{Enabled: false}); err != nil {
+		t.Fatal(err)
+	}
+	defer swapSystemProxyCalls(t, nil,
+		func(sysproxy.State) error { return nil },
+		func(sysproxy.State) error { return nil },
+	)()
+
+	app.restoreSystemProxy()
+
+	if _, ok := app.readSystemProxyBackup(); ok {
+		t.Fatal("a confirmed restore has nothing left to put back, so the backup should be gone")
+	}
+	if app.state.Runtime.SystemProxy || app.state.Runtime.SystemProxyStranded {
+		t.Fatal("the machine was given back, so neither flag should still be set")
+	}
+}
+
+// swapSystemProxyCalls puts test doubles in front of the machine and returns the
+// function that puts the real ones back. A nil double keeps the current one.
+func swapSystemProxyCalls(
+	t *testing.T,
+	current func() (sysproxy.State, error),
+	apply func(sysproxy.State) error,
+	verify func(sysproxy.State) error,
+) func() {
+	t.Helper()
+	previousCurrent, previousApply, previousVerify := systemProxyCurrent, systemProxyApply, systemProxyVerify
+	if current != nil {
+		systemProxyCurrent = current
+	}
+	if apply != nil {
+		systemProxyApply = apply
+	}
+	if verify != nil {
+		systemProxyVerify = verify
+	}
+	return func() {
+		systemProxyCurrent, systemProxyApply, systemProxyVerify = previousCurrent, previousApply, previousVerify
 	}
 }


### PR DESCRIPTION
Fixes a bug in the shipped v1.0.18: on macOS, disconnecting could leave the machine pointed at a proxy that had stopped listening, and nothing on that desktop could reach the internet until it was found by hand.

## What was happening

Restoring the proxy on macOS runs through an administrator prompt, which a user who is merely disconnecting has no reason to expect and can dismiss. That failure was logged and otherwise ignored:

1. Disconnect → `sysproxy.Apply` fails → status still goes to disconnected, backup stays on disk
2. Next connect → `captureSystemProxy` reads the machine's *current* settings — this app's own proxy, still set — and files them as "what was there before"
3. The only record of the user's real settings is now `127.0.0.1:7890`
4. From then on every restore puts the machine back to that, deletes the record, and reports success

## What changed

- **The backup is written once and never overwritten while it is still needed.** Its presence means the machine was never given back, so what is on the machine now is not the user's settings.
- **A restore is read back before it is believed.** `osascript` reports whether it managed to ask, not whether the answer changed anything.
- **A restore that did not happen keeps the backup**, because that file is what makes another attempt possible.
- **`Verify` learned that turning a proxy off is a different question from turning one on.** Both platforms keep the address behind when they disable a proxy, so a machine that was correctly put back reads as disabled-but-still-addressed. The old comparison would have called every successful restore a failure — stranding every user whose settings were "no proxy" to begin with, which is most of them. This is the reason the new `State.Satisfies` exists rather than reusing `SameAs`.
- **Whether the machine was given back is now its own fact**, separate from whether the connection is up. The two were reported as one, and a user told only "Disconnected" has no reason to look for the second thing. A banner says so where it can still be acted on, and names the administrator prompt as what has to be approved.

## Testing

Five new tests. Verified they fail against the old behaviour:

```
--- FAIL: TestConnectingAgainDoesNotOverwriteAnUnusedBackup
--- FAIL: TestRefusedRestoreKeepsTheBackupAndSaysSo/the_change_was_accepted_but_did_not_stick
```

Full suite green, `go vet` clean, `GOOS=darwin` build and vet of `internal/...` clean.

## What still needs a Mac

The darwin code is pure Go and cross-compiles here, but the behaviour was not exercised on macOS. The claim that `networksetup` leaves the address behind when disabling a proxy was reasoned from the code rather than observed — `Satisfies` is correct either way, since it does not read the address when the target is "off", but **someone with a Mac should confirm that a normal disconnect no longer shows the stranded banner.**

## Users already affected

Anyone whose backup was already poisoned will have their settings restored to `127.0.0.1` once more on the next successful restore, after which the record is deleted and the loop breaks. Their original settings are not recoverable — they will need to turn the proxy off by hand once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)