### PR TITLE
One window, however many times the icon is clicked

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -41,9 +41,29 @@ func main() {
 			Assets: assets,
 		},
 		BackgroundColour: &options.RGBA{R: 252, G: 252, B: 252, A: 1},
-		OnStartup:        app.startup,
-		OnShutdown:       app.shutdown,
-		OnBeforeClose:    app.hideInsteadOfClosing,
+		// One window, however many times the icon is clicked.
+		//
+		// Without this every launch started another copy: another taskbar
+		// button, another tray icon, another engine ready to fight the first
+		// one for the proxy port and the tunnel adapter. Clicking a desktop
+		// shortcut twice is not a thing to be punished for, and on Windows a
+		// running app with its window hidden to the tray looks exactly like one
+		// that is not running — so the second launch is the expected move, not
+		// a mistake.
+		//
+		// The lock's answer is to show the window that already exists, which is
+		// what the person clicking wanted in the first place. The second
+		// process then exits on its own.
+		SingleInstanceLock: &options.SingleInstanceLock{
+			// Not the app name: this is the identity of a running instance, and
+			// two builds of different versions are still the same app to a
+			// user. A fixed string keeps that true across upgrades.
+			UniqueId:               "whitevpn-desktop-single-instance",
+			OnSecondInstanceLaunch: app.onSecondInstanceLaunch,
+		},
+		OnStartup:     app.startup,
+		OnShutdown:    app.shutdown,
+		OnBeforeClose: app.hideInsteadOfClosing,
 		Bind: []interface{}{
 			app,
 		},

--- a/desktop/single_instance_test.go
+++ b/desktop/single_instance_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/wailsapp/wails/v2/pkg/options"
+	"whitevpn-desktop/internal/model"
+)
+
+// A second launch can arrive before the first has finished starting, which is
+// exactly what happens when somebody double-clicks the shortcut. The handler
+// runs on the instance that is already going, and at that moment its window may
+// not exist yet — so it has to do nothing rather than take the whole app down
+// with it.
+func TestASecondLaunchBeforeTheWindowExistsIsHarmless(t *testing.T) {
+	app := &App{state: model.DefaultAppState()}
+	if app.ctx != nil {
+		t.Fatal("this test is only meaningful before startup has run")
+	}
+	app.onSecondInstanceLaunch(options.SecondInstanceData{})
+}
+
+// The arguments a second launch carried are ignored on purpose: this app
+// defines none that mean anything, and acting on one would be inventing
+// behaviour at the entry point hardest to see from the interface.
+func TestASecondLaunchIgnoresWhateverItWasGiven(t *testing.T) {
+	app := &App{state: model.DefaultAppState()}
+	app.onSecondInstanceLaunch(options.SecondInstanceData{
+		Args:             []string{"--connect", "/etc/passwd", "whitevpn://join"},
+		WorkingDirectory: `C:\somewhere\else`,
+	})
+}

--- a/desktop/tray.go
+++ b/desktop/tray.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"fyne.io/systray"
+	"github.com/wailsapp/wails/v2/pkg/options"
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 
 	"whitevpn-desktop/internal/model"
@@ -273,4 +274,21 @@ func trayIcon() []byte {
 		return trayIconICO
 	}
 	return trayIconPNG
+}
+
+// onSecondInstanceLaunch runs in the instance that is already going, when
+// somebody starts the app again.
+//
+// Showing the window is the whole of it, and it is what the person clicking
+// wanted: on Windows an app whose window is hidden to the tray is
+// indistinguishable from one that is not running, so launching it again is the
+// obvious move rather than a mistake. The second process exits by itself once
+// this returns.
+//
+// The arguments the second launch carried are deliberately ignored. This app
+// takes none that mean anything — no file to open, no URL to handle — and
+// acting on an argument nobody defined would be inventing behaviour at the one
+// entry point that cannot be tested from the interface.
+func (a *App) onSecondInstanceLaunch(options.SecondInstanceData) {
+	a.showWindow()
 }


### PR DESCRIPTION
Every launch started another copy — another taskbar button, another tray icon, and another engine ready to fight the first one for the proxy port and the tunnel adapter.

## Why this app invites the mistake

Clicking a shortcut twice is not a thing to be punished for, and this app makes it likely: closing the window **hides it to the tray** rather than quitting, and on Windows an app whose window is hidden is indistinguishable from one that is not running. So launching it again is the obvious move, not an error — and the app was answering it by starting a second copy of itself.

## The fix

Wails already has the lock; it was simply never asked for.

```go
SingleInstanceLock: &options.SingleInstanceLock{
	UniqueId:               "whitevpn-desktop-single-instance",
	OnSecondInstanceLaunch: app.onSecondInstanceLaunch,
},
```

The second instance hands the running one a message and exits; the running one shows its window, which is what the person clicking wanted. It reuses `showWindow`, the same helper the tray's Show menu uses, so there is one way to bring the window back rather than two that could drift apart.

## Two deliberate choices

**The unique id is a fixed string, not the version.** Two builds of different versions are still the same app to whoever is clicking, and an id that moved with the version would let an upgrade run alongside what it replaced.

**The second launch's arguments are ignored.** This app defines none that mean anything — no file to open, no URL to handle — and acting on one would be inventing behaviour at the entry point hardest to see from the interface.

## Testing

A second launch can arrive **before the first has finished starting**, which is exactly what a double-click produces. `showWindow` already returns early without a context; a test pins that, because the failure there would be a crash on the path nobody exercises deliberately. A second test pins that arguments are ignored.

Builds clean for Windows, Linux and macOS. Full suite green, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)