### PR TITLE
Offer a reset that keeps what a reset should keep

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -6571,6 +6571,17 @@ function WhiteVPNSettingsPage({
         <UpdateCheckRow t={t} />
       </SettingsSection>
 
+      {/* The reversible one first. Both are called "reset", and the one that
+          keeps your subscriptions is the one almost everybody wants — putting
+          it second would have people reaching past it for the one that does
+          not. */}
+      <SettingsSection
+        title={t("settings.resetSettings.title")}
+        description={t("settings.resetSettings.description")}
+      >
+        <ResetSettingsRow onState={onState} onError={onError} onSuccess={onSuccess} t={t} />
+      </SettingsSection>
+
       <SettingsSection title={t("settings.reset.title")} description={t("settings.reset.description")}>
         <ResetAppDataRow onState={onState} onError={onError} onSuccess={onSuccess} t={t} />
       </SettingsSection>
@@ -6585,6 +6596,73 @@ function WhiteVPNSettingsPage({
 // version and wants to see it should not have to wait out that cache, so this
 // forces it — and then says what it found, including that it could not look,
 // which on these networks is a normal answer rather than an error.
+// Putting the settings back without taking anything with them.
+//
+// Behind a confirmation like its destructive neighbour, but the dialog's work is
+// the opposite one: not warning that this cannot be undone, but saying plainly
+// what it will not touch. The two sit next to each other and are both called
+// "reset", so the difference has to be on screen rather than in the name.
+function ResetSettingsRow({
+  onState,
+  onError,
+  onSuccess,
+  t,
+}: {
+  onState: (next: AppState) => void;
+  onError: (message: string) => void;
+  onSuccess: (message: string) => void;
+  t: TranslateFn;
+}) {
+  const [asking, setAsking] = useState(false);
+  const [working, setWorking] = useState(false);
+
+  async function reset() {
+    if (working) {
+      return;
+    }
+    onError("");
+    setWorking(true);
+    try {
+      onState(await backend.resetWhiteVpnSettings());
+      setAsking(false);
+      onSuccess(t("settings.resetSettings.done"));
+    } catch (err) {
+      onError(messageFromError(err));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  return (
+    <>
+      <div>
+        <Button variant="outline" onClick={() => setAsking(true)}>
+          <RotateCcw />
+          {t("settings.resetSettings.button")}
+        </Button>
+      </div>
+
+      <Dialog open={asking} onOpenChange={(open) => !open && !working && setAsking(false)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t("settings.resetSettings.confirm.title")}</DialogTitle>
+            <DialogDescription>{t("settings.resetSettings.confirm.body")}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAsking(false)} disabled={working}>
+              {t("common.cancel")}
+            </Button>
+            <Button onClick={() => void reset()} disabled={working}>
+              <RotateCcw />
+              {working ? t("settings.resetSettings.working") : t("settings.resetSettings.button")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
 // Deleting everything the app has stored.
 //
 // Behind a confirmation because it cannot be undone and nothing is backed up

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -546,6 +546,22 @@ const strings = {
   // Putting the app back to a fresh install. It exists because a bug that only
   // shows on a first launch is invisible to everyone who has already used the
   // app — which was all of us until a user on a clean install found one.
+  "settings.resetSettings.title": { en: "Reset settings", fa: "بازنشانی تنظیمات" },
+  "settings.resetSettings.description": {
+    en: "Put every setting back to its default. Subscriptions, saved configs, hidden nodes and measured delays are kept, and a connection that is up stays up.",
+    fa: "همهٔ تنظیمات به حالت پیش‌فرض برمی‌گردند. اشتراک‌ها، کانفیگ‌های ذخیره‌شده، سرورهای مخفی‌شده و نتیجهٔ تست‌ها می‌مانند، و اتصالی که برقرار است قطع نمی‌شود.",
+  },
+  "settings.resetSettings.button": { en: "Reset settings", fa: "بازنشانی تنظیمات" },
+  "settings.resetSettings.confirm.title": { en: "Reset every setting?", fa: "همهٔ تنظیمات بازنشانی شود؟" },
+  "settings.resetSettings.confirm.body": {
+    en: "The country, the chosen server, connection types, split tunnelling, DNS, the kill switch, the second hop, the language and the theme all go back to their defaults, and the built-in catalogue is selected again. Nothing is deleted: your subscriptions, saved configs and test results stay, and a connection that is up is left alone. Settings that only apply at connect take effect the next time you connect.",
+    fa: "کشور، سرور انتخاب‌شده، نوع اتصال، تونل جداگانه، DNS، کیل‌سوییچ، هاپ دوم، زبان و پوستهٔ برنامه همه به پیش‌فرض برمی‌گردند و دوباره کاتالوگ داخلی انتخاب می‌شود. چیزی پاک نمی‌شود: اشتراک‌ها، کانفیگ‌های ذخیره‌شده و نتیجهٔ تست‌ها می‌مانند و اتصال برقرار دست‌نخورده می‌ماند. تنظیماتی که فقط موقع اتصال اثر دارند، از اتصال بعدی اعمال می‌شوند.",
+  },
+  "settings.resetSettings.working": { en: "Resetting…", fa: "در حال بازنشانی…" },
+  "settings.resetSettings.done": {
+    en: "Settings are back to their defaults. Your subscriptions, configs and test results were kept.",
+    fa: "تنظیمات به حالت پیش‌فرض برگشت. اشتراک‌ها، کانفیگ‌ها و نتیجهٔ تست‌ها حفظ شدند.",
+  },
   "settings.reset.title": { en: "Reset", fa: "بازنشانی" },
   "settings.reset.description": {
     en: "Delete everything this app has saved and start again as if it were newly installed.",

--- a/desktop/frontend/src/wails.ts
+++ b/desktop/frontend/src/wails.ts
@@ -85,6 +85,7 @@ type AppApi = {
   AcceptPrivacyPolicy(): Promise<AppState>;
   GetAppVersion(): Promise<string>;
   ResetAppData(): Promise<AppState>;
+  ResetWhiteVPNSettings(): Promise<AppState>;
   CheckForUpdate(force: boolean): Promise<UpdateStatus>;
   GetLocalProxyEndpoint(): Promise<string>;
   ListWhiteVPNNodes(refresh: boolean): Promise<WhiteVPNNodeList>;
@@ -184,6 +185,7 @@ export const backend = {
   acceptPrivacyPolicy: () => app().AcceptPrivacyPolicy(),
   getAppVersion: () => app().GetAppVersion(),
   resetAppData: () => app().ResetAppData(),
+  resetWhiteVpnSettings: () => app().ResetWhiteVPNSettings(),
   checkForUpdate: (force: boolean) => app().CheckForUpdate(force),
   getLocalProxyEndpoint: () => app().GetLocalProxyEndpoint(),
   listWhiteVpnNodes: (refresh: boolean) => app().ListWhiteVPNNodes(refresh),

--- a/desktop/reset.go
+++ b/desktop/reset.go
@@ -113,3 +113,52 @@ func removeConfigDirContents(dir string) error {
 	}
 	return nil
 }
+
+// ResetWhiteVPNSettings puts the settings back to a fresh install's and leaves
+// everything else where it is.
+//
+// Separate from ResetAppData, which deletes everything and refuses to run while
+// anything is connected. That is the right tool for "put this machine back to
+// the day it was installed" and the wrong one for every ordinary case: somebody
+// who has narrowed the connection down to one node, turned on a fronting IP and
+// changed the DNS mode while chasing a problem wants those undone, and does not
+// want to lose the subscriptions they pasted in, the delays they spent ten
+// minutes measuring, or the connection they are reading the instructions over.
+//
+// So this touches settings and only settings. Subscriptions, imported and manual
+// configs, hidden nodes, measured delays and validator results are all left
+// alone, and a running connection keeps running: nothing here reaches the engine
+// or the session. Settings that only apply at connect — the listening port, the
+// tunnel — go back to their defaults and take effect the next time, which is the
+// same thing changing them by hand does.
+func (a *App) ResetWhiteVPNSettings() (model.AppState, error) {
+	defaults := model.DefaultWhiteVPNSettings()
+
+	a.mu.Lock()
+	// Consent is a record of something the user did, not a preference they
+	// configured. Clearing it would not put them back to a fresh install, it
+	// would claim they never agreed, and then ask them again — so it carries
+	// over.
+	defaults.AcceptedPrivacyPolicyVersion = a.state.WhiteVPN.AcceptedPrivacyPolicyVersion
+	// Run through the same normalisation a hand-edited save gets, so a default
+	// that this machine cannot honour — the tunnel, where there is no way to
+	// raise one — is corrected here rather than at connect.
+	a.state.WhiteVPN = settingsForThisMachine(model.NormalizeWhiteVPNSettings(defaults))
+	a.state.Theme = model.DefaultAppState().Theme
+	// Which subscription is selected is a setting, and the phone resets it the
+	// same way. The subscriptions themselves stay; only the choice of which one
+	// the VPN connects through goes back to the built-in catalogue.
+	a.state.SelectedSubscriptionID = whiteDNSVPNSubscriptionID
+	state, err := a.saveLocked()
+	a.mu.Unlock()
+
+	if err != nil {
+		return state, fmt.Errorf("reset settings: %w", err)
+	}
+	a.appendRuntimeLog("settings reset to their defaults — subscriptions, saved configs and test results were kept")
+	// The tray reads the language and the status from the same state the page
+	// does, so it is told rather than left to notice.
+	a.notifyTray()
+	a.emit("state:changed", state)
+	return state, nil
+}

--- a/desktop/reset_settings_test.go
+++ b/desktop/reset_settings_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"testing"
+
+	"whitevpn-desktop/internal/model"
+	"whitevpn-desktop/internal/profiles"
+)
+
+// The whole point of this reset is what it does not touch. Someone who narrowed
+// the connection down while chasing a problem wants that undone; they do not
+// want to lose the subscriptions they pasted in or the delays they measured.
+func TestResettingSettingsKeepsEverythingThatIsNotASetting(t *testing.T) {
+	app := newSettingsResetTestApp(t)
+
+	app.state.V2RaySubscriptions = []model.V2RaySubscription{
+		{ID: "provider", Name: "Provider", URL: "https://example.com/sub", ImportedCount: 12},
+	}
+	app.state.V2RayProfiles = []model.V2RayProfile{
+		{ID: "manual-1", Name: "My own server"},
+		{ID: "imported-1", Name: "Provider node", SubscriptionID: "provider"},
+	}
+	app.state.HiddenNodes = map[string][]string{"provider": {"A node they hid"}}
+
+	// And the settings that should go.
+	app.state.WhiteVPN.CountryCode = "NL"
+	app.state.WhiteVPN.Connection = model.ConnectionSelection{Node: "one node only", Types: []string{"vless"}}
+	app.state.WhiteVPN.DNSPrivacy = model.DNSPrivacySettings{Mode: model.DNSPrivacyDoH, DoHURL: "https://somewhere.example/dns"}
+	app.state.WhiteVPN.KillSwitch = model.KillSwitchSettings{Enabled: true}
+	app.state.WhiteVPN.ChainExitNode = "some exit"
+	app.state.WhiteVPN.Language = "fa"
+	app.state.Theme = "dark"
+
+	state, err := app.ResetWhiteVPNSettings()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(state.V2RaySubscriptions) != 1 {
+		t.Fatalf("the subscriptions were not kept: %d left", len(state.V2RaySubscriptions))
+	}
+	if len(state.V2RayProfiles) != 2 {
+		t.Fatalf("saved configs were not kept: %d left", len(state.V2RayProfiles))
+	}
+	if len(state.HiddenNodes["provider"]) != 1 {
+		t.Fatal("hidden nodes belong to a subscription and should have survived")
+	}
+
+	defaults := model.DefaultWhiteVPNSettings()
+	if state.WhiteVPN.CountryCode != defaults.CountryCode {
+		t.Fatal("the country was not reset")
+	}
+	if state.WhiteVPN.Connection.Node != "" || len(state.WhiteVPN.Connection.Types) != 0 {
+		t.Fatal("the narrowed connection selection was not reset")
+	}
+	if state.WhiteVPN.DNSPrivacy.Mode != defaults.DNSPrivacy.Mode {
+		t.Fatal("the DNS mode was not reset")
+	}
+	if state.WhiteVPN.KillSwitch.Enabled {
+		t.Fatal("the kill switch was not reset")
+	}
+	if state.WhiteVPN.ChainExitNode != "" {
+		t.Fatal("the second hop was not reset")
+	}
+	if state.WhiteVPN.Language != "" {
+		t.Fatal("the language was not reset")
+	}
+	if state.Theme != model.DefaultAppState().Theme {
+		t.Fatal("the theme was not reset")
+	}
+}
+
+// Consent is a record of something the user did, not a preference. Clearing it
+// would not put them back to a fresh install; it would claim they never agreed.
+func TestResettingSettingsDoesNotAskForConsentAgain(t *testing.T) {
+	app := newSettingsResetTestApp(t)
+	app.state.WhiteVPN.AcceptedPrivacyPolicyVersion = 3
+
+	state, err := app.ResetWhiteVPNSettings()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.WhiteVPN.AcceptedPrivacyPolicyVersion != 3 {
+		t.Fatal("a settings reset should not withdraw a consent that was given")
+	}
+}
+
+// Unlike the full reset, this one runs while connected and must leave the
+// session alone: somebody may well be reading the instructions over it.
+func TestResettingSettingsDoesNotTouchARunningConnection(t *testing.T) {
+	app := newSettingsResetTestApp(t)
+	app.state.Runtime.Status = model.RuntimeConnected
+	app.state.Runtime.Message = "Connected"
+	app.state.Runtime.ActiveConnectionID = "live"
+	app.state.Runtime.NodeName = "Tokyo"
+
+	state, err := app.ResetWhiteVPNSettings()
+	if err != nil {
+		t.Fatalf("a settings reset must not refuse while connected: %v", err)
+	}
+	if state.Runtime.Status != model.RuntimeConnected {
+		t.Fatalf("the connection was disturbed: status is now %q", state.Runtime.Status)
+	}
+	if state.Runtime.ActiveConnectionID != "live" || state.Runtime.NodeName != "Tokyo" {
+		t.Fatal("the running session's identity was cleared")
+	}
+}
+
+// The subscriptions stay; which one is selected is a setting, and goes back to
+// the built-in catalogue the way it does on the phone.
+func TestResettingSettingsSelectsTheCatalogueAgain(t *testing.T) {
+	app := newSettingsResetTestApp(t)
+	app.state.V2RaySubscriptions = []model.V2RaySubscription{
+		{ID: "provider", Name: "Provider", URL: "https://example.com/sub"},
+	}
+	app.state.SelectedSubscriptionID = "provider"
+
+	state, err := app.ResetWhiteVPNSettings()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.SelectedSubscriptionID != whiteDNSVPNSubscriptionID {
+		t.Fatalf("expected the catalogue to be selected, got %q", state.SelectedSubscriptionID)
+	}
+	if len(state.V2RaySubscriptions) != 1 {
+		t.Fatal("selecting the catalogue must not remove the subscription that was selected before")
+	}
+}
+
+func newSettingsResetTestApp(t *testing.T) *App {
+	t.Helper()
+	dir := t.TempDir()
+	store := profiles.NewStore(dir + "/state.json")
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &App{state: state, store: store, configDir: dir}
+}


### PR DESCRIPTION
The "Reset settings, without deleting subscriptions, test results, or dropping the active connection" item from the Android v1.6.2 changelog, following the phone's `AppSettingsResetter`.

## Why

There was one reset — `ResetAppData` — and it deletes everything, refuses to run while anything is connected, and cannot be undone. That is the right tool for putting a machine back to the day it was installed, and the wrong one for every ordinary case.

Somebody who has narrowed the connection down to one node, turned on a fronting IP and changed the DNS mode while chasing a problem wants those undone. They do not want to lose the subscriptions they pasted in, the configs they wrote by hand, the nodes they hid, the delays they spent ten minutes measuring, or the connection they are reading the instructions over.

Having nothing between "change fourteen things back by hand" and "delete everything" is why people pick the second and then ask where their subscriptions went.

## What it does

| Back to defaults | Left alone |
|---|---|
| Country, chosen server, connection types | Subscriptions and saved configs |
| Split tunnelling, DNS, kill switch | Hidden nodes |
| Second hop, language, theme | Test results and measured delays |
| Selected subscription → built-in catalogue | **A running connection** |

Nothing here reaches the engine or the session, which is what lets it run while connected. Settings that only apply at connect take effect the next time, the same way changing them by hand does.

## Two judgement calls worth reviewing

**Privacy policy consent carries over.** That is a record of something the user did rather than a preference they configured — clearing it would not put them back to a fresh install, it would claim they never agreed and then ask again.

**Hidden nodes stay.** Hiding a node is curation of a subscription's contents, and this promises not to touch subscriptions.

**The selected subscription does reset**, to the built-in catalogue, matching `AppSettingsResetter.reset` on the phone (`saveSelectedSubscriptionId(DEFAULT_SUBSCRIPTION_ID)`). The subscriptions themselves stay; only the choice of which one to connect through goes back.

## In the interface

The reversible one is listed **first**. Both are called "reset" and the one that keeps your subscriptions is the one almost everybody wants, so putting it second would have people reaching past it for the one that does not. The dialog's job is the opposite of its neighbour's: not warning that this cannot be undone, but saying plainly what it will not touch.

## Testing

Four new tests, all focused on what has to survive — including that it runs under `RuntimeConnected` and leaves the session's identity intact.

Backend and frontend both build, `tsc` clean, `go vet` clean, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)