### PR TITLE
Build the engine in CI, so its tests stop standing aside

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,59 @@ jobs:
             GOOS="${target%/*}" GOARCH="${target#*/}" go build ./internal/...
           done
 
+  engine:
+    name: Engine
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "1.26.5"
+          cache-dependency-path: desktop/go.sum
+
+      # The engine is the one part of this system nothing automated ever
+      # touched. It is built from pinned mihomo and FlClash sources at package
+      # time, ships as a separate binary, and carries every byte of a user's
+      # traffic — and the five tests that talk to a real one skipped in CI,
+      # silently, because the binary was never there to talk to.
+      #
+      # That made a green tick on an engine version bump mean nothing about the
+      # engine. The tests exist and are good; they just had nothing to run
+      # against.
+      #
+      # Keyed on the setup script because that is where the versions are pinned,
+      # so moving MIHOMO_TAG or either commit rebuilds instead of quietly
+      # testing the old engine against the new pins — which would be worse than
+      # not testing at all.
+      - name: Cache the engine sources and binary
+        uses: actions/cache@v4
+        with:
+          path: |
+            desktop/third_party/flclash
+            desktop/cores
+          key: engine-${{ runner.os }}-${{ hashFiles('desktop/scripts/setup-mihomo-core.sh', 'desktop/scripts/build-mihomo-core.sh', 'desktop/scripts/patches/*.patch') }}
+
+      - name: Build the engine
+        working-directory: desktop
+        run: make mihomo-core TARGET_GOOS=linux TARGET_GOARCH=amd64
+
+      # Proves the binary is the one the tests will find, and says which version
+      # was built — so a log from a failed run identifies the engine without
+      # anyone having to work it out from the pins.
+      - name: Report what was built
+        working-directory: desktop
+        run: |
+          set -euo pipefail
+          ls -l cores/
+          ./cores/mihomo-linux-amd64 -v || true
+
+      # -run is deliberately absent: this runs the engine package's whole suite,
+      # so the tests that were skipping are simply no longer skipping.
+      - name: Test against the real engine
+        working-directory: desktop
+        run: go test -v ./internal/engine/
+
+
   frontend:
     name: Frontend
     runs-on: ubuntu-latest


### PR DESCRIPTION
The engine is the one part of this system nothing automated has ever touched.

## The gap

`mihomo` is built from pinned sources at package time, ships as a separate binary, and carries every byte of a user's traffic. Five tests talk to a real one:

| Test | What it proves |
|---|---|
| `TestGeneratedConfigIsReadableByTheEngine` | the config we generate parses |
| `TestTheEngineReadsAChainedConfig` | the two-hop config from v1.0.18 parses |
| `TestEngineRejectsUnparseableConfig` | a broken config is rejected, not silently accepted |
| `TestRealCoreAcceptsOurActionEncoding` | the wire encoding this app speaks is understood |
| `TestRealCoreLeavesUnknownMethodsUnanswered` | unknown methods do not hang it |

**Every one of them has been skipping in CI, silently.** `corePath` skips when the core binary is absent — correct on a developer's machine, and it meant that on the one machine that checks everything, the engine was checked by nothing.

Neither workflow ever built it:

```
grep mihomo .github/workflows/ci.yml              → nothing
grep mihomo .github/workflows/desktop-release.yml → nothing
```

It is built only inside `make prepare-embedded-core`, and only when `cores/` is empty.

## Why it matters right now

**A green tick on a pull request that moves `MIHOMO_TAG` says nothing about the engine.** It proves the desktop's Go code still compiles.

#58 moves that tag from v1.19.29 to v1.19.30, moves `FLCLASH_PATCH_COMMIT`, and adds a hand-resolved patch that reorders `updateNTP` and `updateDNS` — the DNS startup path. It also adds `amneziawg_integration_test.go`, which would have skipped too. That PR is currently unreviewable in the way that matters most.

## What this adds

An `Engine` job that builds the core for linux/amd64 and runs `go test ./internal/engine/` against it. No `-run` filter: the tests that were skipping simply stop skipping.

`CGO_ENABLED=0`, so it needs nothing but git and Go.

## The cache key is the point

Keyed on `setup-mihomo-core.sh`, `build-mihomo-core.sh` and `patches/*.patch` — where the versions are pinned. A bump to `MIHOMO_TAG` or either commit **rebuilds** rather than testing yesterday's engine against today's pins.

That failure mode would be worse than no testing at all, because it would look like coverage.

## What it still does not cover

It proves the engine starts, parses what we generate, and speaks our protocol. It does not prove traffic flows — that needs a live server. The open REALITY-in-mihomo problem is not addressed here either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)