### PR TITLE
Let the tray icon say whether traffic is being carried

### DIFF
--- a/desktop/tray.go
+++ b/desktop/tray.go
@@ -166,6 +166,8 @@ func (a *App) refreshTray() {
 	a.tray.show.SetTitle(words.show)
 	a.tray.quit.SetTitle(words.quit)
 	systray.SetTooltip(trayAppName + " — " + label)
+	// The colour says the same thing the tooltip does, without needing a hover.
+	systray.SetIcon(trayIconFor(state.Runtime.Status))
 
 	// Nothing to toggle while stopping, exactly as the button on the page.
 	if state.Runtime.Status == model.RuntimeStopping {

--- a/desktop/tray_icon.go
+++ b/desktop/tray_icon.go
@@ -1,0 +1,215 @@
+package main
+
+// Making the tray icon say whether traffic is being carried.
+//
+// Asked for by a user: knowing whether the connection is up meant opening the
+// window, when the icon is already on screen and could simply say so. The menu
+// and the tooltip have carried the status all along, but both need a click or a
+// hover — the colour needs neither, which is the whole point of an icon.
+//
+// The variants are derived from the one embedded logo at runtime rather than
+// shipped as four more files. The source is a 1024px PNG that already costs
+// 1.6 MB in the binary; four of those would be six, to say one of four things.
+// Deriving them also means the icon has one source of truth, so redrawing the
+// logo does not leave three stale copies behind.
+//
+// Each state drains the colour out of the logo and pulls it towards one hue —
+// green, amber, red, grey. Colour rather than a change of shape, because a
+// shape has to be recognised and a colour only has to be seen, and at sixteen
+// pixels on a busy taskbar that is the whole difference.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image"
+	"image/color"
+	"image/png"
+	"runtime"
+	"sync"
+
+	"whitevpn-desktop/internal/model"
+)
+
+// traySize is what the derived icons are scaled to.
+//
+// Trays draw at 16 or 24 points and ask for more on a HiDPI screen. 64 covers
+// that with room to spare and is a sixteenth of the source in each direction,
+// which makes the box filter below an exact average rather than a resampling.
+const traySize = 64
+
+// trayTint is how a state colours the icon: a colour to pull it towards, and
+// how far. Zero strength leaves it alone.
+type trayTint struct {
+	colour   color.RGBA
+	strength float64
+}
+
+// The palette.
+//
+// Connected is tinted rather than left as the logo, which was the first attempt
+// and the wrong one. The logo is dark and nearly monochrome, so "connected" and
+// "disconnected" came out as black and grey — the weakest distinction in the
+// set, and the one the whole feature exists to make. On a dark taskbar the
+// untinted version all but disappears. Green is what every other client on the
+// platform uses for this, and it survives being sixteen pixels wide.
+var trayTints = map[string]trayTint{
+	model.RuntimeConnected:    {colour: color.RGBA{R: 0x3F, G: 0xB9, B: 0x63, A: 0xFF}, strength: 0.8},
+	model.RuntimeConnecting:   {colour: color.RGBA{R: 0xE8, G: 0xA3, B: 0x3D, A: 0xFF}, strength: 0.75},
+	model.RuntimeStopping:     {colour: color.RGBA{R: 0xE8, G: 0xA3, B: 0x3D, A: 0xFF}, strength: 0.75},
+	model.RuntimeFailed:       {colour: color.RGBA{R: 0xD9, G: 0x4B, B: 0x4B, A: 0xFF}, strength: 0.8},
+	model.RuntimeDisconnected: {colour: color.RGBA{R: 0x8A, G: 0x8A, B: 0x92, A: 0xFF}, strength: 0.85},
+}
+
+var (
+	trayIconsOnce sync.Once
+	trayIcons     map[string][]byte
+	trayIconBase  []byte
+)
+
+// trayIconFor returns the icon bytes for a runtime status.
+//
+// It never fails: if the logo cannot be decoded — which would mean the embedded
+// asset is broken and the build is wrong — every state gets the icon that
+// shipped, and the tray looks exactly as it did before this existed. An icon
+// that does not change colour is a small loss; no icon at all is the app
+// becoming unreachable once its window is closed.
+func trayIconFor(status string) []byte {
+	trayIconsOnce.Do(buildTrayIcons)
+	if icon, ok := trayIcons[status]; ok {
+		return icon
+	}
+	return trayIconBase
+}
+
+func buildTrayIcons() {
+	trayIconBase = trayIcon()
+	trayIcons = map[string][]byte{}
+
+	source, err := png.Decode(bytes.NewReader(trayIconPNG))
+	if err != nil {
+		return
+	}
+	scaled := downscale(source, traySize)
+	for status, tint := range trayTints {
+		encoded, err := encodeTrayIcon(applyTint(scaled, tint))
+		if err != nil {
+			continue
+		}
+		trayIcons[status] = encoded
+	}
+}
+
+// downscale averages the source down to a square of the given size.
+//
+// A box filter rather than nearest neighbour: dropping fifteen pixels in
+// sixteen off a logo with thin strokes is how an icon comes out looking like it
+// was drawn with a broken pen.
+func downscale(source image.Image, size int) *image.NRGBA {
+	bounds := source.Bounds()
+	out := image.NewNRGBA(image.Rect(0, 0, size, size))
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			x0 := bounds.Min.X + x*bounds.Dx()/size
+			x1 := bounds.Min.X + (x+1)*bounds.Dx()/size
+			y0 := bounds.Min.Y + y*bounds.Dy()/size
+			y1 := bounds.Min.Y + (y+1)*bounds.Dy()/size
+
+			var r, g, b, a, n uint64
+			for sy := y0; sy < y1; sy++ {
+				for sx := x0; sx < x1; sx++ {
+					// Alpha-weighted, so a transparent pixel's colour — which is
+					// arbitrary — does not wash into its opaque neighbours and
+					// leave a halo around the logo.
+					sr, sg, sb, sa := source.At(sx, sy).RGBA()
+					r += uint64(sr)
+					g += uint64(sg)
+					b += uint64(sb)
+					a += uint64(sa)
+					n++
+				}
+			}
+			if n == 0 {
+				continue
+			}
+			alpha := a / n
+			pixel := color.NRGBA{A: uint8(alpha >> 8)}
+			if alpha > 0 {
+				// Back out of premultiplied form, which is what RGBA() returns.
+				pixel.R = uint8(min64(r/n*0xFFFF/alpha, 0xFFFF) >> 8)
+				pixel.G = uint8(min64(g/n*0xFFFF/alpha, 0xFFFF) >> 8)
+				pixel.B = uint8(min64(b/n*0xFFFF/alpha, 0xFFFF) >> 8)
+			}
+			out.SetNRGBA(x, y, pixel)
+		}
+	}
+	return out
+}
+
+// applyTint drains the colour out of an image and pulls it towards one hue.
+//
+// Through luminance rather than by multiplying the original channels: the logo
+// is not one colour, and multiplying leaves its darker parts almost black while
+// its lighter parts take the tint, which reads as a smudge rather than a state.
+func applyTint(source *image.NRGBA, tint trayTint) *image.NRGBA {
+	if tint.strength <= 0 {
+		return source
+	}
+	out := image.NewNRGBA(source.Bounds())
+	copy(out.Pix, source.Pix)
+	for i := 0; i < len(out.Pix); i += 4 {
+		if out.Pix[i+3] == 0 {
+			continue
+		}
+		luma := 0.2126*float64(out.Pix[i]) + 0.7152*float64(out.Pix[i+1]) + 0.0722*float64(out.Pix[i+2])
+		// Held off pure black so a dark logo still shows its tint rather than
+		// turning into a silhouette.
+		lit := 0.35 + 0.65*(luma/255)
+		out.Pix[i] = blend(out.Pix[i], uint8(float64(tint.colour.R)*lit), tint.strength)
+		out.Pix[i+1] = blend(out.Pix[i+1], uint8(float64(tint.colour.G)*lit), tint.strength)
+		out.Pix[i+2] = blend(out.Pix[i+2], uint8(float64(tint.colour.B)*lit), tint.strength)
+	}
+	return out
+}
+
+func blend(from, to uint8, strength float64) uint8 {
+	return uint8(float64(from)*(1-strength) + float64(to)*strength)
+}
+
+func min64(value, limit uint64) uint64 {
+	if value > limit {
+		return limit
+	}
+	return value
+}
+
+// encodeTrayIcon writes the image in the format this platform's tray wants.
+//
+// Windows wants an ICO, which since Vista may hold a PNG directly rather than
+// the old bitmap-with-a-mask — so the container is twenty-two bytes of header
+// around the same PNG everything else gets.
+func encodeTrayIcon(img image.Image) ([]byte, error) {
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, img); err != nil {
+		return nil, err
+	}
+	if runtime.GOOS != "windows" {
+		return encoded.Bytes(), nil
+	}
+
+	size := img.Bounds().Dx()
+	if size >= 256 {
+		// The field is one byte and 0 is how the format spells 256.
+		size = 0
+	}
+	var ico bytes.Buffer
+	// ICONDIR: reserved, type 1 (icon), one image.
+	_ = binary.Write(&ico, binary.LittleEndian, [3]uint16{0, 1, 1})
+	// ICONDIRENTRY: width, height, palette size, reserved.
+	ico.Write([]byte{byte(size), byte(size), 0, 0})
+	_ = binary.Write(&ico, binary.LittleEndian, uint16(1))  // colour planes
+	_ = binary.Write(&ico, binary.LittleEndian, uint16(32)) // bits per pixel
+	_ = binary.Write(&ico, binary.LittleEndian, uint32(encoded.Len()))
+	_ = binary.Write(&ico, binary.LittleEndian, uint32(22)) // the header's own length
+	ico.Write(encoded.Bytes())
+	return ico.Bytes(), nil
+}

--- a/desktop/tray_icon_test.go
+++ b/desktop/tray_icon_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"image/png"
+	"runtime"
+	"testing"
+
+	"whitevpn-desktop/internal/model"
+)
+
+// The point of the feature: the states have to be told apart at a glance, and
+// the pair that matters most is connected against disconnected. The first
+// attempt left the connected icon untinted, which made those two black and grey
+// — the weakest distinction in the set, and the one it exists to make.
+func TestEveryTrayStateLooksDifferentFromEveryOther(t *testing.T) {
+	states := []string{
+		model.RuntimeConnected,
+		model.RuntimeConnecting,
+		model.RuntimeFailed,
+		model.RuntimeDisconnected,
+	}
+	seen := map[string]string{}
+	for _, state := range states {
+		icon := trayIconFor(state)
+		if len(icon) == 0 {
+			t.Fatalf("%s has no icon at all", state)
+		}
+		if previous, ok := seen[string(icon)]; ok {
+			t.Fatalf("%s and %s are the same image, so the tray cannot tell them apart", state, previous)
+		}
+		seen[string(icon)] = state
+	}
+}
+
+// A status nothing was drawn for still has to produce an icon. Returning
+// nothing would leave the tray blank, and a blank tray is an app that cannot be
+// reached once its window is closed.
+func TestAnUnknownStatusStillGetsAnIcon(t *testing.T) {
+	if len(trayIconFor("something-nobody-has-written-yet")) == 0 {
+		t.Fatal("an unrecognised status left the tray with no icon")
+	}
+	if len(trayIconFor("")) == 0 {
+		t.Fatal("an empty status left the tray with no icon")
+	}
+}
+
+// Windows will not draw a PNG handed to it as an icon, so the container has to
+// be right. The rest of the world takes the PNG as it is.
+func TestTheIconIsInTheFormatThisPlatformDraws(t *testing.T) {
+	icon := trayIconFor(model.RuntimeConnected)
+	payload := icon
+	if isWindows() {
+		if len(icon) < 22 {
+			t.Fatal("an ICO cannot be shorter than its own header")
+		}
+		// ICONDIR: reserved 0, type 1, one image.
+		if want := []byte{0, 0, 1, 0, 1, 0}; !bytes.Equal(icon[:6], want) {
+			t.Fatalf("the ICO header is wrong: got %v, want %v", icon[:6], want)
+		}
+		if icon[0+6] != traySize || icon[1+6] != traySize {
+			t.Fatalf("the ICO declares %dx%d, but the image is %d", icon[6], icon[7], traySize)
+		}
+		payload = icon[22:]
+	}
+	image, err := png.Decode(bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("the icon does not contain a readable PNG: %v", err)
+	}
+	if image.Bounds().Dx() != traySize || image.Bounds().Dy() != traySize {
+		t.Fatalf("the icon is %v, want %dx%d", image.Bounds().Size(), traySize, traySize)
+	}
+}
+
+// Deriving the icons is the reason they are not four more embedded files, so it
+// has to actually be cheaper than the thing it replaced.
+func TestADerivedIconIsSmallerThanTheOneItReplaces(t *testing.T) {
+	derived := len(trayIconFor(model.RuntimeConnected))
+	if derived >= len(trayIcon()) {
+		t.Fatalf("the derived icon is %d bytes against the shipped %d — deriving is buying nothing", derived, len(trayIcon()))
+	}
+}
+
+func isWindows() bool { return runtime.GOOS == "windows" }


### PR DESCRIPTION
Closes #63.

Knowing whether the connection was up meant opening the window. The menu and tooltip have carried the status all along, but both need a click or a hover — a colour needs neither, which is the whole point of having an icon.

| State | Colour |
|---|---|
| Connected | green |
| Connecting / stopping | amber |
| Failed | red |
| Disconnected | grey |

## The first attempt was wrong, and looking at it showed why

The connected icon was originally left untinted, reasoning that the ordinary state should look like the application rather than a status light.

Rendering the four and putting them side by side settled it: this logo is dark and nearly monochrome, so connected and disconnected came out **black and grey** — the weakest distinction in the set, and precisely the one the feature exists to make. On a dark taskbar the untinted version all but disappears.

Green is what every other client on the platform uses for this, and it survives being sixteen pixels wide.

## Derived, not shipped

The variants are built from the embedded logo at runtime rather than added as four more files. That source is a 1024px PNG already costing 1.6 MB in the binary; four would be six, to say one of four things. Each derived icon is about **7 KB** — smaller than the 123 KB `.ico` that ships today, and there is a test asserting it stays that way.

It also leaves the icon with one source of truth, so redrawing the logo cannot leave three stale copies behind.

## Two details that matter for how it looks

- **Tinting goes through luminance**, not by multiplying the original channels. Multiplying leaves the dark parts almost black and lets only the light parts take the colour, which reads as a smudge rather than a state.
- **Scaling is a box filter.** Dropping fifteen pixels in sixteen off a logo with thin strokes is how an icon ends up looking drawn with a broken pen.

No new dependency — `image/png` and about twenty lines of averaging.

## Failure behaviour

If the logo cannot be decoded — which would mean the embedded asset is broken and the build is wrong — every state gets the icon that ships today and the tray looks exactly as it does now. An icon that does not change colour is a small loss; no icon at all is an app that cannot be reached once its window is closed.

## Testing

Four tests, including one that asserts **no two states produce the same image** — which is the failure the first attempt would have shipped. Also covers the ICO container on Windows (Vista-style, PNG inside), unknown statuses still yielding an icon, and the size claim above.

Builds and vets clean for darwin and linux as well as Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)