### PR TITLE
Bump the remaining actions, in one commit rather than four

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
         # other platforms have to be here.
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26.5"
           cache-dependency-path: desktop/go.sum
@@ -90,8 +90,8 @@ jobs:
     name: Cross-compile
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26.5"
           cache-dependency-path: desktop/go.sum
@@ -113,7 +113,7 @@ jobs:
     name: Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: "24"
@@ -138,7 +138,7 @@ jobs:
     name: No secrets in source
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # The catalogue's key sat in a public file from the first commit until it
       # was moved into the build. Nothing stopped it going back except noticing,

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
 
@@ -93,7 +93,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26.5"
           cache: true
@@ -232,7 +232,7 @@ jobs:
       contents: write
     steps:
       - name: Download packages
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: release-assets
           merge-multiple: true
@@ -241,6 +241,6 @@ jobs:
         run: find release-assets -maxdepth 1 -type f -print | sort
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: release-assets/*


### PR DESCRIPTION
Supersedes #53, #54, #55 and #56.

## Why one commit

All four Dependabot PRs edit the same two workflow files, so merging any one puts the other three into conflict — #57 went in first and #56 immediately failed with `Pull Request has merge conflicts`. Taking them individually means four rebase-and-wait rounds for a handful of version strings.

The SHAs here are **Dependabot's own**, lifted from its pull requests rather than resolved by hand, so the pins are the ones it verified. It will close those four itself once it sees the versions already present.

## What changed

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 / `d23441a` | v7.0.1 / `3d3c42e` |
| `actions/setup-go` | v5 / `924ae3a` | v7.0.0 / `b7ad1da` |
| `actions/download-artifact` | `018cc2c` (v6) | v8.0.1 / `3e5f45b` |
| `softprops/action-gh-release` | `3bb1273` (v2) | v3.0.2 / `3d0d988` |

`ci.yml` uses tags, `desktop-release.yml` pins by SHA — both conventions kept as they were.

## Stale comments corrected

The release workflow's pins carried `# v6` and `# v2` against SHAs that are now v7 and v3. A comment that disagrees with the pin beside it is worse than no comment: the whole point of pinning by SHA is that the tag cannot be trusted, and the comment is the only thing telling a reader what they are looking at.

## Risk

Workflow-only — no product code. The failure mode is a red build, which is visible immediately rather than something users find. `actions/upload-artifact` is deliberately left alone; Dependabot has not offered it and its pin is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)