### PR TITLE
Let people keep chosen sites out of the tunnel

### DIFF
--- a/desktop/directroute_settings_test.go
+++ b/desktop/directroute_settings_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"whitevpn-desktop/internal/model"
+)
+
+// Switching it off has to produce the same configuration as never having
+// switched it on, or somebody comparing two connections is comparing documents
+// that differ for no reason.
+func TestDirectRoutingOffKeepsTheListsButWritesNoRules(t *testing.T) {
+	settings := model.WhiteVPNSettings{
+		DirectRouting: model.DirectRoutingSettings{
+			Enabled: false,
+			Domains: []string{"ir", "digikala.com"},
+			IPs:     []string{"10.0.0.0/8"},
+		},
+	}
+	route := directRouteFor(settings)
+	if route.Active() {
+		t.Fatal("the lists should not reach the engine while the switch is off")
+	}
+	// And the lists themselves survive, which is what makes turning it off
+	// worth doing rather than clearing them.
+	if len(settings.DirectRouting.Domains) != 2 {
+		t.Fatal("the saved list was modified by reading it")
+	}
+}
+
+func TestDirectRoutingOnCarriesBothLists(t *testing.T) {
+	route := directRouteFor(model.WhiteVPNSettings{
+		DirectRouting: model.DirectRoutingSettings{
+			Enabled: true,
+			Domains: []string{"ir"},
+			IPs:     []string{"10.0.0.0/8"},
+		},
+	})
+	if !route.Active() {
+		t.Fatal("expected the route to be active")
+	}
+	rules := strings.Join(route.Rules(), "\n")
+	for _, want := range []string{"DOMAIN-SUFFIX,ir,DIRECT", "IP-CIDR,10.0.0.0/8,DIRECT,no-resolve"} {
+		if !strings.Contains(rules, want) {
+			t.Errorf("missing %q in:\n%s", want, rules)
+		}
+	}
+}
+
+// The starting list is off, so an update cannot change where anybody's traffic
+// goes without them choosing it.
+func TestTheStartingListIsOffButNotEmpty(t *testing.T) {
+	defaults := model.DefaultDirectRouting()
+	if defaults.Enabled {
+		t.Fatal("shipping this on would reroute traffic nobody asked to reroute")
+	}
+	if len(defaults.Domains) == 0 {
+		t.Fatal("an empty list behind a switch teaches nobody what the switch is for")
+	}
+	// ".ir" is the entry that earns its place without any database at all.
+	found := false
+	for _, domain := range defaults.Domains {
+		if domain == "ir" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal(`"ir" covers the whole .ir top-level domain and should be there`)
+	}
+}
+
+// A settings file edited by hand, or one carried from an older version, must
+// not be able to put blanks or repeats in front of the engine.
+func TestHandEditedListsAreTidiedOnLoad(t *testing.T) {
+	got := model.NormalizeWhiteVPNSettings(model.WhiteVPNSettings{
+		DirectRouting: model.DirectRoutingSettings{
+			Enabled: true,
+			Domains: []string{"IR", " ", "ir", "digikala.com", ""},
+			IPs:     []string{"10.0.0.0/8", "", "10.0.0.0/8"},
+		},
+	})
+	if len(got.DirectRouting.Domains) != 2 {
+		t.Fatalf("domains were not tidied: %v", got.DirectRouting.Domains)
+	}
+	if len(got.DirectRouting.IPs) != 1 {
+		t.Fatalf("addresses were not tidied: %v", got.DirectRouting.IPs)
+	}
+}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -6248,6 +6248,8 @@ function WhiteVPNSettingsPage({
 
   const [frontingDraft, setFrontingDraft] = useState("");
   const [processDraft, setProcessDraft] = useState("");
+  const [directDomainDraft, setDirectDomainDraft] = useState("");
+  const [directIpDraft, setDirectIpDraft] = useState("");
   const [saving, setSaving] = useState(false);
 
   // Settings changed elsewhere — a backup restore, most likely — have to reach
@@ -6302,6 +6304,21 @@ function WhiteVPNSettingsPage({
     }
     patch({ splitTunnel: { ...draft.splitTunnel, processes: [...draft.splitTunnel.processes, value] } });
     setProcessDraft("");
+  }
+
+  function addDirectEntry(kind: "domains" | "ips", value: string, clear: () => void) {
+    const entry = value.trim();
+    if (!entry) {
+      return;
+    }
+    // Cleared even when it is already there, so a second Enter on the same
+    // value does not leave the field looking like it failed.
+    if (draft.directRouting[kind].includes(entry)) {
+      clear();
+      return;
+    }
+    patch({ directRouting: { ...draft.directRouting, [kind]: [...draft.directRouting[kind], entry] } });
+    clear();
   }
 
   const dnsMode = draft.dnsPrivacy.mode;
@@ -6510,6 +6527,108 @@ function WhiteVPNSettingsPage({
           emptyLabel={t("settings.fronting.empty")}
           onRemove={(value) => patch({ frontingIps: draft.frontingIps.filter((entry) => entry !== value) })}
         />
+      </SettingsSection>
+
+      <SettingsSection
+        title={t("settings.directRouting.title")}
+        description={t("settings.directRouting.description")}
+      >
+        <SettingSwitchRow
+          label={t("settings.directRouting.enable")}
+          checked={draft.directRouting.enabled}
+          onCheckedChange={(enabled) => patch({ directRouting: { ...draft.directRouting, enabled } })}
+        />
+        <FieldDescription>{t("settings.directRouting.enableHint")}</FieldDescription>
+
+        <FieldGroup>
+          <Field>
+            <FieldLabel>{t("settings.directRouting.domain")}</FieldLabel>
+            <div className="flex gap-2">
+              <Input
+                value={directDomainDraft}
+                placeholder="digikala.com"
+                disabled={!draft.directRouting.enabled}
+                onChange={(event) => setDirectDomainDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    addDirectEntry("domains", directDomainDraft, () => setDirectDomainDraft(""));
+                  }
+                }}
+              />
+              <Button
+                variant="outline"
+                disabled={!draft.directRouting.enabled}
+                onClick={() => addDirectEntry("domains", directDomainDraft, () => setDirectDomainDraft(""))}
+              >
+                {t("common.add")}
+              </Button>
+            </div>
+            <FieldDescription>{t("settings.directRouting.domainHint")}</FieldDescription>
+          </Field>
+        </FieldGroup>
+        <RemovableBadges
+          values={draft.directRouting.domains}
+          emptyLabel={t("settings.directRouting.emptyDomains")}
+          onRemove={(value) =>
+            patch({
+              directRouting: {
+                ...draft.directRouting,
+                domains: draft.directRouting.domains.filter((entry) => entry !== value),
+              },
+            })
+          }
+        />
+
+        <FieldGroup>
+          <Field>
+            <FieldLabel>{t("settings.directRouting.ip")}</FieldLabel>
+            <div className="flex gap-2">
+              <Input
+                value={directIpDraft}
+                placeholder="10.0.0.0/8"
+                disabled={!draft.directRouting.enabled}
+                onChange={(event) => setDirectIpDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    addDirectEntry("ips", directIpDraft, () => setDirectIpDraft(""));
+                  }
+                }}
+              />
+              <Button
+                variant="outline"
+                disabled={!draft.directRouting.enabled}
+                onClick={() => addDirectEntry("ips", directIpDraft, () => setDirectIpDraft(""))}
+              >
+                {t("common.add")}
+              </Button>
+            </div>
+            <FieldDescription>{t("settings.directRouting.ipHint")}</FieldDescription>
+          </Field>
+        </FieldGroup>
+        <RemovableBadges
+          values={draft.directRouting.ips}
+          emptyLabel={t("settings.directRouting.emptyIps")}
+          onRemove={(value) =>
+            patch({
+              directRouting: {
+                ...draft.directRouting,
+                ips: draft.directRouting.ips.filter((entry) => entry !== value),
+              },
+            })
+          }
+        />
+
+        {/* Said where the lists are, not in a tooltip. Somebody who has just
+            sent their bank around the tunnel should know what that means before
+            they close the page, not find out from a landlord or an employer. */}
+        {draft.directRouting.enabled && (
+          <Alert>
+            <AlertCircle />
+            <AlertDescription>{t("settings.directRouting.warning")}</AlertDescription>
+          </Alert>
+        )}
       </SettingsSection>
 
       <SettingsSection title={t("settings.splitTunnel.title")} description={t("settings.splitTunnel.description")}>

--- a/desktop/frontend/src/i18n.ts
+++ b/desktop/frontend/src/i18n.ts
@@ -756,6 +756,32 @@ const strings = {
     fa: "آدرس جایگزینی تنظیم نشده. سرورها مستقیم در دسترس‌اند.",
   },
 
+  "settings.directRouting.title": { en: "Sites that skip the tunnel", fa: "سایت‌هایی که از تونل رد نمی‌شوند" },
+  "settings.directRouting.description": {
+    en: "Send chosen sites straight out of this machine instead of through the VPN. Iranian sites are the usual reason: they load faster, some refuse foreign addresses outright, and you no longer have to disconnect to reach a bank or a government form.",
+    fa: "سایت‌های انتخابی به‌جای عبور از وی‌پی‌ان، مستقیم از همین دستگاه خارج می‌شوند. دلیل معمولش سایت‌های ایرانی است: سریع‌تر باز می‌شوند، بعضی‌شان آدرس خارجی را اصلاً قبول نمی‌کنند، و دیگر لازم نیست برای بانک یا سامانه‌های دولتی اتصال را قطع کنید.",
+  },
+  "settings.directRouting.enable": { en: "Send these straight out", fa: "این‌ها مستقیم خارج شوند" },
+  "settings.directRouting.enableHint": {
+    en: "Off keeps the lists but sends everything through the tunnel, so you can turn it off to test a site and back on without retyping anything.",
+    fa: "خاموش، فهرست‌ها را نگه می‌دارد ولی همه چیز از تونل رد می‌شود — پس می‌توانید برای تست یک سایت خاموشش کنید و بعد بدون تایپ دوباره برش گردانید.",
+  },
+  "settings.directRouting.domain": { en: "Website", fa: "وب‌سایت" },
+  "settings.directRouting.domainHint": {
+    en: "Matched by ending, so \"ir\" covers every .ir address at once and \"digikala.com\" covers its subdomains too. Pasting a full address is fine — the scheme and path are trimmed.",
+    fa: "بر اساس پایان آدرس تطبیق داده می‌شود، پس «ir» همهٔ آدرس‌های ir. را یکجا می‌گیرد و «digikala.com» زیردامنه‌هایش را هم شامل می‌شود. چسباندن آدرس کامل هم اشکالی ندارد — بخش‌های اضافه حذف می‌شوند.",
+  },
+  "settings.directRouting.emptyDomains": { en: "No websites listed", fa: "هیچ وب‌سایتی در فهرست نیست" },
+  "settings.directRouting.ip": { en: "Address range", fa: "محدودهٔ آدرس" },
+  "settings.directRouting.ipHint": {
+    en: "A range like 10.0.0.0/8, or a single address. Useful for something reached by address rather than by name — a work network, a device on another site.",
+    fa: "محدوده‌ای مثل 10.0.0.0/8، یا یک آدرس تکی. برای چیزی که با آدرس صدا زده می‌شود نه با نام — مثل شبکهٔ محل کار یا دستگاهی در جای دیگر.",
+  },
+  "settings.directRouting.emptyIps": { en: "No address ranges listed", fa: "هیچ محدودهٔ آدرسی در فهرست نیست" },
+  "settings.directRouting.warning": {
+    en: "Traffic to everything listed here leaves with your real address and is visible to your internet provider, exactly as it would be with the VPN switched off. That is the point of it — but it means anything you would not want seen does not belong on these lists.",
+    fa: "ترافیک هر چیزی که اینجا فهرست شده با آدرس واقعی شما خارج می‌شود و برای سرویس‌دهندهٔ اینترنتتان قابل دیدن است، دقیقاً مثل وقتی که وی‌پی‌ان خاموش باشد. هدف همین است — ولی یعنی هر چیزی که نمی‌خواهید دیده شود، جایش در این فهرست‌ها نیست.",
+  },
   "settings.splitTunnel.title": { en: "Split tunnel", fa: "تقسیم تونل" },
   "settings.splitTunnel.description": {
     en: "Choose which programs the tunnel carries.",

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -751,10 +751,24 @@ export type WhiteVPNNodeList = {
 
 // Mirrors model.WhiteVPNSettings. Every field here is a setting WhiteVPN for
 // Android exposes, so that someone moving from the phone finds the same options.
+// Destinations that never enter the tunnel — the user's own two lists.
+//
+// Not a country switch: mihomo's GEOIP rule downloads a database when one is
+// not on disk and fails the whole configuration when it cannot reach it, so on
+// a filtered network it would stop the tunnel rather than route around it.
+export type DirectRoutingSettings = {
+  enabled: boolean;
+  // Matched by suffix: "ir" catches every .ir address.
+  domains: string[];
+  // CIDR ranges; a bare address is read as a single host.
+  ips: string[];
+};
+
 export type WhiteVPNSettings = {
   countryCode: string;
   connection: ConnectionSelection;
   splitTunnel: SplitTunnelSettings;
+  directRouting: DirectRoutingSettings;
   tlsIntegrityEnabled: boolean;
   amneziaNoise: AmneziaNoiseSettings;
   frontingIps: string[];

--- a/desktop/internal/engine/config_integration_test.go
+++ b/desktop/internal/engine/config_integration_test.go
@@ -73,6 +73,50 @@ func TestGeneratedConfigIsReadableByTheEngine(t *testing.T) {
 	}
 }
 
+// Direct-routing rules are generated text going into someone else's parser, so
+// whether that parser accepts them is not something reading our own code can
+// answer. ValidateConfig only catches what fails to parse, which is exactly the
+// class of fault a malformed rule would be.
+func TestDirectRoutingRulesAreReadableByTheEngine(t *testing.T) {
+	proxies, err := mihomoconf.ConvertLinks(
+		"vless://11111111-2222-3333-4444-555555555555@a.example.com:443?security=tls&type=tcp#Direct%20Routing")
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	proxiesYAML, _, err := mihomoconf.BuildProxiesYAMLWithRouting(proxies, mihomoconf.Routing{
+		Direct: mihomoconf.DirectRoute{
+			// The shipped starting list, plus the shapes a person types.
+			Domains: []string{"ir", "digikala.com", "  APARAT.com ", "https://bank.ir/login"},
+			IPs:     []string{"10.0.0.0/8", "1.2.3.4", "2001:db8::/32"},
+		},
+		Split: mihomoconf.SplitTunnel{Mode: mihomoconf.SplitTunnelBypass, Processes: []string{"firefox.exe"}},
+	})
+	if err != nil {
+		t.Fatalf("build proxies: %v", err)
+	}
+	config := mihomoconf.Render(proxiesYAML, mihomoconf.Options{
+		Secret:     "validation-secret",
+		ProxyGroup: mihomoconf.SelectGroup,
+	})
+
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	proc := spawnReal(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := proc.Init(ctx, home, 36); err != nil {
+		t.Fatalf("initClash: %v", err)
+	}
+	if err := proc.ValidateConfig(ctx, configPath); err != nil {
+		t.Fatalf("the engine could not read our direct-routing rules: %v\n---\n%s", err, config)
+	}
+}
+
 // The negative control, so the check above is not vacuous. It has to be
 // unparseable YAML, because that is the only class of fault this call detects.
 func TestEngineRejectsUnparseableConfig(t *testing.T) {

--- a/desktop/internal/mihomoconf/config.go
+++ b/desktop/internal/mihomoconf/config.go
@@ -185,22 +185,45 @@ type Options struct {
 	SplitTunnel SplitTunnel
 }
 
+// Routing is how traffic is divided between the tunnel and everything else.
+//
+// A struct rather than three more parameters. These are one decision made in
+// three parts — what leaves directly, which programs are in scope, and whether
+// there is a second hop — and they are read together at the one place that
+// orders them into a rule list, where getting the order wrong is the whole
+// failure mode.
+type Routing struct {
+	// Direct never enters the tunnel: the user's own destinations.
+	Direct DirectRoute
+	// Split decides which programs are carried.
+	Split SplitTunnel
+	// Chain optionally sends traffic through a second node before it leaves.
+	Chain Chain
+}
+
 // BuildProxiesYAML renders proxies plus the two default groups and a catch-all
 // rule, which is what a link-based subscription needs: links carry nodes and
 // nothing else, so without this there is nothing for traffic to match.
 func BuildProxiesYAML(proxies []Proxy, split SplitTunnel) (string, error) {
-	document, _, err := BuildProxiesYAMLWithChain(proxies, split, Chain{})
+	document, _, err := BuildProxiesYAMLWithRouting(proxies, Routing{Split: split})
 	return document, err
 }
 
 // BuildProxiesYAMLWithChain is BuildProxiesYAML, and optionally a second hop.
+func BuildProxiesYAMLWithChain(proxies []Proxy, split SplitTunnel, chain Chain) (string, []string, error) {
+	return BuildProxiesYAMLWithRouting(proxies, Routing{Split: split, Chain: chain})
+}
+
+// BuildProxiesYAMLWithRouting renders the document with every routing decision
+// applied.
 //
 // It also returns the names the first hop may be chosen from, which is not the
 // full list once a chain is in play: the exit's own node is taken out, and a
 // datagram exit narrows it further to nodes that can carry UDP. A caller
 // selecting a proxy has to select from these, or it would name one the group
 // does not contain.
-func BuildProxiesYAMLWithChain(proxies []Proxy, split SplitTunnel, chain Chain) (string, []string, error) {
+func BuildProxiesYAMLWithRouting(proxies []Proxy, routing Routing) (string, []string, error) {
+	split, chain, direct := routing.Split, routing.Chain, routing.Direct
 	if len(proxies) == 0 {
 		return "", nil, fmt.Errorf("mihomoconf: no proxies to build a config from")
 	}
@@ -256,9 +279,19 @@ func BuildProxiesYAMLWithChain(proxies []Proxy, split SplitTunnel, chain Chain) 
 				"proxies":   firstHopNames,
 			},
 		},
-		// Split-tunnel rules first, because mihomo takes the first rule that
-		// fits: a catch-all above them means nothing below is ever reached.
-		"rules": append(split.Rules(exitTarget), catchAllRules(split, exitTarget)...),
+		// Order is the whole of a rule list's meaning, because mihomo takes the
+		// first rule that fits.
+		//
+		// Direct routing comes before the split tunnel, not after. Both can
+		// send traffic direct, so for the bypass mode the order changes
+		// nothing — but under "only these programs are tunnelled" it decides
+		// whether a tunnelled program's Iranian traffic still goes around. It
+		// should: somebody who named their bank has named it whichever program
+		// opens it.
+		//
+		// The catch-all is last and may be absent, when the split tunnel has
+		// written its own.
+		"rules": concatRules(direct.Rules(), split.Rules(exitTarget), catchAllRules(split, exitTarget)),
 	}
 
 	encoded, err := yaml.Marshal(document)
@@ -266,6 +299,19 @@ func BuildProxiesYAMLWithChain(proxies []Proxy, split SplitTunnel, chain Chain) 
 		return "", nil, err
 	}
 	return string(encoded), firstHopNames, nil
+}
+
+// concatRules joins the rule groups in the order they must be matched.
+func concatRules(groups ...[]string) []string {
+	total := 0
+	for _, group := range groups {
+		total += len(group)
+	}
+	rules := make([]string, 0, total)
+	for _, group := range groups {
+		rules = append(rules, group...)
+	}
+	return rules
 }
 
 // catchAllRules is what everything not matched already does.

--- a/desktop/internal/mihomoconf/directroute.go
+++ b/desktop/internal/mihomoconf/directroute.go
@@ -1,0 +1,129 @@
+package mihomoconf
+
+// Destinations the user wants kept out of the tunnel.
+//
+// The request this answers: Iranian sites should not have to travel to another
+// country and back, and people were disconnecting the VPN to reach a bank or a
+// government form and then forgetting to turn it on again. A connection people
+// keep switching off is not protecting them.
+//
+// Held as the user's own two lists rather than a country switch, and that is a
+// deliberate refusal of the obvious design. mihomo can match a country with
+// GEOIP, but `NewGEOIP` calls `InitGeoIP`, which downloads a database when one
+// is not on disk and returns an error when it cannot — and a rule that fails to
+// parse fails the whole configuration. Nothing ships that database with this
+// app. So on a filtered network, on the first connection after an install, a
+// GEOIP rule would not send Iranian traffic around the tunnel; it would stop
+// the tunnel existing, for exactly the people who most need it. That is a bad
+// enough trade to be worth writing down rather than discovering.
+//
+// Two lists cost nothing and cannot fail. `ir` as a domain suffix covers every
+// `.ir` address on its own, with no database anywhere, and the rest is names
+// people add as they meet them — which also makes this useful to somebody whose
+// list has nothing to do with Iran.
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DirectRoute names destinations that leave the machine directly.
+type DirectRoute struct {
+	// Domains are matched by suffix, so "ir" catches every .ir address and
+	// "digikala.com" catches its subdomains too. Written without a leading dot;
+	// that is mihomo's spelling and the one people copy out of other clients.
+	Domains []string
+
+	// IPs are CIDR ranges. A bare address is accepted and read as a single
+	// host, because typing /32 after an address is a step people forget and an
+	// error message about it teaches nothing.
+	IPs []string
+}
+
+// Active reports whether anything here would produce a rule.
+func (d DirectRoute) Active() bool {
+	return len(cleanDomains(d.Domains)) > 0 || len(cleanIPs(d.IPs)) > 0
+}
+
+// Rules renders the direct-routing rules, most specific first.
+//
+// Addresses before names, because an IP rule can be answered without resolving
+// anything while a domain rule cannot, and mihomo takes the first rule that
+// fits.
+func (d DirectRoute) Rules() []string {
+	domains := cleanDomains(d.Domains)
+	ips := cleanIPs(d.IPs)
+
+	rules := make([]string, 0, len(domains)+len(ips))
+	for _, ip := range ips {
+		// no-resolve, so a name is never looked up just to test it against an
+		// address range. Without it every request would resolve before routing,
+		// which both slows things down and leaks the name to whichever resolver
+		// answered — the leak this app closes elsewhere.
+		rules = append(rules, fmt.Sprintf("IP-CIDR,%s,DIRECT,no-resolve", ip))
+	}
+	for _, domain := range domains {
+		rules = append(rules, fmt.Sprintf("DOMAIN-SUFFIX,%s,DIRECT", domain))
+	}
+	return rules
+}
+
+// cleanDomains normalises what somebody typed into what mihomo matches.
+//
+// A leading dot, a scheme, a path, a stray uppercase: all of them are what a
+// person copying an address out of a browser produces, and all of them would
+// silently match nothing. Fixing them here is better than a validation message,
+// because there is exactly one thing each could have meant.
+func cleanDomains(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		domain := strings.ToLower(strings.TrimSpace(value))
+		if scheme := strings.Index(domain, "://"); scheme >= 0 {
+			domain = domain[scheme+3:]
+		}
+		domain, _, _ = strings.Cut(domain, "/")
+		// A port would make the suffix match nothing, and "example.com:443" is
+		// what someone copies out of a proxy field.
+		if host, _, found := strings.Cut(domain, ":"); found {
+			domain = host
+		}
+		domain = strings.Trim(domain, ".")
+		if domain == "" || seen[domain] {
+			continue
+		}
+		seen[domain] = true
+		out = append(out, domain)
+	}
+	return out
+}
+
+// cleanIPs keeps what could be a range and gives a bare address its /32.
+//
+// Deliberately not a full parse: mihomo validates its own rules and reports
+// what it could not read, and a second opinion here that disagreed with it
+// would be the harder bug to find. This only removes what is plainly empty and
+// supplies the mask people leave off.
+func cleanIPs(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		entry := strings.TrimSpace(value)
+		if entry == "" {
+			continue
+		}
+		if !strings.Contains(entry, "/") {
+			if strings.Contains(entry, ":") {
+				entry += "/128"
+			} else {
+				entry += "/32"
+			}
+		}
+		if seen[entry] {
+			continue
+		}
+		seen[entry] = true
+		out = append(out, entry)
+	}
+	return out
+}

--- a/desktop/internal/mihomoconf/directroute_test.go
+++ b/desktop/internal/mihomoconf/directroute_test.go
@@ -1,0 +1,135 @@
+package mihomoconf
+
+import (
+	"strings"
+	"testing"
+)
+
+// What somebody types is not what mihomo matches, and every one of these would
+// otherwise match nothing at all while looking perfectly reasonable in the list.
+func TestWhatSomebodyTypedBecomesWhatMihomoMatches(t *testing.T) {
+	cases := []struct {
+		typed string
+		want  string
+	}{
+		{"digikala.com", "digikala.com"},
+		{"  aparat.com  ", "aparat.com"},
+		{".ir", "ir"},
+		{"IR", "ir"},
+		{"https://www.bank.ir/login", "www.bank.ir"},
+		{"example.com:443", "example.com"},
+		{"http://example.com", "example.com"},
+	}
+	for _, tc := range cases {
+		got := cleanDomains([]string{tc.typed})
+		if len(got) != 1 || got[0] != tc.want {
+			t.Errorf("%q became %v, want [%q]", tc.typed, got, tc.want)
+		}
+	}
+}
+
+// Blank entries are what a textarea produces; duplicates are what pasting a
+// list twice produces. Neither should reach the engine.
+func TestEmptyAndRepeatedEntriesAreDropped(t *testing.T) {
+	got := cleanDomains([]string{"ir", "", "  ", "ir", ".IR", "example.com"})
+	if len(got) != 2 || got[0] != "ir" || got[1] != "example.com" {
+		t.Fatalf("got %v, want [ir example.com]", got)
+	}
+}
+
+// Typing /32 after an address is a step people forget, and an error message
+// about it teaches nothing they wanted to know.
+func TestABareAddressGetsItsOwnMask(t *testing.T) {
+	got := cleanIPs([]string{"1.2.3.4", "10.0.0.0/8", "2001:db8::1", "  "})
+	want := []string{"1.2.3.4/32", "10.0.0.0/8", "2001:db8::1/128"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+// Addresses before names, because an IP rule can be answered without resolving
+// anything and mihomo takes the first rule that fits.
+func TestAddressRulesComeBeforeNameRules(t *testing.T) {
+	rules := DirectRoute{Domains: []string{"ir"}, IPs: []string{"10.0.0.0/8"}}.Rules()
+	if len(rules) != 2 {
+		t.Fatalf("expected two rules, got %v", rules)
+	}
+	if !strings.HasPrefix(rules[0], "IP-CIDR,") {
+		t.Fatalf("the address rule should come first: %v", rules)
+	}
+	if !strings.HasPrefix(rules[1], "DOMAIN-SUFFIX,") {
+		t.Fatalf("the name rule should come second: %v", rules)
+	}
+}
+
+// Without no-resolve every request would resolve before routing, which both
+// slows things down and hands the name to whichever resolver answered — the
+// leak this app closes elsewhere.
+func TestAddressRulesDoNotResolveNames(t *testing.T) {
+	rules := DirectRoute{IPs: []string{"10.0.0.0/8"}}.Rules()
+	if len(rules) != 1 || !strings.HasSuffix(rules[0], ",no-resolve") {
+		t.Fatalf("expected a no-resolve address rule, got %v", rules)
+	}
+}
+
+// Nothing configured has to mean no rules, so that switching this off produces
+// the same document as never having switched it on.
+func TestNothingConfiguredProducesNoRules(t *testing.T) {
+	for _, route := range []DirectRoute{
+		{},
+		{Domains: []string{"", "   "}},
+		{IPs: []string{""}},
+	} {
+		if route.Active() {
+			t.Errorf("%#v should not be active", route)
+		}
+		if rules := route.Rules(); len(rules) != 0 {
+			t.Errorf("%#v produced %v", route, rules)
+		}
+	}
+}
+
+// The ordering that decides what this feature actually does.
+//
+// Under "only these programs are tunnelled" the split tunnel writes
+// MATCH,DIRECT last and a PROCESS-NAME rule pointing at the group first. If the
+// direct rules came after that process rule, a tunnelled program's Iranian
+// traffic would go through the tunnel anyway — which is the one case somebody
+// turning this on is trying to prevent.
+func TestDirectRulesAreMatchedBeforeTheSplitTunnel(t *testing.T) {
+	document, _, err := BuildProxiesYAMLWithRouting(chainProxies(), Routing{
+		Direct: DirectRoute{Domains: []string{"ir"}},
+		Split:  SplitTunnel{Mode: SplitTunnelOnly, Processes: []string{"firefox.exe"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	directAt := strings.Index(document, "DOMAIN-SUFFIX,ir,DIRECT")
+	processAt := strings.Index(document, "PROCESS-NAME,firefox.exe")
+	if directAt < 0 || processAt < 0 {
+		t.Fatalf("both rules should be present:\n%s", document)
+	}
+	if directAt > processAt {
+		t.Fatalf("the direct rule must be matched first:\n%s", document)
+	}
+}
+
+// And the catch-all stays last, or nothing above it is ever reached.
+func TestTheCatchAllIsStillLast(t *testing.T) {
+	document, _, err := BuildProxiesYAMLWithRouting(chainProxies(), Routing{
+		Direct: DirectRoute{Domains: []string{"ir"}, IPs: []string{"10.0.0.0/8"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	matchAt := strings.LastIndex(document, "MATCH,")
+	for _, rule := range []string{"DOMAIN-SUFFIX,ir,DIRECT", "IP-CIDR,10.0.0.0/8,DIRECT,no-resolve"} {
+		at := strings.Index(document, rule)
+		if at < 0 {
+			t.Fatalf("%s is missing:\n%s", rule, document)
+		}
+		if at > matchAt {
+			t.Fatalf("%s comes after the catch-all, so it can never match:\n%s", rule, document)
+		}
+	}
+}

--- a/desktop/internal/model/whitevpn_settings.go
+++ b/desktop/internal/model/whitevpn_settings.go
@@ -78,6 +78,30 @@ type ConnectionSelection struct {
 
 // SplitTunnelSettings routes some programs around the tunnel, or only some
 // through it.
+// DirectRoutingSettings names destinations that never enter the tunnel.
+//
+// The user's own two lists rather than a country switch. mihomo can match a
+// country with GEOIP, but that rule downloads a database when one is not on
+// disk and fails the whole configuration when it cannot reach it — so on a
+// filtered network it would not route Iranian traffic around the tunnel, it
+// would stop the tunnel existing. See internal/mihomoconf/directroute.go.
+//
+// "ir" as a domain suffix covers every .ir address with no database anywhere,
+// which is most of what this was asked for, and the rest is names people add as
+// they meet them.
+type DirectRoutingSettings struct {
+	// Enabled keeps the lists while switching them off, so somebody testing
+	// whether a site is misbehaving does not have to retype them afterwards.
+	Enabled bool `json:"enabled"`
+
+	// Domains are matched by suffix: "ir" catches every .ir address,
+	// "digikala.com" catches its subdomains too.
+	Domains []string `json:"domains"`
+
+	// IPs are CIDR ranges. A bare address is read as a single host.
+	IPs []string `json:"ips"`
+}
+
 type SplitTunnelSettings struct {
 	Mode string `json:"mode"`
 	// Processes are executable names, because that is what mihomo's
@@ -105,6 +129,11 @@ type WhiteVPNSettings struct {
 	CountryCode string              `json:"countryCode"`
 	Connection  ConnectionSelection `json:"connection"`
 	SplitTunnel SplitTunnelSettings `json:"splitTunnel"`
+
+	// DirectRouting keeps chosen destinations out of the tunnel. Off by
+	// default, with a starting list rather than an empty one: an empty list
+	// behind a switch teaches nobody what the switch is for.
+	DirectRouting DirectRoutingSettings `json:"directRouting"`
 
 	// Settings sections, in the order the phone shows them.
 	TLSIntegrityEnabled bool                 `json:"tlsIntegrityEnabled"`
@@ -168,12 +197,39 @@ type WhiteVPNSettings struct {
 	AcceptedPrivacyPolicyVersion int `json:"acceptedPrivacyPolicyVersion"`
 }
 
+// DefaultDirectRouting is the list somebody starts from.
+//
+// Off, but not empty. The switch is the decision; the list is the explanation
+// of what the switch does, and an empty one behind it teaches nothing and
+// leaves a person guessing at the format.
+//
+// "ir" is the whole of the .ir top-level domain and needs no database. The rest
+// are the large Iranian services people actually named when asking for this,
+// and they are ordinary entries: editable, removable, and no more privileged
+// than anything added later.
+func DefaultDirectRouting() DirectRoutingSettings {
+	return DirectRoutingSettings{
+		Enabled: false,
+		Domains: []string{
+			"ir",
+			"digikala.com",
+			"aparat.com",
+			"varzesh3.com",
+			"divar.ir",
+			"snapp.ir",
+			"shaparak.ir",
+		},
+		IPs: []string{},
+	}
+}
+
 // DefaultWhiteVPNSettings mirrors the phone's defaults.
 func DefaultWhiteVPNSettings() WhiteVPNSettings {
 	return WhiteVPNSettings{
 		CountryCode:         "", // unset means automatic
 		Connection:          ConnectionSelection{Node: "", Types: []string{}, DelaySort: false},
 		SplitTunnel:         SplitTunnelSettings{Mode: SplitTunnelOff, Processes: []string{}},
+		DirectRouting:       DefaultDirectRouting(),
 		TLSIntegrityEnabled: false,
 		AmneziaNoise: AmneziaNoiseSettings{
 			Enabled: false,
@@ -264,6 +320,12 @@ func NormalizeWhiteVPNSettings(settings WhiteVPNSettings) WhiteVPNSettings {
 	}
 
 	settings.FrontingIPs = nonEmptyStrings(settings.FrontingIPs)
+
+	// Blank lines out of a textarea, and the duplicates that come of pasting a
+	// list twice. Shape only: what each entry means is mihomoconf's to decide,
+	// and a second opinion here that disagreed with it would be the harder bug.
+	settings.DirectRouting.Domains = nonEmptyStrings(lowered(settings.DirectRouting.Domains))
+	settings.DirectRouting.IPs = nonEmptyStrings(settings.DirectRouting.IPs)
 	if len(settings.FrontingIPs) > MaxFrontingIPs {
 		settings.FrontingIPs = settings.FrontingIPs[:MaxFrontingIPs]
 	}

--- a/desktop/internal/session/session.go
+++ b/desktop/internal/session/session.go
@@ -36,6 +36,14 @@ type Options struct {
 	// phone on the same hotspot reaches this desktop's connection.
 	AllowLAN bool
 
+	// Direct names destinations that never enter the tunnel — the user's own
+	// domain and address lists. Empty means everything goes through.
+	//
+	// Like Chain, only the link-based path honours it: a subscription arriving
+	// as a whole mihomo document brings its own rules, and inserting ours above
+	// them would be rewriting somebody else's routing.
+	Direct mihomoconf.DirectRoute
+
 	// Chain sends traffic through a second node before the internet. Empty means
 	// one hop, which is the ordinary case.
 	//
@@ -697,7 +705,11 @@ func PrepareConfig(opts Options) (string, []string, error) {
 		}
 		// Share links, which is what the WhiteDNS catalogue is. They carry nodes
 		// only, so the groups and rule have to be generated around them.
-		document, firstHop, buildErr := mihomoconf.BuildProxiesYAMLWithChain(proxies, opts.SplitTunnel, opts.Chain)
+		document, firstHop, buildErr := mihomoconf.BuildProxiesYAMLWithRouting(proxies, mihomoconf.Routing{
+			Direct: opts.Direct,
+			Split:  opts.SplitTunnel,
+			Chain:  opts.Chain,
+		})
 		if buildErr != nil {
 			return "", nil, buildErr
 		}

--- a/desktop/mihomo_connect.go
+++ b/desktop/mihomo_connect.go
@@ -127,6 +127,7 @@ func (a *App) startWhiteDNSVPNWithMihomo() (model.AppState, error) {
 		// would be the worst of both.
 		Exclude:     a.hiddenNodeNames(a.selectedSubscriptionID()),
 		SplitTunnel: splitTunnelFor(settings),
+		Direct:      directRouteFor(settings),
 		// The fourth control that was stored and never read. It refuses a node
 		// whose certificates do not verify through the tunnel — a connection
 		// that carries traffic while being read is the failure it exists for.
@@ -698,6 +699,22 @@ func amneziaNoiseFor(settings model.WhiteVPNSettings) mihomoconf.AmneziaNoise {
 // added to the bypass list went through the tunnel like everything else and the
 // site it was meant to reach still saw the VPN. A control that changes nothing
 // is worse than one that is absent.
+// directRouteFor turns the saved lists into the engine's shape.
+//
+// Switched off means no rules at all rather than empty lists, so that turning
+// it off is the same configuration as never having turned it on — otherwise a
+// user comparing two connections would be comparing documents that differ for
+// no reason.
+func directRouteFor(settings model.WhiteVPNSettings) mihomoconf.DirectRoute {
+	if !settings.DirectRouting.Enabled {
+		return mihomoconf.DirectRoute{}
+	}
+	return mihomoconf.DirectRoute{
+		Domains: settings.DirectRouting.Domains,
+		IPs:     settings.DirectRouting.IPs,
+	}
+}
+
 func splitTunnelFor(settings model.WhiteVPNSettings) mihomoconf.SplitTunnel {
 	switch settings.SplitTunnel.Mode {
 	case model.SplitTunnelBypass:


### PR DESCRIPTION
Iranian sites should not travel to another country and back. People were disconnecting the VPN to reach a bank or a government form and then forgetting to turn it on again — and a connection people keep switching off is not protecting them.

**Settings → Sites that skip the tunnel**, with two lists the user owns: websites and address ranges.

## Why not GEOIP

This is the important decision, and it goes against the obvious design.

mihomo can match a country with `GEOIP,IR,DIRECT`. But `NewGEOIP` calls `InitGeoIP`, which **downloads a database when one is not on disk** and returns an error when it cannot:

```go
if err := geodata.InitGeoIP(); err != nil {
	log.Errorln("can't initial GeoIP: %s", err)
	return nil, err          // ← a rule that fails to parse fails the whole config
}
```

Nothing ships that database with this app — `cores/` holds the engine and `wintun.dll`, and the `geoip.dat` in the Makefile is staged for the legacy Xray core, not mihomo.

So on a filtered network, on the first connection after an install, a GEOIP rule would not route Iranian traffic around the tunnel. **It would stop the tunnel existing**, for exactly the people who most need it.

Two lists cost nothing and cannot fail. `ir` as a domain suffix covers every `.ir` address with no database anywhere — most of what this was asked for — and the rest is names people add as they meet them, which also makes the feature useful to someone whose list has nothing to do with Iran.

## The starting list ships off, but not empty

```
ir · digikala.com · aparat.com · varzesh3.com · divar.ir · snapp.ir · shaparak.ir
```

The switch is the decision; the list is the explanation of what the switch does. An empty one behind it teaches nothing and leaves a person guessing at the format. **Off** by default, because an update must not move anybody's traffic without them choosing it. Every entry is ordinary — editable, removable, no more privileged than one added later.

Turning the switch off keeps the lists, so testing whether a site is misbehaving does not cost retyping them.

## Order is the whole of a rule list's meaning

Direct rules are matched **before** the split tunnel. Both can send traffic direct, so under bypass mode the order changes nothing — but under *"only these programs are tunnelled"* it decides whether a tunnelled program's Iranian traffic still goes around. It should: somebody who named their bank has named it whichever program opens it.

`TestDirectRulesAreMatchedBeforeTheSplitTunnel` fails if the two are swapped — confirmed by mutation, not just asserted.

## Details worth reviewing

- **Address rules carry `no-resolve`.** Without it every request resolves before routing and hands the name to whichever resolver answered — the leak this app closes elsewhere.
- **What people type is not what mihomo matches.** A leading dot, a scheme, a path, a port, stray capitals: all trimmed rather than rejected, because each could have meant exactly one thing and a validation message would only teach a syntax to satisfy this field. A bare address gets its own `/32` (or `/128`).
- **The warning sits with the lists, not in a tooltip.** Anything listed leaves with the user's real address; somebody who has just sent their bank around the tunnel should know that before closing the page.

## Shape

Three parameters became a `Routing` struct on the way through — one decision made in three parts, read together at the one place that orders them into a rule list. `BuildProxiesYAML` and `BuildProxiesYAMLWithChain` stay as thin wrappers, so **no existing caller moved** and no test churned.

## Testing

12 new tests: input normalisation, rule shape and ordering, settings behaviour, and one that puts the generated rules through **the real engine's parser** — `ValidateConfig` only catches what fails to parse, which is exactly the class of fault a malformed rule would be. That one runs green against a locally built core.

Full suite green, `go vet` clean, `tsc --noEmit` clean, frontend builds.

## Noted, not touched

`V2RaySettingsProfile.IranRoutingEnabled` exists on the legacy Xray profile and is **read by nothing** — another stored-and-never-read control, like the four this codebase has already found. It predates this change and removing it is its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)