### PR TITLE
Let the port shared on the network be chosen, not discovered

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -6390,10 +6390,13 @@ function WhiteVPNSettingsPage({
           {!tunnelAvailable && <FieldDescription>{t("settings.routing.tun.unavailable")}</FieldDescription>}
         </Field>
 
-        {/* Only in proxy-only mode. Everywhere else the port is an
-            implementation detail and inviting someone to change it would be
-            inviting them to break something for no reason. */}
-        {routingMode(draft) === "proxyOnly" && (
+        {/* In proxy-only mode the port is the whole interface — it is what
+            gets typed into Telegram. Everywhere else it stays hidden until
+            sharing is on, because that is the only other moment a fixed number
+            matters: a phone on the LAN has to be told an address, and it
+            cannot follow a silent switch to a different port any more than
+            Telegram could. */}
+        {(routingMode(draft) === "proxyOnly" || draft.allowLan) && (
           <Field>
             <FieldLabel>{t("settings.routing.port")}</FieldLabel>
             <Input

--- a/desktop/mihomo_connect.go
+++ b/desktop/mihomo_connect.go
@@ -446,9 +446,21 @@ func chooseProxyPort(settings model.WhiteVPNSettings) (int, error) {
 		wanted = mihomoconf.DefaultMixedPort
 	}
 
-	if proxyOnly(settings) {
+	// A number somebody else is relying on, in two ways. In proxy-only mode it
+	// is what got typed into Telegram or a browser extension. Shared on the
+	// network it is what another device was told to connect to. Either way, a
+	// silent switch to a different port is a program that stops working days
+	// later, in another application or on another machine, with nothing
+	// connecting that failure back to this one.
+	if proxyOnly(settings) || settings.AllowLAN {
 		if !portIsFree(wanted) {
-			return 0, fmt.Errorf("port %d is already in use by another program — choose a different local proxy port in Settings, or turn the system proxy back on", wanted)
+			howToFix := "choose a different local proxy port in Settings, or turn the system proxy back on"
+			if !proxyOnly(settings) {
+				// Sharing is what made the port somebody's business here; the
+				// system proxy is not on trial.
+				howToFix = "choose a different local proxy port in Settings"
+			}
+			return 0, fmt.Errorf("port %d is already in use by another program — %s", wanted, howToFix)
 		}
 		return wanted, nil
 	}

--- a/desktop/proxyonly_test.go
+++ b/desktop/proxyonly_test.go
@@ -69,6 +69,47 @@ func TestATakenPortIsReportedInProxyOnlyMode(t *testing.T) {
 	}
 }
 
+// Sharing on the network makes the port somebody else's business the same way
+// proxy-only does — a device that was told to connect to it cannot follow a
+// silent switch to a different one.
+func TestATakenPortIsReportedWhenSharedOnTheNetwork(t *testing.T) {
+	held, port := holdAPort(t)
+	defer held.Close()
+
+	for _, settings := range []model.WhiteVPNSettings{
+		{TunEnabled: false, SetSystemProxy: true, AllowLAN: true, ListenPort: port},
+		{TunEnabled: true, SetSystemProxy: false, AllowLAN: true, ListenPort: port},
+	} {
+		_, err := chooseProxyPort(settings)
+		if err == nil {
+			t.Fatal("a port that cannot be had must be reported when it is shared, not worked around")
+		}
+		if !strings.Contains(err.Error(), fmt.Sprint(port)) {
+			t.Errorf("the message should mention %d: %v", port, err)
+		}
+		// The system proxy is not what is on trial here; sharing is.
+		if strings.Contains(err.Error(), "system proxy") {
+			t.Errorf("blaming the system proxy for a sharing conflict is misleading: %v", err)
+		}
+	}
+}
+
+// Without sharing, the two settings behave exactly as they did before this: a
+// taken port is worked around, not reported.
+func TestATakenPortIsStillWorkedAroundWithoutSharing(t *testing.T) {
+	held, port := holdAPort(t)
+	defer held.Close()
+
+	settings := model.WhiteVPNSettings{TunEnabled: false, SetSystemProxy: true, AllowLAN: false, ListenPort: port}
+	got, err := chooseProxyPort(settings)
+	if err != nil {
+		t.Fatalf("this mode should not fail over a port: %v", err)
+	}
+	if got == port {
+		t.Fatal("the held port was handed out anyway")
+	}
+}
+
 // A free port is used as asked, in every mode.
 func TestAFreePortIsUsedAsAsked(t *testing.T) {
 	held, port := holdAPort(t)


### PR DESCRIPTION
Addresses the LAN-sharing part of the user's request: HTTP alongside SOCKS5, and a way to set the port.

## HTTP already worked

mihomo's `mixed-port` serves HTTP and SOCKS5 on the same listener — nothing to add there. The description already said so (`settings.routing.port.description`).

## The actual gap: no way to fix the port outside proxy-only mode

The port field was hidden everywhere except proxy-only mode, on the reasoning that the number is an implementation detail nobody needs to see (see the comment it replaces). That holds until another device is told to connect to it.

Worse, the backend was already inconsistent about this. `chooseProxyPort`:

- **Proxy-only**: a taken port is reported as an error — right, because it is what got typed into Telegram.
- **Everywhere else**: a taken port is silently swapped for a random free one.

Once LAN sharing is on in system-proxy or tunnel mode, the second behaviour is wrong for the same reason the first is right: a phone that was told to connect to `192.168.1.x:2080` cannot follow a silent switch to a different port, and had no way to set one in the first place.

## What changed

**Backend** (`mihomo_connect.go`): `chooseProxyPort` now treats a taken port as an error whenever `AllowLAN` is on, not only in proxy-only mode. The error wording adapts — it blames the system proxy only when proxy-only mode is what makes the port matter; sharing gets its own message, because the system proxy isn't on trial there.

**Frontend**: the port field is shown whenever `routingMode === "proxyOnly" || allowLan` — so turning on sharing in any mode reveals the field to set it. No i18n changes needed; the existing description already covers "accepts both HTTP and SOCKS5" and the taken-port behaviour.

## Testing

Two new tests: a taken port is reported once sharing is on, in both system-proxy and tunnel mode; the existing silent-fallback behaviour is confirmed unchanged when sharing is off. Confirmed the new test fails against the prior behaviour before the fix.

Full suite green, `tsc --noEmit` clean, frontend builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)