### PR TITLE
Keep the last subscription that worked, and connect from it

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -81,6 +81,11 @@ type App struct {
 	lastFirewallStatusKey string
 	emitHook              func(name string, payload any)
 
+	// fetchSubscriptionHook stands in for the network when there is one, so the
+	// snapshot fallback can be tested against a provider that fails without a
+	// test that depends on one being unreachable.
+	fetchSubscriptionHook func(ctx context.Context, id string) (string, error)
+
 	proxyCountryMu    sync.Mutex
 	proxyCountryCache map[string]proxyCountryCacheEntry
 }

--- a/desktop/subscription_snapshot.go
+++ b/desktop/subscription_snapshot.go
@@ -1,0 +1,177 @@
+package main
+
+// The last subscription body that worked, kept where a restart can find it.
+//
+// Connecting fetched the subscription every time and had nowhere else to go
+// when the fetch failed. For an app whose whole purpose is reaching a network
+// that is being interfered with, that is the wrong way round: the provider being
+// unreachable is the ordinary case, not the exceptional one, and it was enough
+// to make a machine holding a perfectly good node list from ten minutes ago
+// unable to connect at all.
+//
+// So a body that parsed is written down, and a fetch that fails falls back to
+// it. Three things this is careful about, each of which was a way to lose the
+// only good copy:
+//
+//   - Content is compiled before it is stored. A provider answering with an
+//     error page, a captive portal, or half a document must not replace a
+//     snapshot that works.
+//   - Valid means it parses and yields at least one node. A timestamp cannot
+//     make a broken document fresh, and a file that reads as zero nodes is not
+//     a subscription with no servers — it is a file that is wrong.
+//   - A stored snapshot that no longer parses is thrown away rather than
+//     returned. Whatever corrupted it — a half-written file from a power cut, a
+//     disk that lied — is not something to keep serving to the engine.
+//
+// This is deliberately not a cache in front of the network. A refresh still
+// goes out and still reports what it finds. The snapshot is only consulted when
+// the answer would otherwise be nothing at all.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"whitevpn-desktop/internal/model"
+)
+
+// snapshotOrigin says where a body came from, which the caller needs in order
+// to be honest about it: content served from a failed refresh must not be
+// reported as freshly fetched.
+type snapshotOrigin string
+
+const (
+	// originRefreshed is a body that was just fetched and parsed.
+	originRefreshed snapshotOrigin = "refreshed"
+	// originLastKnownGood is the stored body, returned because fetching failed.
+	originLastKnownGood snapshotOrigin = "last-known-good"
+)
+
+// subscriptionSnapshot is one stored body and when it was fetched.
+type subscriptionSnapshot struct {
+	// SubscriptionID is written so a file found on its own can be identified,
+	// and so a name collision between two hashes cannot serve one subscription's
+	// nodes under another's.
+	SubscriptionID string `json:"subscriptionId"`
+	FetchedAt      string `json:"fetchedAt"`
+	Body           string `json:"body"`
+	// NodeCount is what the body held when it was stored. Kept for the log line
+	// that tells a user how old the list they are looking at is and how big it
+	// was, without having to parse the body to say so.
+	NodeCount int `json:"nodeCount"`
+}
+
+func (a *App) subscriptionSnapshotDir() string {
+	return filepath.Join(a.configDir, "subscriptions")
+}
+
+// subscriptionSnapshotPath names the file for a subscription.
+//
+// Hashed because a subscription id is a URL as often as it is a name, and a URL
+// contains everything a filename may not. The id inside the file is what
+// identifies it; this only has to be stable and unique.
+func (a *App) subscriptionSnapshotPath(id string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(id)))
+	return filepath.Join(a.subscriptionSnapshotDir(), hex.EncodeToString(sum[:16])+".json")
+}
+
+// storeSubscriptionSnapshot writes a body that has already been shown to parse.
+//
+// The caller compiles first and passes the count it got. Doing the parsing here
+// would be the same work twice, and taking the caller's word for it is safe
+// because the only caller is the one that just did it.
+func (a *App) storeSubscriptionSnapshot(id string, body string, nodeCount int) error {
+	if nodeCount <= 0 {
+		// Refused rather than stored empty. A body that yields nothing is not a
+		// subscription that has no servers today; it is a body that is wrong,
+		// and storing it would overwrite the last one that was right.
+		return fmt.Errorf("subscription snapshot: refusing to store a body with no nodes")
+	}
+	encoded, err := json.Marshal(subscriptionSnapshot{
+		SubscriptionID: strings.TrimSpace(id),
+		FetchedAt:      time.Now().UTC().Format(time.RFC3339),
+		Body:           body,
+		NodeCount:      nodeCount,
+	})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(a.subscriptionSnapshotDir(), 0o755); err != nil {
+		return err
+	}
+	// Written beside and renamed over, so a process that dies mid-write leaves
+	// the previous snapshot whole rather than a truncated file that parses as
+	// nothing.
+	path := a.subscriptionSnapshotPath(id)
+	tmp := fmt.Sprintf("%s.%d.tmp", path, time.Now().UnixNano())
+	if err := os.WriteFile(tmp, encoded, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// lastKnownGoodSubscription returns the stored body for a subscription, if there
+// is one and it still holds nodes.
+//
+// A file that cannot be read, cannot be parsed, belongs to a different
+// subscription, or no longer yields a node is removed. Keeping it would mean
+// answering every failed fetch with something known to be useless, forever.
+func (a *App) lastKnownGoodSubscription(id string) (subscriptionSnapshot, bool) {
+	id = strings.TrimSpace(id)
+	path := a.subscriptionSnapshotPath(id)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return subscriptionSnapshot{}, false
+	}
+	var snapshot subscriptionSnapshot
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		a.discardSubscriptionSnapshot(id, "it could not be read")
+		return subscriptionSnapshot{}, false
+	}
+	if strings.TrimSpace(snapshot.SubscriptionID) != id {
+		a.discardSubscriptionSnapshot(id, "it belongs to a different subscription")
+		return subscriptionSnapshot{}, false
+	}
+	// Checked against the body rather than trusted from the file. What was
+	// written was valid; what is on disk now is a separate question, and this is
+	// the one place that can tell the difference.
+	nodes, err := whiteVPNNodesFromSubscription(snapshot.Body)
+	if err != nil || len(nodes) == 0 {
+		a.discardSubscriptionSnapshot(id, "it no longer holds any servers")
+		return subscriptionSnapshot{}, false
+	}
+	snapshot.NodeCount = len(nodes)
+	return snapshot, true
+}
+
+// discardSubscriptionSnapshot removes a stored body that turned out not to be
+// usable, and says so where a user can see it.
+func (a *App) discardSubscriptionSnapshot(id string, reason string) {
+	_ = os.Remove(a.subscriptionSnapshotPath(id))
+	a.appendRuntimeLog(fmt.Sprintf(
+		"the saved copy of %q was discarded because %s — it will be fetched again", id, reason))
+}
+
+// forgetSubscriptionSnapshot removes a subscription's stored body, for a
+// subscription the user deleted.
+func (a *App) forgetSubscriptionSnapshot(id string) {
+	_ = os.Remove(a.subscriptionSnapshotPath(id))
+}
+
+// subscriptionIsStorable reports whether a subscription's body is worth keeping.
+//
+// The manual list is not: it is built out of the user's own stored configs every
+// time it is asked for, so it cannot fail to be available and a second copy of
+// it could only go stale.
+func subscriptionIsStorable(id string) bool {
+	return strings.TrimSpace(id) != model.ManualServerSourceID
+}

--- a/desktop/subscription_snapshot_test.go
+++ b/desktop/subscription_snapshot_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"whitevpn-desktop/internal/model"
+)
+
+// A provider that cannot be reached is the ordinary case for this app, not the
+// exceptional one. Before this, it meant a machine holding a good node list from
+// ten minutes ago could not connect at all.
+func TestAFailedFetchFallsBackToTheLastBodyThatWorked(t *testing.T) {
+	app := newSnapshotTestApp(t)
+
+	app.fetchSubscriptionHook = func(context.Context, string) (string, error) {
+		return subscriptionLinks, nil
+	}
+	body, origin, err := app.resolveSubscriptionBody(context.Background(), "provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if origin != originRefreshed || body != subscriptionLinks {
+		t.Fatalf("a successful fetch should be reported as fetched: got origin %q", origin)
+	}
+
+	app.fetchSubscriptionHook = func(context.Context, string) (string, error) {
+		return "", errors.New("dial tcp: i/o timeout")
+	}
+	body, origin, err = app.resolveSubscriptionBody(context.Background(), "provider")
+	if err != nil {
+		t.Fatalf("the stored body should have answered this: %v", err)
+	}
+	if origin != originLastKnownGood {
+		t.Fatalf("content served from a failed refresh must not be reported as fetched: got %q", origin)
+	}
+	if body != subscriptionLinks {
+		t.Fatal("the body that came back is not the one that was stored")
+	}
+}
+
+// The failure mode that loses the only good copy: a provider that answers, but
+// not with a subscription. A captive portal's login page is still a 200.
+func TestAnUnparseableBodyNeverReplacesAGoodOne(t *testing.T) {
+	app := newSnapshotTestApp(t)
+
+	app.fetchSubscriptionHook = func(context.Context, string) (string, error) {
+		return subscriptionLinks, nil
+	}
+	if _, _, err := app.resolveSubscriptionBody(context.Background(), "provider"); err != nil {
+		t.Fatal(err)
+	}
+
+	app.fetchSubscriptionHook = func(context.Context, string) (string, error) {
+		return "<html><body>Please sign in to this network</body></html>", nil
+	}
+	body, origin, err := app.resolveSubscriptionBody(context.Background(), "provider")
+	if err != nil {
+		t.Fatalf("the previous body was still good and should have been used: %v", err)
+	}
+	if origin != originLastKnownGood || body != subscriptionLinks {
+		t.Fatal("a login page replaced a working subscription")
+	}
+
+	stored, ok := app.lastKnownGoodSubscription("provider")
+	if !ok || stored.Body != subscriptionLinks {
+		t.Fatal("the stored copy was overwritten by content that does not parse")
+	}
+}
+
+// Nothing is stored until it has been shown to hold servers, and a body that
+// holds none is not a subscription with no servers today — it is a wrong file.
+func TestABodyWithNoServersIsNotStored(t *testing.T) {
+	app := newSnapshotTestApp(t)
+	if err := app.storeSubscriptionSnapshot("provider", "proxies: []\n", 0); err == nil {
+		t.Fatal("expected an empty body to be refused")
+	}
+	if _, ok := app.lastKnownGoodSubscription("provider"); ok {
+		t.Fatal("nothing should have been written")
+	}
+}
+
+// A stored file that no longer parses is thrown away rather than served. Keeping
+// it would answer every failed fetch with something known to be useless.
+func TestACorruptStoredBodyIsDiscardedRatherThanServed(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		written string
+	}{
+		{"the file is not readable at all", "{ this is not json"},
+		{"the file is readable but holds no subscription", `{"subscriptionId":"provider","body":"<html>login</html>","nodeCount":7}`},
+		{"the file belongs to another subscription", `{"subscriptionId":"somebody-else","body":"` + strings.ReplaceAll(subscriptionLinks, "\n", `\n`) + `"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			app := newSnapshotTestApp(t)
+			if err := os.MkdirAll(app.subscriptionSnapshotDir(), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			path := app.subscriptionSnapshotPath("provider")
+			if err := os.WriteFile(path, []byte(tc.written), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, ok := app.lastKnownGoodSubscription("provider"); ok {
+				t.Fatal("a body that cannot be used was served anyway")
+			}
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Fatal("expected the unusable file to be removed so it is fetched again")
+			}
+		})
+	}
+}
+
+// The manual list is built from the user's own configs every time it is asked
+// for. It cannot fail to be available, so a second copy could only go stale.
+func TestTheManualListIsNeverStored(t *testing.T) {
+	app := newSnapshotTestApp(t)
+	app.fetchSubscriptionHook = func(context.Context, string) (string, error) {
+		return subscriptionLinks, nil
+	}
+	if _, _, err := app.resolveSubscriptionBody(context.Background(), model.ManualServerSourceID); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := app.lastKnownGoodSubscription(model.ManualServerSourceID); ok {
+		t.Fatal("the manual list should not have been written to disk")
+	}
+}
+
+// With nothing stored, a failed fetch still fails. The fallback is a second
+// answer, not a way of never reporting the first.
+func TestAFailedFetchWithNothingStoredStillFails(t *testing.T) {
+	app := newSnapshotTestApp(t)
+	app.fetchSubscriptionHook = func(context.Context, string) (string, error) {
+		return "", errors.New("dial tcp: i/o timeout")
+	}
+	if _, _, err := app.resolveSubscriptionBody(context.Background(), "provider"); err == nil {
+		t.Fatal("expected the fetch failure to be reported when there is nothing to fall back to")
+	}
+}
+
+// A subscription the user removed must not leave its servers behind.
+func TestDeletingASubscriptionRemovesItsStoredBody(t *testing.T) {
+	app := newSnapshotTestApp(t)
+	if err := app.storeSubscriptionSnapshot("provider", subscriptionLinks, 2); err != nil {
+		t.Fatal(err)
+	}
+	app.forgetSubscriptionSnapshot("provider")
+	if _, ok := app.lastKnownGoodSubscription("provider"); ok {
+		t.Fatal("the stored body outlived the subscription it belonged to")
+	}
+}
+
+func newSnapshotTestApp(t *testing.T) *App {
+	t.Helper()
+	return &App{state: model.DefaultAppState(), configDir: t.TempDir()}
+}

--- a/desktop/v2ray.go
+++ b/desktop/v2ray.go
@@ -333,6 +333,9 @@ func (a *App) DeleteV2RaySubscription(id string) (model.AppState, error) {
 		return profile.SubscriptionID == id
 	})
 	a.forgetWhiteVPNNodes(id)
+	// The stored body goes too. A subscription the user removed must not leave a
+	// copy of its servers behind for something to fall back to later.
+	a.forgetSubscriptionSnapshot(id)
 	return a.saveLocked()
 }
 

--- a/desktop/whitedns_vpn.go
+++ b/desktop/whitedns_vpn.go
@@ -219,7 +219,62 @@ func (a *App) subscriptionBody(ctx context.Context) (string, error) {
 
 // subscriptionBodyFor fetches one by name, which is what lets the Servers page
 // look at a subscription the VPN is not connecting through.
+//
+// A body that arrives and parses is stored; a fetch that fails falls back to the
+// last one that did. See subscription_snapshot.go for why the fallback is worth
+// having and what it refuses to store.
 func (a *App) subscriptionBodyFor(ctx context.Context, id string) (string, error) {
+	body, origin, err := a.resolveSubscriptionBody(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	if origin == originLastKnownGood {
+		// Said plainly rather than left to be inferred from a node list that
+		// looks normal. Connecting on a list from yesterday is usually right and
+		// occasionally why a node that no longer exists is being dialled.
+		a.appendRuntimeLog(fmt.Sprintf(
+			"%s could not be fetched — using the last copy that worked", id))
+	}
+	return body, nil
+}
+
+// resolveSubscriptionBody is subscriptionBodyFor, and where the body came from.
+func (a *App) resolveSubscriptionBody(ctx context.Context, id string) (string, snapshotOrigin, error) {
+	fetch := a.fetchSubscriptionBodyFor
+	if a.fetchSubscriptionHook != nil {
+		fetch = a.fetchSubscriptionHook
+	}
+	body, err := fetch(ctx, id)
+	if !subscriptionIsStorable(id) {
+		return body, originRefreshed, err
+	}
+	if err == nil {
+		// Compiled before it is stored, so a captive portal's login page or a
+		// half-served document cannot replace a snapshot that works. A body that
+		// arrives and does not parse is a failed fetch by another name, and is
+		// treated as one.
+		if nodes, parseErr := whiteVPNNodesFromSubscription(body); parseErr == nil && len(nodes) > 0 {
+			if storeErr := a.storeSubscriptionSnapshot(id, body, len(nodes)); storeErr != nil {
+				// Not fatal. The body in hand is good and the connection can be
+				// made from it; what failed is being able to make the next one
+				// without the network.
+				a.appendRuntimeLog(fmt.Sprintf("could not save a copy of %q: %v", id, storeErr))
+			}
+			return body, originRefreshed, nil
+		} else if parseErr != nil {
+			err = fmt.Errorf("subscription unreadable: %w", parseErr)
+		} else {
+			err = fmt.Errorf("subscription held no servers")
+		}
+	}
+	if snapshot, ok := a.lastKnownGoodSubscription(id); ok {
+		return snapshot.Body, originLastKnownGood, nil
+	}
+	return "", originRefreshed, err
+}
+
+// fetchSubscriptionBodyFor goes to wherever this subscription actually lives.
+func (a *App) fetchSubscriptionBodyFor(ctx context.Context, id string) (string, error) {
 	if id == model.ManualServerSourceID {
 		a.mu.Lock()
 		manualProfiles := make([]model.V2RayProfile, 0, len(a.state.V2RayProfiles))


### PR DESCRIPTION
Brings the desktop in line with the phone's **Subscription Snapshot resolution** spec (`docs/specs/unify-subscription-snapshot-resolution.md`, WhiteVPN v1.6.2) — the "last healthy subscription is kept" and "corrupt subscription files are detected and re-fetched" items from the Android changelog.

## Why

Connecting fetched the subscription every time and had nowhere to go when the fetch failed:

```go
// mihomo_connect.go
subscription, err := a.subscriptionBody(ctx)
if err != nil {
    a.reportConnectFailure(ctx, err.Error())   // the whole connect fails
```

There was **no on-disk cache of the subscription body at all** — the only cache was the parsed node list, held in memory, which dies with the process. For an app whose purpose is reaching a network that is being interfered with, this is the wrong way round: the provider being unreachable is the ordinary case, and it was enough to stop a machine holding a good node list from ten minutes ago connecting at all.

## What changed

A body that arrives and parses is written down; a fetch that fails falls back to it.

The fallback is a second answer, not a way of never reporting the first: **with nothing stored, a failed fetch still fails**, and a body served from disk is reported as `originLastKnownGood` and said so in the log — connecting on a list from yesterday is usually right and occasionally why a node that no longer exists is being dialled.

Three things it refuses to do, each of which was a way to lose the only good copy:

| Rule | Why |
|---|---|
| Compile before persist | A captive portal's login page or a half-served document must not replace a snapshot that works. A provider answering with something that is not a subscription is a failed fetch by another name. |
| Never store a body with no nodes | That is not a subscription with no servers today, it is a file that is wrong — and a timestamp cannot make it fresh. |
| Compile stored content again on the way out | Whatever corrupted it since — a half-written file from a power cut, a disk that lied — is discarded and re-fetched rather than handed to the engine. |

The manual list is left out: it is built from the user's own configs every time it is asked for, so it cannot fail to be available and a second copy could only go stale. A deleted subscription takes its stored body with it.

## Testing

Seven new tests. The compile-before-persist guarantee is the subtle one, so it was mutation-tested — removing the check makes it fail:

```
--- FAIL: TestAnUnparseableBodyNeverReplacesAGoodOne
```

Full suite green, `go vet` clean.

## Not included

The UI does not yet show that a node list came from disk rather than the network — it is only in the runtime log. An "last updated: 2 hours ago" indicator is a design decision rather than part of this fix, so it was left out deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)