### PR TITLE
Offer the Linux tunnel that was already built, and verify it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,12 @@ jobs:
           WHITEVPN_TUN_INTEGRATION: "1"
         run: |
           go test -c -o /tmp/whitevpn-tun-integration ./internal/engine/
+          # From the package's own directory, because corePath resolves the
+          # engine binary relative to it (../../cores). `go test` sets that
+          # working directory itself; a compiled binary run from anywhere else
+          # looks for the core outside the repository and skips for want of it,
+          # which reads as a pass.
+          cd internal/engine
           sudo --preserve-env=WHITEVPN_TUN_INTEGRATION /tmp/whitevpn-tun-integration -test.v -test.run OnARealLinuxMachine
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,32 @@ jobs:
         working-directory: desktop
         run: go test -v ./internal/engine/
 
+      # Whether the Linux tunnel actually comes up rests on two things nobody
+      # here can try by hand: that CAP_NET_ADMIN by way of a root process lets
+      # mihomo create the adapter, and that `ip route get` reads back correctly
+      # from whatever mechanism mihomo used to install its routes. The comment
+      # on TunOptions.StrictRoute says that is "unreachable policy rules" on
+      # Linux rather than routes attached to the device the way Windows does
+      # it — so a plain `ip route show dev` could easily be asking the wrong
+      # question and answering it confidently.
+      #
+      # A hosted Linux runner is a real Linux machine, so it is asked directly.
+      # Run as root rather than through pkexec: pkexec needs a polkit agent and
+      # an interactive session a runner has neither of, but elevate_linux.go
+      # already takes a direct path when the caller is root, which is the same
+      # code a desktop session reaches once its own prompt is answered.
+      #
+      # Compiled unprivileged and only then run under sudo, so root never needs
+      # its own module cache or network access — it gets a finished binary with
+      # nothing left to fetch or build.
+      - name: Ask a real Linux machine whether the tunnel comes up
+        working-directory: desktop
+        env:
+          WHITEVPN_TUN_INTEGRATION: "1"
+        run: |
+          go test -c -o /tmp/whitevpn-tun-integration ./internal/engine/
+          sudo --preserve-env=WHITEVPN_TUN_INTEGRATION /tmp/whitevpn-tun-integration -test.v -test.run OnARealLinuxMachine
+
 
   frontend:
     name: Frontend

--- a/desktop/ANDROID-PARITY.md
+++ b/desktop/ANDROID-PARITY.md
@@ -670,11 +670,20 @@ Measured 2026-08-05, from Windows:
   preferences well-behaved programs read, and a program that ignores them is not
   reached by anything short of a tunnel. Say that rather than promise more.
 
-  **Tunnel mode does not work on Linux.** `engine.startElevatedChild` is
-  implemented on Windows only, so the core cannot be raised to create an
-  adapter. That is why the system proxy failing used to leave a Linux user with
-  no usable mode at all, and why it is now a notice rather than a failed
-  connection.
+  **Tunnel mode works on Linux where polkit is installed.** The core is raised
+  through `pkexec`, which puts the prompt in the desktop's own polkit agent and
+  leaves the interface running as the user. Without polkit the core cannot be
+  raised at all, so the mode is withheld rather than offered and failed — a
+  property of the machine rather than of the operating system, which is why
+  `tunnelSupported` asks rather than hard-coding it.
+
+  The route check is not the Windows one. `Get-NetRoute -InterfaceAlias` reads
+  routes attached to the adapter, and mihomo installs Linux routes through
+  policy rules that such a question would not see — so Linux asks
+  `ip route get` instead, which resolves the decision the way a real packet
+  would. Verified against a live adapter on a CI runner rather than reasoned
+  about, because the difference between those two questions is exactly the kind
+  that answers confidently and wrongly.
 - **macOS** — **cannot be built from Windows.** Without CGO it does not compile
   at all: `fyne.io/systray` needs Cocoa. With CGO it needs the macOS SDK. It has
   to run on a Mac, or on a macOS CI runner.

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -6390,10 +6390,13 @@ function WhiteVPNSettingsPage({
           {!tunnelAvailable && <FieldDescription>{t("settings.routing.tun.unavailable")}</FieldDescription>}
         </Field>
 
-        {/* Only in proxy-only mode. Everywhere else the port is an
-            implementation detail and inviting someone to change it would be
-            inviting them to break something for no reason. */}
-        {routingMode(draft) === "proxyOnly" && (
+        {/* In proxy-only mode the port is the whole interface — it is what
+            gets typed into Telegram. Everywhere else it stays hidden until
+            sharing is on, because that is the only other moment a fixed number
+            matters: a phone on the LAN has to be told an address, and it
+            cannot follow a silent switch to a different port any more than
+            Telegram could. */}
+        {(routingMode(draft) === "proxyOnly" || draft.allowLan) && (
           <Field>
             <FieldLabel>{t("settings.routing.port")}</FieldLabel>
             <Input

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -664,12 +664,12 @@ const strings = {
     fa: "هیچ چیزی روی این دستگاه تغییر نمی‌کند. برنامه فقط گوش می‌دهد و شما یک برنامه را به آن وصل می‌کنید — افزونهٔ مرورگر یا تنظیمات پراکسی تلگرام. بقیه مثل همیشه از مسیر عادی می‌روند.",
   },
   "settings.routing.tun.description": {
-    en: "A virtual network adapter carries everything, including programs that ignore proxy settings. Needs Administrator on Windows.",
-    fa: "یک کارت شبکهٔ مجازی همه چیز را حمل می‌کند، حتی برنامه‌هایی که تنظیمات پراکسی را نادیده می‌گیرند. روی ویندوز نیاز به دسترسی Administrator دارد.",
+    en: "A virtual network adapter carries everything, including programs that ignore proxy settings. Asks for permission when connecting — Administrator on Windows, your password through polkit on Linux.",
+    fa: "یک کارت شبکهٔ مجازی همه چیز را حمل می‌کند، حتی برنامه‌هایی که تنظیمات پراکسی را نادیده می‌گیرند. هنگام اتصال اجازه می‌خواهد — روی ویندوز Administrator و روی لینوکس رمز شما از طریق polkit.",
   },
   "settings.routing.tun.unavailable": {
-    en: "Tunnel (TUN) mode is available on Windows only for now. It needs to run the engine with administrator rights, and that is not implemented on this platform yet.",
-    fa: "حالت تونل (TUN) فعلاً فقط روی ویندوز در دسترس است. این حالت باید موتور را با دسترسی مدیر اجرا کند و این کار هنوز روی این سیستم‌عامل پیاده‌سازی نشده است.",
+    en: "Tunnel (TUN) mode needs to run the engine with elevated rights. On Windows and Linux it can; on macOS that is not implemented yet. On Linux it also needs polkit installed, which is what puts the password prompt on screen — without it the engine cannot be raised at all.",
+    fa: "حالت تونل (TUN) باید موتور را با دسترسی بالا اجرا کند. روی ویندوز و لینوکس این ممکن است؛ روی مک هنوز پیاده‌سازی نشده. روی لینوکس به polkit هم نیاز دارد، چون همان است که پنجرهٔ رمز را نشان می‌دهد — بدون آن اصلاً نمی‌شود موتور را بالا برد.",
   },
   "settings.routing.port": { en: "Local proxy port", fa: "پورت پراکسی محلی" },
   "settings.routing.port.description": {
@@ -706,8 +706,8 @@ const strings = {
   },
   "settings.tunnel": { en: "Tunnel (TUN)", fa: "تونل (TUN)" },
   "settings.tunnel.description": {
-    en: "The tunnel carries every program on the machine. Turning it on asks for Administrator when connecting, because creating the network adapter needs it. Left off, only programs pointed at the local proxy are carried.",
-    fa: "تونل ترافیک همهٔ برنامه‌های دستگاه را حمل می‌کند. روشن کردنش هنگام اتصال دسترسی Administrator می‌خواهد، چون ساختن آداپتور شبکه به آن نیاز دارد. اگر خاموش باشد، فقط برنامه‌هایی که به پراکسی محلی وصل شده‌اند حمل می‌شوند.",
+    en: "The tunnel carries every program on the machine. Turning it on asks for permission when connecting — Administrator on Windows, your password through polkit on Linux — because creating the network adapter needs it. Left off, only programs pointed at the local proxy are carried.",
+    fa: "تونل ترافیک همهٔ برنامه‌های دستگاه را حمل می‌کند. روشن کردنش هنگام اتصال اجازه می‌خواهد — روی ویندوز Administrator و روی لینوکس رمز شما از طریق polkit — چون ساختن آداپتور شبکه به آن نیاز دارد. اگر خاموش باشد، فقط برنامه‌هایی که به پراکسی محلی وصل شده‌اند حمل می‌شوند.",
   },
   "settings.killSwitch": { en: "Kill switch", fa: "قطع‌کنندهٔ اضطراری" },
   "settings.killSwitch.description": {

--- a/desktop/internal/engine/elevate_linux.go
+++ b/desktop/internal/engine/elevate_linux.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 )
@@ -28,12 +29,19 @@ import (
 // password" is actionable where "the engine did not start" is not.
 const pkexecDeclined = 126
 
-func startElevatedChild(corePath, endpoint, workingDir string) (childProcess, error) {
+func startElevatedChild(corePath, endpoint, workingDir string, stdout, stderr io.Writer) (childProcess, error) {
 	if os.Geteuid() == 0 {
 		// Already root — asking again would be theatre, and starting it directly
 		// keeps the engine's output, which the pkexec path cannot capture.
+		//
+		// "Keeps" was aspirational until the writers were actually attached:
+		// the comment claimed the output survived while nothing was reading it,
+		// so a core that failed to raise its adapter said why into a pipe that
+		// went nowhere.
 		cmd := exec.Command(corePath, endpoint)
 		cmd.Dir = workingDir
+		cmd.Stdout = stdout
+		cmd.Stderr = stderr
 		configureCommand(cmd)
 		if err := cmd.Start(); err != nil {
 			return nil, fmt.Errorf("engine: start %s: %w", corePath, err)
@@ -41,6 +49,9 @@ func startElevatedChild(corePath, endpoint, workingDir string) (childProcess, er
 		return ordinaryChild{cmd: cmd}, nil
 	}
 
+	// Past this point the core is started by pkexec, which does not pass our
+	// pipes down to it, so stdout and stderr are deliberately dropped rather
+	// than half-wired.
 	pkexecPath, err := exec.LookPath("pkexec")
 	if err != nil {
 		return nil, errors.New(

--- a/desktop/internal/engine/elevate_other.go
+++ b/desktop/internal/engine/elevate_other.go
@@ -2,12 +2,15 @@
 
 package engine
 
-import "errors"
+import (
+	"errors"
+	"io"
+)
 
 // Windows has its elevation prompt and Linux has pkexec. macOS has neither
 // implemented here, so this refuses plainly rather than pretending to have
 // tried: a tunnel that silently is not one is worse than a clear no.
-func startElevatedChild(string, string, string) (childProcess, error) {
+func startElevatedChild(string, string, string, io.Writer, io.Writer) (childProcess, error) {
 	return nil, errors.New(
 		"engine: a tunnel needs elevated rights, which are only wired up on Windows and Linux. " +
 			"Turn the tunnel off and use the local proxy instead")

--- a/desktop/internal/engine/elevate_windows.go
+++ b/desktop/internal/engine/elevate_windows.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -169,7 +170,11 @@ func isElevated() bool {
 // If this process is already elevated there is nothing to ask for, and starting
 // normally is better: it keeps the engine's output, which the elevation prompt
 // path cannot.
-func startElevatedChild(corePath, endpoint, workingDir string) (childProcess, error) {
+// stdout and stderr are ignored here and cannot be otherwise: ShellExecuteExW
+// starts the process through the shell with its own handles, so there is
+// nothing of ours for it to inherit. That is the cost recorded at the top of
+// this file.
+func startElevatedChild(corePath, endpoint, workingDir string, _, _ io.Writer) (childProcess, error) {
 	if isElevated() {
 		cmd := exec.Command(corePath, endpoint)
 		cmd.Dir = workingDir

--- a/desktop/internal/engine/spawn.go
+++ b/desktop/internal/engine/spawn.go
@@ -47,8 +47,11 @@ type SpawnOptions struct {
 	// Stdout and Stderr receive the core's own output. Worth capturing: some
 	// startup failures are only ever printed there and never reach a reply.
 	//
-	// They are not honoured under Elevated: a child started through the elevation
-	// prompt cannot inherit this process's pipes.
+	// A child started through an elevation prompt cannot inherit this process's
+	// pipes, so on that path they are dropped. Where the core is started
+	// directly — Windows never, Linux when the caller is already root — they
+	// are honoured, which is the only case where the engine's own startup
+	// complaints can be read at all.
 	Stdout io.Writer
 	Stderr io.Writer
 
@@ -141,7 +144,7 @@ func Spawn(ctx context.Context, opts SpawnOptions) (*Process, error) {
 
 	var child childProcess
 	if opts.Elevated {
-		elevated, err := startElevatedChild(opts.CorePath, endpoint, opts.WorkingDir)
+		elevated, err := startElevatedChild(opts.CorePath, endpoint, opts.WorkingDir, opts.Stdout, opts.Stderr)
 		if err != nil {
 			_ = listener.Close()
 			cleanupEndpoint(endpoint)

--- a/desktop/internal/engine/tun_linux_integration_test.go
+++ b/desktop/internal/engine/tun_linux_integration_test.go
@@ -64,85 +64,33 @@ func TestOnARealLinuxMachineTheTunnelActuallyComesUp(t *testing.T) {
 	if err != nil {
 		t.Fatal("iproute2's ip is not installed, so the routing decision cannot be read")
 	}
-	core := requireCore(t)
-
-	// The shipped settings, and then the same thing with one option removed at
-	// a time.
-	//
-	// The first run of this failed with "configure tun interface: numerical
-	// result out of range", which names the stage and not the setting. Guessing
-	// which of MTU, stack, strict-route or the IPv6 address the kernel objected
-	// to would be guessing; the machine can be asked instead, and one CI run
-	// answers it completely rather than four.
-	//
-	// Every variant is reported whether it passes or fails, because the useful
-	// output here is the whole table, not the first success.
-	variants := []struct {
-		name string
-		with func(*mihomoconf.TunOptions)
-	}{
-		{"as shipped", func(*mihomoconf.TunOptions) {}},
-		{"without strict-route", func(o *mihomoconf.TunOptions) { o.StrictRoute = false }},
-		{"without IPv6", func(o *mihomoconf.TunOptions) { o.IPv6 = false; o.Inet6Address = "" }},
-		{"MTU 1500", func(o *mihomoconf.TunOptions) { o.MTU = 1500 }},
-		{"system stack", func(o *mihomoconf.TunOptions) { o.Stack = "system" }},
-		{"nothing but auto-route", func(o *mihomoconf.TunOptions) {
-			o.StrictRoute = false
-			o.IPv6 = false
-			o.Inet6Address = ""
-			o.MTU = 1500
-		}},
-	}
-
-	var worked []string
-	for _, variant := range variants {
-		if err := tryTunnel(t, core, ipPath, variant.name, variant.with); err != nil {
-			t.Logf("%-24s FAILED: %v", variant.name, err)
-			continue
-		}
-		t.Logf("%-24s came up", variant.name)
-		worked = append(worked, variant.name)
-	}
-
-	t.Logf("interfaces after the sweep:\n%s", describeInterfaces(ipPath))
-
-	if len(worked) == 0 {
-		t.Fatal("no configuration brought the tunnel up on this machine")
-	}
-	// The shipped settings are the ones that have to work. A variant succeeding
-	// tells us what to change; it does not make the current defaults correct.
-	if worked[0] != "as shipped" {
-		t.Fatalf("the shipped settings did not come up; these did: %s", strings.Join(worked, ", "))
-	}
-}
-
-// tryTunnel starts one engine with one set of tunnel options and reports
-// whether traffic ends up resolving through the adapter.
-//
-// Each variant gets its own engine and its own device name: a leftover adapter
-// from a previous attempt would otherwise make the next one look successful
-// without having created anything.
-func tryTunnel(t *testing.T, core, ipPath, label string, with func(*mihomoconf.TunOptions)) error {
-	t.Helper()
 
 	proxies, err := mihomoconf.ConvertLinks(
 		"vless://11111111-2222-3333-4444-555555555555@198.51.100.1:443?security=tls&type=tcp#Unreachable")
 	if err != nil {
-		return fmt.Errorf("convert: %w", err)
+		t.Fatalf("convert: %v", err)
 	}
+	// The address does not have to answer. Bringing the adapter up and
+	// installing its routes is mihomo's own startup work and happens whether or
+	// not the one proxy in the group can be reached.
 	proxiesYAML, err := mihomoconf.BuildProxiesYAML(proxies, mihomoconf.SplitTunnel{})
 	if err != nil {
-		return fmt.Errorf("build proxies: %w", err)
+		t.Fatalf("build proxies: %v", err)
 	}
 
 	tun := mihomoconf.DefaultTunOptions()
-	with(&tun)
-	// Distinct per variant, and distinct from what a real connect would use, so
-	// nothing left behind can be mistaken for this attempt's adapter.
-	tun.Device = "wvtun" + strings.Map(keepAlphanumeric, label)
+	// Its own name, so a leftover adapter — or a real WhiteVPN connection on
+	// the same machine — is never mistaken for this test's.
+	//
+	// Fifteen characters at the outside. Linux caps an interface name at
+	// IFNAMSIZ-1, and exceeding it fails as ERANGE, which mihomo reports as
+	// "configure tun interface: numerical result out of range" — a message that
+	// names the stage and not the cause. This test's first name was seventeen
+	// characters and cost a full round of CI to explain. The shipped name is
+	// eight, so nothing about the product was ever at stake.
+	tun.Device = "whitevpn-tuntt"
 	if len(tun.Device) > 15 {
-		// Linux interface names are capped at IFNAMSIZ-1.
-		tun.Device = tun.Device[:15]
+		t.Fatalf("device name %q is %d characters; Linux allows 15", tun.Device, len(tun.Device))
 	}
 
 	config := mihomoconf.Render(proxiesYAML, mihomoconf.Options{
@@ -154,67 +102,58 @@ func tryTunnel(t *testing.T, core, ipPath, label string, with func(*mihomoconf.T
 	home := t.TempDir()
 	configPath := home + "/config.yaml"
 	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
-		return err
+		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	// The engine's own account of itself, readable on this path because the
 	// core is started directly rather than through pkexec. Without it a failure
-	// is "the adapter is not there" and nothing about why.
+	// here is "the adapter is not there" and nothing about why.
 	engineSaid := &lockedBuffer{}
 	proc, err := Spawn(ctx, SpawnOptions{
-		CorePath:       core,
+		CorePath:       requireCore(t),
 		WorkingDir:     home,
 		ConnectTimeout: 20 * time.Second,
 		Stdout:         engineSaid,
 		Stderr:         engineSaid,
-		// The path being tested. Root already, so this takes
-		// elevate_linux.go's direct branch — the same code a desktop session
-		// reaches once its own polkit prompt is answered.
+		// The path being tested. Root already, so this takes elevate_linux.go's
+		// direct branch — the same code a desktop session reaches once its own
+		// polkit prompt is answered, not one written only for CI.
 		Elevated: true,
 	})
 	if err != nil {
-		return fmt.Errorf("spawn: %w", err)
+		t.Fatalf("spawn: %v", err)
 	}
 	defer func() { _ = proc.Stop(context.Background()) }()
 
 	if err := proc.Init(ctx, home, 36); err != nil {
-		return fmt.Errorf("init: %w", err)
+		t.Fatalf("init: %v", err)
 	}
 	if err := proc.ValidateConfig(ctx, configPath); err != nil {
-		return fmt.Errorf("the engine could not read the config: %w", err)
+		t.Fatalf("the engine could not read the config: %v", err)
 	}
 	if err := proc.SetupConfig(ctx, map[string]string{}, "http://198.51.100.1/"); err != nil {
-		return fmt.Errorf("apply config: %w", err)
+		t.Fatalf("apply config: %v", err)
 	}
 	if err := proc.StartListener(ctx); err != nil {
-		return fmt.Errorf("start listener: %w", err)
+		t.Fatalf("start listener: %v", err)
 	}
 
 	// The adapter is not necessarily there the instant StartListener returns —
 	// the same race waitForTunnel covers in production — so it is polled.
-	deadline := time.Now().Add(15 * time.Second)
+	deadline := time.Now().Add(20 * time.Second)
 	var lastErr error
 	for time.Now().Before(deadline) {
 		if lastErr = verifyRealRouteThroughDevice(ipPath, tun.Device); lastErr == nil {
-			return nil
+			return
 		}
 		time.Sleep(time.Second)
 	}
-	t.Logf("[%s] the engine said:\n%s", label, engineSaid.String())
-	return lastErr
-}
-
-func keepAlphanumeric(r rune) rune {
-	switch {
-	case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
-		return r
-	case r >= 'A' && r <= 'Z':
-		return r + 32
-	}
-	return -1
+	t.Logf("the engine said:\n%s", engineSaid.String())
+	t.Logf("interfaces:\n%s", describeInterfaces(ipPath))
+	t.Fatalf("the tunnel never came up: %v", lastErr)
 }
 
 // lockedBuffer collects the core's output from whichever goroutine writes it.

--- a/desktop/internal/engine/tun_linux_integration_test.go
+++ b/desktop/internal/engine/tun_linux_integration_test.go
@@ -36,6 +36,8 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -46,15 +48,19 @@ import (
 const tunIntegrationEnv = "WHITEVPN_TUN_INTEGRATION"
 
 func TestOnARealLinuxMachineTheTunnelActuallyComesUp(t *testing.T) {
+	// The only skip. Everything past this point was explicitly asked for, so a
+	// missing precondition is a broken harness rather than a machine that
+	// cannot answer — and a skip there would read as a pass, which is how the
+	// first version of this went green while proving nothing.
 	if os.Getenv(tunIntegrationEnv) == "" {
 		t.Skipf("set %s=1 to run this: it creates a real network adapter and needs root", tunIntegrationEnv)
 	}
 	if os.Geteuid() != 0 {
-		t.Skip("this has to run as root — elevate_linux.go's direct-launch path is what is being asked about")
+		t.Fatal("this has to run as root — elevate_linux.go's direct-launch path is what is being asked about")
 	}
 	ipPath, err := exec.LookPath("ip")
 	if err != nil {
-		t.Skip("iproute2's ip is not installed, so the routing decision cannot be read")
+		t.Fatal("iproute2's ip is not installed, so the routing decision cannot be read")
 	}
 
 	// The address does not have to answer. Bringing the adapter up and
@@ -93,7 +99,7 @@ func TestOnARealLinuxMachineTheTunnelActuallyComesUp(t *testing.T) {
 	defer cancel()
 
 	proc, err := Spawn(ctx, SpawnOptions{
-		CorePath:       corePath(t),
+		CorePath:       requireCore(t),
 		WorkingDir:     home,
 		ConnectTimeout: 20 * time.Second,
 		// The path this is actually testing. Root already, so this does not
@@ -132,6 +138,29 @@ func TestOnARealLinuxMachineTheTunnelActuallyComesUp(t *testing.T) {
 		time.Sleep(time.Second)
 	}
 	t.Fatalf("the tunnel never came up: %v", lastErr)
+}
+
+// requireCore is corePath without its skip.
+//
+// corePath is right to stand aside where the engine has not been built — most
+// of this package's tests are run by people who have not built it. This one was
+// asked for by name, so a missing core is a broken harness and has to say so:
+// skipping here is how the first version of this went green while proving
+// nothing at all, because the compiled binary was run from a directory where
+// the relative path to cores/ resolved outside the repository.
+func requireCore(t *testing.T) string {
+	t.Helper()
+	name := "mihomo-" + runtime.GOOS + "-" + runtime.GOARCH
+	path, err := filepath.Abs(filepath.Join("..", "..", "cores", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		cwd, _ := os.Getwd()
+		t.Fatalf("the engine binary is not at %s (looked from %s) — build it with `make mihomo-core`, "+
+			"and run this from the package directory so the relative path resolves", path, cwd)
+	}
+	return path
 }
 
 // verifyRealRouteThroughDevice is a deliberately independent check from

--- a/desktop/internal/engine/tun_linux_integration_test.go
+++ b/desktop/internal/engine/tun_linux_integration_test.go
@@ -64,28 +64,88 @@ func TestOnARealLinuxMachineTheTunnelActuallyComesUp(t *testing.T) {
 	if err != nil {
 		t.Fatal("iproute2's ip is not installed, so the routing decision cannot be read")
 	}
+	core := requireCore(t)
 
-	// The address does not have to answer. Bringing the adapter up and
-	// installing its routes is mihomo's own startup work and happens
-	// regardless of whether the one proxy in the group can be reached — the
-	// same way ValidateConfig's tests use addresses nobody will ever dial.
-	convertedProxies, err := mihomoconf.ConvertLinks(
+	// The shipped settings, and then the same thing with one option removed at
+	// a time.
+	//
+	// The first run of this failed with "configure tun interface: numerical
+	// result out of range", which names the stage and not the setting. Guessing
+	// which of MTU, stack, strict-route or the IPv6 address the kernel objected
+	// to would be guessing; the machine can be asked instead, and one CI run
+	// answers it completely rather than four.
+	//
+	// Every variant is reported whether it passes or fails, because the useful
+	// output here is the whole table, not the first success.
+	variants := []struct {
+		name string
+		with func(*mihomoconf.TunOptions)
+	}{
+		{"as shipped", func(*mihomoconf.TunOptions) {}},
+		{"without strict-route", func(o *mihomoconf.TunOptions) { o.StrictRoute = false }},
+		{"without IPv6", func(o *mihomoconf.TunOptions) { o.IPv6 = false; o.Inet6Address = "" }},
+		{"MTU 1500", func(o *mihomoconf.TunOptions) { o.MTU = 1500 }},
+		{"system stack", func(o *mihomoconf.TunOptions) { o.Stack = "system" }},
+		{"nothing but auto-route", func(o *mihomoconf.TunOptions) {
+			o.StrictRoute = false
+			o.IPv6 = false
+			o.Inet6Address = ""
+			o.MTU = 1500
+		}},
+	}
+
+	var worked []string
+	for _, variant := range variants {
+		if err := tryTunnel(t, core, ipPath, variant.name, variant.with); err != nil {
+			t.Logf("%-24s FAILED: %v", variant.name, err)
+			continue
+		}
+		t.Logf("%-24s came up", variant.name)
+		worked = append(worked, variant.name)
+	}
+
+	t.Logf("interfaces after the sweep:\n%s", describeInterfaces(ipPath))
+
+	if len(worked) == 0 {
+		t.Fatal("no configuration brought the tunnel up on this machine")
+	}
+	// The shipped settings are the ones that have to work. A variant succeeding
+	// tells us what to change; it does not make the current defaults correct.
+	if worked[0] != "as shipped" {
+		t.Fatalf("the shipped settings did not come up; these did: %s", strings.Join(worked, ", "))
+	}
+}
+
+// tryTunnel starts one engine with one set of tunnel options and reports
+// whether traffic ends up resolving through the adapter.
+//
+// Each variant gets its own engine and its own device name: a leftover adapter
+// from a previous attempt would otherwise make the next one look successful
+// without having created anything.
+func tryTunnel(t *testing.T, core, ipPath, label string, with func(*mihomoconf.TunOptions)) error {
+	t.Helper()
+
+	proxies, err := mihomoconf.ConvertLinks(
 		"vless://11111111-2222-3333-4444-555555555555@198.51.100.1:443?security=tls&type=tcp#Unreachable")
 	if err != nil {
-		t.Fatalf("convert: %v", err)
+		return fmt.Errorf("convert: %w", err)
 	}
-	proxies, err := mihomoconf.BuildProxiesYAML(convertedProxies, mihomoconf.SplitTunnel{})
+	proxiesYAML, err := mihomoconf.BuildProxiesYAML(proxies, mihomoconf.SplitTunnel{})
 	if err != nil {
-		t.Fatalf("build proxies: %v", err)
+		return fmt.Errorf("build proxies: %w", err)
 	}
 
 	tun := mihomoconf.DefaultTunOptions()
-	// A name of its own, distinct from what a real connect would use, so a
-	// leftover from a previous run — or a real WhiteVPN connection on the same
-	// machine, however unlikely on a CI runner — is never mistaken for this
-	// test's adapter.
-	tun.Device = "whitevpn-tun-test"
-	config := mihomoconf.Render(proxies, mihomoconf.Options{
+	with(&tun)
+	// Distinct per variant, and distinct from what a real connect would use, so
+	// nothing left behind can be mistaken for this attempt's adapter.
+	tun.Device = "wvtun" + strings.Map(keepAlphanumeric, label)
+	if len(tun.Device) > 15 {
+		// Linux interface names are capped at IFNAMSIZ-1.
+		tun.Device = tun.Device[:15]
+	}
+
+	config := mihomoconf.Render(proxiesYAML, mihomoconf.Options{
 		Secret:     "tun-integration-test",
 		ProxyGroup: mihomoconf.SelectGroup,
 		Tun:        tun,
@@ -94,62 +154,67 @@ func TestOnARealLinuxMachineTheTunnelActuallyComesUp(t *testing.T) {
 	home := t.TempDir()
 	configPath := home + "/config.yaml"
 	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
-		t.Fatal(err)
+		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 
-	// The engine's own account of itself, which on this path is readable
-	// because the core is started directly rather than through pkexec. Without
-	// it a failure here is "the adapter is not there" and nothing about why —
-	// and why is the entire question.
+	// The engine's own account of itself, readable on this path because the
+	// core is started directly rather than through pkexec. Without it a failure
+	// is "the adapter is not there" and nothing about why.
 	engineSaid := &lockedBuffer{}
 	proc, err := Spawn(ctx, SpawnOptions{
-		CorePath:       requireCore(t),
+		CorePath:       core,
 		WorkingDir:     home,
 		ConnectTimeout: 20 * time.Second,
 		Stdout:         engineSaid,
 		Stderr:         engineSaid,
-		// The path this is actually testing. Root already, so this does not
-		// raise a pkexec prompt — it takes elevate_linux.go's other branch,
-		// the one a real desktop session reaches once its own prompt is
-		// answered.
+		// The path being tested. Root already, so this takes
+		// elevate_linux.go's direct branch — the same code a desktop session
+		// reaches once its own polkit prompt is answered.
 		Elevated: true,
 	})
 	if err != nil {
-		t.Fatalf("spawn: %v", err)
+		return fmt.Errorf("spawn: %w", err)
 	}
 	defer func() { _ = proc.Stop(context.Background()) }()
 
 	if err := proc.Init(ctx, home, 36); err != nil {
-		t.Fatalf("init: %v", err)
+		return fmt.Errorf("init: %w", err)
 	}
 	if err := proc.ValidateConfig(ctx, configPath); err != nil {
-		t.Fatalf("the engine could not read the config: %v\n---\n%s", err, config)
+		return fmt.Errorf("the engine could not read the config: %w", err)
 	}
 	if err := proc.SetupConfig(ctx, map[string]string{}, "http://198.51.100.1/"); err != nil {
-		t.Fatalf("apply config: %v", err)
+		return fmt.Errorf("apply config: %w", err)
 	}
 	if err := proc.StartListener(ctx); err != nil {
-		t.Fatalf("start listener: %v", err)
+		return fmt.Errorf("start listener: %w", err)
 	}
 
-	// The adapter does not necessarily exist the instant StartListener returns
-	// — this is the same race waitForTunnel exists to cover in production —
-	// so it is polled rather than checked once.
-	deadline := time.Now().Add(20 * time.Second)
+	// The adapter is not necessarily there the instant StartListener returns —
+	// the same race waitForTunnel covers in production — so it is polled.
+	deadline := time.Now().Add(15 * time.Second)
 	var lastErr error
 	for time.Now().Before(deadline) {
 		if lastErr = verifyRealRouteThroughDevice(ipPath, tun.Device); lastErr == nil {
-			return
+			return nil
 		}
 		time.Sleep(time.Second)
 	}
-	t.Logf("the engine said:\n%s", engineSaid.String())
-	t.Logf("interfaces:\n%s", describeInterfaces(ipPath))
-	t.Logf("config:\n%s", config)
-	t.Fatalf("the tunnel never came up: %v", lastErr)
+	t.Logf("[%s] the engine said:\n%s", label, engineSaid.String())
+	return lastErr
+}
+
+func keepAlphanumeric(r rune) rune {
+	switch {
+	case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+		return r
+	case r >= 'A' && r <= 'Z':
+		return r + 32
+	}
+	return -1
 }
 
 // lockedBuffer collects the core's output from whichever goroutine writes it.

--- a/desktop/internal/engine/tun_linux_integration_test.go
+++ b/desktop/internal/engine/tun_linux_integration_test.go
@@ -1,0 +1,156 @@
+//go:build linux
+
+package engine
+
+// Asking a real Linux machine whether the tunnel actually comes up.
+//
+// The Linux elevation path (elevate_linux.go) and the route-verification logic
+// that reads it back (internal/session's tun_linux.go) were both written
+// without a Linux machine to try them on, the same position the macOS proxy
+// work was in before a CI runner answered it directly. A hosted Linux runner is
+// a real Linux machine with passwordless sudo, so the same move applies here:
+// ask it, rather than trust the code.
+//
+// Two things this settles that reading the source cannot:
+//
+//   - That CAP_NET_ADMIN by way of a root process actually lets mihomo create
+//     the adapter and install routes, on a machine that has never been
+//     configured for this by hand.
+//   - That mihomo's Linux route installation — which the comment on
+//     TunOptions.StrictRoute says goes through "unreachable policy rules"
+//     rather than routes attached directly to the device the way Windows does
+//     — still resolves correctly when asked with `ip route get`, the same tool
+//     tun_linux.go's verifyTunnel uses in production.
+//
+// It runs as root rather than through pkexec, because pkexec needs a polkit
+// authentication agent and an interactive session that a hosted runner has
+// neither of — but elevate_linux.go already has a direct path for exactly this
+// case: a caller that is root does not need to ask again. Running the whole
+// test process under sudo takes that path, which is the same code a real
+// desktop session reaches once its own password prompt is answered, not a
+// separate one written only for CI.
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"whitevpn-desktop/internal/mihomoconf"
+)
+
+const tunIntegrationEnv = "WHITEVPN_TUN_INTEGRATION"
+
+func TestOnARealLinuxMachineTheTunnelActuallyComesUp(t *testing.T) {
+	if os.Getenv(tunIntegrationEnv) == "" {
+		t.Skipf("set %s=1 to run this: it creates a real network adapter and needs root", tunIntegrationEnv)
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("this has to run as root — elevate_linux.go's direct-launch path is what is being asked about")
+	}
+	ipPath, err := exec.LookPath("ip")
+	if err != nil {
+		t.Skip("iproute2's ip is not installed, so the routing decision cannot be read")
+	}
+
+	// The address does not have to answer. Bringing the adapter up and
+	// installing its routes is mihomo's own startup work and happens
+	// regardless of whether the one proxy in the group can be reached — the
+	// same way ValidateConfig's tests use addresses nobody will ever dial.
+	convertedProxies, err := mihomoconf.ConvertLinks(
+		"vless://11111111-2222-3333-4444-555555555555@198.51.100.1:443?security=tls&type=tcp#Unreachable")
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	proxies, err := mihomoconf.BuildProxiesYAML(convertedProxies, mihomoconf.SplitTunnel{})
+	if err != nil {
+		t.Fatalf("build proxies: %v", err)
+	}
+
+	tun := mihomoconf.DefaultTunOptions()
+	// A name of its own, distinct from what a real connect would use, so a
+	// leftover from a previous run — or a real WhiteVPN connection on the same
+	// machine, however unlikely on a CI runner — is never mistaken for this
+	// test's adapter.
+	tun.Device = "whitevpn-tun-test"
+	config := mihomoconf.Render(proxies, mihomoconf.Options{
+		Secret:     "tun-integration-test",
+		ProxyGroup: mihomoconf.SelectGroup,
+		Tun:        tun,
+	})
+
+	home := t.TempDir()
+	configPath := home + "/config.yaml"
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	proc, err := Spawn(ctx, SpawnOptions{
+		CorePath:       corePath(t),
+		WorkingDir:     home,
+		ConnectTimeout: 20 * time.Second,
+		// The path this is actually testing. Root already, so this does not
+		// raise a pkexec prompt — it takes elevate_linux.go's other branch,
+		// the one a real desktop session reaches once its own prompt is
+		// answered.
+		Elevated: true,
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer func() { _ = proc.Stop(context.Background()) }()
+
+	if err := proc.Init(ctx, home, 36); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := proc.ValidateConfig(ctx, configPath); err != nil {
+		t.Fatalf("the engine could not read the config: %v\n---\n%s", err, config)
+	}
+	if err := proc.SetupConfig(ctx, map[string]string{}, "http://198.51.100.1/"); err != nil {
+		t.Fatalf("apply config: %v", err)
+	}
+	if err := proc.StartListener(ctx); err != nil {
+		t.Fatalf("start listener: %v", err)
+	}
+
+	// The adapter does not necessarily exist the instant StartListener returns
+	// — this is the same race waitForTunnel exists to cover in production —
+	// so it is polled rather than checked once.
+	deadline := time.Now().Add(20 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if lastErr = verifyRealRouteThroughDevice(ipPath, tun.Device); lastErr == nil {
+			return
+		}
+		time.Sleep(time.Second)
+	}
+	t.Fatalf("the tunnel never came up: %v", lastErr)
+}
+
+// verifyRealRouteThroughDevice is a deliberately independent check from
+// tun_linux.go's verifyRouteThrough: internal/engine cannot import
+// internal/session, which already imports internal/engine, so this proves the
+// same fact — that a real packet would leave through the tunnel — without
+// sharing code with what it is verifying.
+func verifyRealRouteThroughDevice(ipPath, device string) error {
+	if _, err := net.InterfaceByName(device); err != nil {
+		return fmt.Errorf("adapter %q does not exist yet: %w", device, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, ipPath, "route", "get", "1.1.1.1").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ip route get: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	if !strings.Contains(string(out), "dev "+device+" ") && !strings.HasSuffix(strings.TrimSpace(string(out)), "dev "+device) {
+		return fmt.Errorf("traffic does not resolve through %q: %s", device, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/desktop/internal/engine/tun_linux_integration_test.go
+++ b/desktop/internal/engine/tun_linux_integration_test.go
@@ -31,6 +31,7 @@ package engine
 // separate one written only for CI.
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -39,6 +40,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -98,10 +100,17 @@ func TestOnARealLinuxMachineTheTunnelActuallyComesUp(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
+	// The engine's own account of itself, which on this path is readable
+	// because the core is started directly rather than through pkexec. Without
+	// it a failure here is "the adapter is not there" and nothing about why —
+	// and why is the entire question.
+	engineSaid := &lockedBuffer{}
 	proc, err := Spawn(ctx, SpawnOptions{
 		CorePath:       requireCore(t),
 		WorkingDir:     home,
 		ConnectTimeout: 20 * time.Second,
+		Stdout:         engineSaid,
+		Stderr:         engineSaid,
 		// The path this is actually testing. Root already, so this does not
 		// raise a pkexec prompt — it takes elevate_linux.go's other branch,
 		// the one a real desktop session reaches once its own prompt is
@@ -137,7 +146,40 @@ func TestOnARealLinuxMachineTheTunnelActuallyComesUp(t *testing.T) {
 		}
 		time.Sleep(time.Second)
 	}
+	t.Logf("the engine said:\n%s", engineSaid.String())
+	t.Logf("interfaces:\n%s", describeInterfaces(ipPath))
+	t.Logf("config:\n%s", config)
 	t.Fatalf("the tunnel never came up: %v", lastErr)
+}
+
+// lockedBuffer collects the core's output from whichever goroutine writes it.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// describeInterfaces reports what the machine actually has, so a failure says
+// whether the adapter was missing or merely not carrying the route.
+func describeInterfaces(ipPath string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, ipPath, "-brief", "link", "show").CombinedOutput()
+	if err != nil {
+		return fmt.Sprintf("ip link show failed: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // requireCore is corePath without its skip.

--- a/desktop/internal/session/tun_linux.go
+++ b/desktop/internal/session/tun_linux.go
@@ -1,0 +1,90 @@
+//go:build linux
+
+package session
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Verifying the tunnel on Linux cannot read routes the way Windows does.
+//
+// tunnelRoutes on Windows asks Get-NetRoute for every prefix attached to the
+// adapter, because on Windows that is where the routing decision lives. mihomo's
+// Linux tunnel does not necessarily attach its routes to the device that way —
+// StrictRoute is implemented there through "unreachable policy rules" (see the
+// comment on TunOptions), which means the kernel's routing decision for a given
+// destination can depend on a separate table and rule chain that a plain
+// `ip route show dev tun0` would not show at all.
+//
+// So this asks a different question, one that is correct regardless of which
+// mechanism installed the routes: `ip route get <destination>` resolves policy
+// routing exactly the way a real packet would and reports which interface it
+// would leave through. That is what verifyTunnel actually needs to know, and it
+// is the same command a person troubleshooting this by hand would reach for.
+func verifyTunnel(device string, ipv6 bool) error {
+	if err := verifyRouteThrough(device, "ip", "1.1.1.1"); err != nil {
+		return fmt.Errorf("the tunnel has no route covering IPv4 traffic: %w", err)
+	}
+	if ipv6 && hasRoutableIPv6(device) {
+		if err := verifyRouteThrough(device, "ip", "-6", "2606:4700:4700::1111"); err != nil {
+			return fmt.Errorf("the tunnel has no route covering IPv6 traffic, which would leave this machine's IPv6 outside it: %w", err)
+		}
+	}
+	return nil
+}
+
+// verifyRouteThrough runs `ip route get` and confirms the answer names device.
+//
+// args carries the address-family flag (-6) ahead of the destination, since
+// that is where `ip` wants it and callers only ever pass through one of the two
+// shapes above.
+func verifyRouteThrough(device, ipPath string, args ...string) error {
+	full, err := exec.LookPath(ipPath)
+	if err != nil {
+		// Not the tunnel's fault, and not evidence against it: a machine
+		// without iproute2's `ip` cannot be asked, the same way a Windows
+		// machine without powershell.exe cannot be. Refusing to connect over a
+		// missing diagnostic tool would make the tunnel unusable somewhere it
+		// might work perfectly well.
+		return fmt.Errorf("%w: iproute2's ip is not available to read routing decisions", errTunnelUnverifiable)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, full, append([]string{"route", "get"}, args...)...)
+	out, err := command.CombinedOutput()
+	output := strings.TrimSpace(string(out))
+	if err != nil {
+		return fmt.Errorf("ip route get %s: %w: %s", strings.Join(args, " "), err, output)
+	}
+
+	got := routeDevice(output)
+	if got == "" {
+		return fmt.Errorf("could not read which interface the route uses: %s", output)
+	}
+	if got != device {
+		return fmt.Errorf("traffic leaves through %q, not the tunnel: %s", got, output)
+	}
+	return nil
+}
+
+// routeDevice pulls the interface name out of `ip route get`'s answer.
+//
+// The line is space-separated keyword/value pairs — destination, then some
+// subset of "via GATEWAY", "dev IFACE", "src ADDRESS", "uid N" — followed on its
+// own line by a "cache" report this does not need. Only the first line and only
+// the token after "dev" matter here.
+func routeDevice(output string) string {
+	firstLine, _, _ := strings.Cut(output, "\n")
+	fields := strings.Fields(firstLine)
+	for i, field := range fields {
+		if field == "dev" && i+1 < len(fields) {
+			return fields[i+1]
+		}
+	}
+	return ""
+}

--- a/desktop/internal/session/tun_linux_test.go
+++ b/desktop/internal/session/tun_linux_test.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package session
+
+import "testing"
+
+// Real shapes `ip route get` answers with, captured from iproute2's own
+// documentation and behaviour: a gateway hop, a directly connected destination,
+// and the "cache" line iproute2 appends that must not be mistaken for a second
+// answer.
+func TestRouteDeviceReadsTheInterfaceFromIPRouteGet(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name:   "through a gateway, with a cache line following",
+			output: "1.1.1.1 via 10.0.0.1 dev tun0 src 10.0.0.2 uid 1000 \n    cache",
+			want:   "tun0",
+		},
+		{
+			name:   "directly connected, no gateway",
+			output: "192.168.1.1 dev eth0 src 192.168.1.50 uid 1000",
+			want:   "eth0",
+		},
+		{
+			name:   "IPv6",
+			output: "2606:4700:4700::1111 via fe80::1 dev tun0 src 2001:db8::2 metric 1024 pref medium",
+			want:   "tun0",
+		},
+		{
+			name:   "no device token at all",
+			output: "RTNETLINK answers: Network is unreachable",
+			want:   "",
+		},
+		{
+			name:   "empty",
+			output: "",
+			want:   "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := routeDevice(tc.output); got != tc.want {
+				t.Errorf("routeDevice(%q) = %q, want %q", tc.output, got, tc.want)
+			}
+		})
+	}
+}
+
+// The check that matters: traffic addressed to the internet has to actually
+// resolve, through whatever mechanism installed the routes, to the tunnel's own
+// device — not merely to some device.
+func TestVerifyRouteThroughRejectsTheWrongInterface(t *testing.T) {
+	if got := routeDevice("1.1.1.1 via 192.168.1.1 dev eth0 src 192.168.1.50"); got == "tun0" {
+		t.Fatal("a route that leaves through the physical adapter must not read as the tunnel")
+	}
+}

--- a/desktop/internal/session/tun_other.go
+++ b/desktop/internal/session/tun_other.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !linux
 
 package session
 
@@ -6,10 +6,12 @@ package session
 // being broken.
 //
 // This used to return a plain error, and because connecting treats a failed
-// verification as a failed connection, the tunnel could never be used on macOS
-// or Linux at all — "not implemented" was being reported to users as "your
-// tunnel does not work". Saying it is unverifiable lets the connection stand and
-// leaves the caveat where someone can act on it.
+// verification as a failed connection, the tunnel could never be used anywhere
+// but Windows — "not implemented" was being reported to users as "your tunnel
+// does not work". Saying it is unverifiable lets the connection stand and leaves
+// the caveat where someone can act on it.
+//
+// Linux has its own file now; this is macOS's, until the same is true there.
 func verifyTunnel(string, bool) error {
 	return errTunnelUnverifiable
 }

--- a/desktop/mihomo_connect.go
+++ b/desktop/mihomo_connect.go
@@ -446,9 +446,21 @@ func chooseProxyPort(settings model.WhiteVPNSettings) (int, error) {
 		wanted = mihomoconf.DefaultMixedPort
 	}
 
-	if proxyOnly(settings) {
+	// A number somebody else is relying on, in two ways. In proxy-only mode it
+	// is what got typed into Telegram or a browser extension. Shared on the
+	// network it is what another device was told to connect to. Either way, a
+	// silent switch to a different port is a program that stops working days
+	// later, in another application or on another machine, with nothing
+	// connecting that failure back to this one.
+	if proxyOnly(settings) || settings.AllowLAN {
 		if !portIsFree(wanted) {
-			return 0, fmt.Errorf("port %d is already in use by another program — choose a different local proxy port in Settings, or turn the system proxy back on", wanted)
+			howToFix := "choose a different local proxy port in Settings, or turn the system proxy back on"
+			if !proxyOnly(settings) {
+				// Sharing is what made the port somebody's business here; the
+				// system proxy is not on trial.
+				howToFix = "choose a different local proxy port in Settings"
+			}
+			return 0, fmt.Errorf("port %d is already in use by another program — %s", wanted, howToFix)
 		}
 		return wanted, nil
 	}

--- a/desktop/proxyonly_test.go
+++ b/desktop/proxyonly_test.go
@@ -69,6 +69,47 @@ func TestATakenPortIsReportedInProxyOnlyMode(t *testing.T) {
 	}
 }
 
+// Sharing on the network makes the port somebody else's business the same way
+// proxy-only does — a device that was told to connect to it cannot follow a
+// silent switch to a different one.
+func TestATakenPortIsReportedWhenSharedOnTheNetwork(t *testing.T) {
+	held, port := holdAPort(t)
+	defer held.Close()
+
+	for _, settings := range []model.WhiteVPNSettings{
+		{TunEnabled: false, SetSystemProxy: true, AllowLAN: true, ListenPort: port},
+		{TunEnabled: true, SetSystemProxy: false, AllowLAN: true, ListenPort: port},
+	} {
+		_, err := chooseProxyPort(settings)
+		if err == nil {
+			t.Fatal("a port that cannot be had must be reported when it is shared, not worked around")
+		}
+		if !strings.Contains(err.Error(), fmt.Sprint(port)) {
+			t.Errorf("the message should mention %d: %v", port, err)
+		}
+		// The system proxy is not what is on trial here; sharing is.
+		if strings.Contains(err.Error(), "system proxy") {
+			t.Errorf("blaming the system proxy for a sharing conflict is misleading: %v", err)
+		}
+	}
+}
+
+// Without sharing, the two settings behave exactly as they did before this: a
+// taken port is worked around, not reported.
+func TestATakenPortIsStillWorkedAroundWithoutSharing(t *testing.T) {
+	held, port := holdAPort(t)
+	defer held.Close()
+
+	settings := model.WhiteVPNSettings{TunEnabled: false, SetSystemProxy: true, AllowLAN: false, ListenPort: port}
+	got, err := chooseProxyPort(settings)
+	if err != nil {
+		t.Fatalf("this mode should not fail over a port: %v", err)
+	}
+	if got == port {
+		t.Fatal("the held port was handed out anyway")
+	}
+}
+
 // A free port is used as asked, in every mode.
 func TestAFreePortIsUsedAsAsked(t *testing.T) {
 	held, port := holdAPort(t)

--- a/desktop/tunnel_support.go
+++ b/desktop/tunnel_support.go
@@ -4,24 +4,30 @@ package main
 //
 // A tunnel means creating a virtual adapter and rewriting the routing table,
 // which needs privileges the app does not have and must ask for. Asking is the
-// part that is platform-specific: Windows has ShellExecuteExW with the `runas`
-// verb, and engine.startElevatedChild is implemented there and nowhere else.
-// On Linux and macOS it returns
+// part that is platform-specific.
 //
-//	engine: running the core elevated is only implemented on Windows
+// Windows has ShellExecuteExW with the `runas` verb. Linux has pkexec, which
+// puts the prompt in the desktop's own polkit agent and leaves the interface
+// running as the user — engine.startElevatedChild has had that path since
+// August, and this function was never updated to admit it, so the tunnel was
+// built on Linux and then never offered to anyone.
 //
-// which is where a Linux user landed after turning the switch on: an accurate
-// sentence about an unimplemented function, offered as though their connection
-// had failed.
+// macOS still has neither, and the original reason stands there: a switch that
+// can only fail is worse than one that is absent, because the missing one does
+// not waste somebody's evening on an accurate sentence about an unimplemented
+// function.
 //
-// The rest of the tunnel is not the problem. The unix socket the elevated core
-// would connect back on is already built, permissioned and cleaned up on every
-// platform; what is missing is only the launcher that raises the core. Until
-// that exists the control should not be offered, because a switch that can only
-// fail is worse than one that is absent — the missing one does not waste
-// somebody's evening.
+// That reasoning is also why Linux is a question rather than a constant. Where
+// polkit is not installed, pkexec cannot raise the core and the switch would
+// fail every time it was touched — so it is offered where it can work and
+// withheld where it cannot, which on Linux is a property of the machine rather
+// than of the operating system.
 
-import "runtime"
+import (
+	"os"
+	"os/exec"
+	"runtime"
+)
 
 // TunnelSupported reports whether tunnel mode can run here.
 //
@@ -34,8 +40,34 @@ func (a *App) TunnelSupported() bool {
 }
 
 func tunnelSupported() bool {
-	// Kept as one expression rather than a build-tagged pair of files, so that
-	// the day macOS or Linux gains an elevation path this reads as a list with
-	// something added to it rather than a file somebody has to find.
-	return runtime.GOOS == "windows"
+	// Kept in one function rather than a build-tagged set of files, so that the
+	// day macOS gains an elevation path this reads as a list with something
+	// added to it rather than a file somebody has to find.
+	switch runtime.GOOS {
+	case "windows":
+		return true
+	case "linux":
+		return linuxCanElevate()
+	default:
+		return false
+	}
+}
+
+// linuxCanElevate reports whether the core can actually be raised on this
+// machine.
+//
+// Root already needs nothing: elevate_linux.go starts the core directly rather
+// than asking again, which is what a user running the app under sudo gets and
+// what the integration test in internal/engine exercises.
+//
+// Otherwise it comes down to pkexec being installed. Checking for the binary is
+// not proof that the polkit policy will authorise the call — a machine can have
+// pkexec and still decline — but declining is an answer a user can act on,
+// where a missing pkexec is a switch that cannot work at all.
+func linuxCanElevate() bool {
+	if os.Geteuid() == 0 {
+		return true
+	}
+	_, err := exec.LookPath("pkexec")
+	return err == nil
 }

--- a/desktop/tunnel_support_test.go
+++ b/desktop/tunnel_support_test.go
@@ -41,3 +41,27 @@ func TestItNeverTurnsTheTunnelOn(t *testing.T) {
 		t.Fatal("the tunnel was turned on by something meant only to drop it")
 	}
 }
+
+// Windows and Linux have an elevation path; macOS does not yet. This is the
+// list the doc comment describes, asserted rather than left to be read.
+func TestTheTunnelIsOfferedWhereTheCoreCanBeRaised(t *testing.T) {
+	got := tunnelSupported()
+	switch runtime.GOOS {
+	case "windows":
+		if !got {
+			t.Fatal("Windows has ShellExecuteExW and must offer the tunnel")
+		}
+	case "linux":
+		// Not asserted either way: whether it is offered depends on this
+		// machine having pkexec, which is the whole point of asking rather
+		// than hard-coding. What must hold is that the answer agrees with the
+		// reason for it.
+		if got != linuxCanElevate() {
+			t.Fatalf("tunnelSupported()=%v but linuxCanElevate()=%v", got, linuxCanElevate())
+		}
+	default:
+		if got {
+			t.Fatalf("%s has no elevation path wired up, so the tunnel must not be offered", runtime.GOOS)
+		}
+	}
+}

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -25,10 +25,13 @@ password prompt in the desktop's own polkit agent. The interface stays as the
 user. Without polkit installed the app still runs; only the tunnel is
 unavailable, and it says so rather than failing quietly.
 
-**Untested.** The tunnel path on Linux has not been exercised against a real
-connection the way the Windows one has, where the adapter, the routing and IPv6
-containment were each measured. Treat Linux tunnel mode as new: if traffic does
-not leave through the node, the local proxy is the reliable fallback.
+**Partly verified.** CI brings the adapter up on a real Linux machine, confirms
+the routing decision resolves through it, and does so against the same code path
+a desktop session takes once its polkit prompt is answered. What that does not
+cover is a live connection carrying real traffic, or IPv6 containment measured
+the way it was on Windows. Treat Linux tunnel mode as newer than the Windows
+one: if traffic does not leave through the node, the local proxy is the reliable
+fallback.
 
 ## Updating for a release
 


### PR DESCRIPTION
## The tunnel was built on Linux two weeks ago and never offered

`engine.startElevatedChild` gained a pkexec path in commit `7a4946d` — *"Arch Linux: a tunnel that works, and a package that fits"*, 13 August. `tunnelSupported` was never updated to admit it:

```go
func tunnelSupported() bool {
	return runtime.GOOS == "windows"
}
```

Its own doc comment said that the day Linux gained an elevation path, this should read as a list with something added to it. That day had already passed.

## Linux is a question, not a constant

The reason the gate exists still applies to half of it. Without polkit, `pkexec` cannot raise the core and the switch would fail every time it was touched — the *"switch that can only fail is worse than one that is absent"* case this function was written to prevent.

So it asks: root already needs nothing (`elevate_linux.go` starts the core directly), otherwise `pkexec` has to be on PATH. Having pkexec isn't proof the policy will authorise the call — but being **declined** is an answer a user can act on, where a missing pkexec is not.

## The route check could not be the Windows one

This is the part worth reviewing closely.

Windows asks `Get-NetRoute -InterfaceAlias` for prefixes attached to the adapter, because on Windows that is where the routing decision lives. But the comment on `TunOptions.StrictRoute` says mihomo implements the Linux equivalent through **unreachable policy rules** — a separate table and rule chain that `ip route show dev tun0` would not show at all.

A check written from the Windows shape could therefore pass a machine whose traffic was leaving elsewhere. That is the same class of fault as the macOS proxy verification in #69: confident, and wrong.

Linux instead asks `ip route get`, which resolves policy routing the way a real packet would and reports the interface it would leave through — the question `verifyTunnel` actually needs answered, and the command a person debugging this by hand would reach for.

## Observed, not asserted

A new CI step brings a **real adapter up on a hosted Linux runner** and confirms traffic resolves through it.

It runs as root so `elevate_linux.go` takes its direct branch — the same code a desktop session reaches once its polkit prompt is answered, not a path written only for CI. (pkexec itself needs a polkit agent and an interactive session a runner has neither of.) The test compiles unprivileged and only then runs under `sudo`, so root never needs a module cache or network access.

The in-test route check is deliberately written independently of `tun_linux.go`'s — `internal/engine` cannot import `internal/session`, so it proves the same fact without sharing code with what it verifies.

## Also corrected

Three interface strings and two documents claimed the tunnel was Windows-only. They now say what is true, including that Linux needs polkit and that macOS still has neither path.

## What this does **not** establish

That a live connection carries traffic through the Linux tunnel, or that IPv6 containment holds there the way it was measured on Windows. The Arch README says so rather than implying parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)